### PR TITLE
Add ability to mock out curried functions

### DIFF
--- a/ConsumePlugin/GeneratedMock.fs
+++ b/ConsumePlugin/GeneratedMock.fs
@@ -82,9 +82,9 @@ type internal CurriedMock<'a> =
     {
         Mem1 : int -> 'a -> string
         Mem2 : int * string -> 'a -> string
-        Mem3 : int * string -> 'a -> string
-        Mem4 : int * string -> 'a * int -> string
-        Mem5 : int * string -> 'a * int -> string
+        Mem3 : (int * string) -> 'a -> string
+        Mem4 : (int * string) -> ('a * int) -> string
+        Mem5 : int * string -> ('a * int) -> string
         Mem6 : int * string -> 'a * int -> string
     }
 
@@ -101,12 +101,12 @@ type internal CurriedMock<'a> =
     interface Curried<'a> with
         member this.Mem1 (arg_0_0) (arg_1_0) = this.Mem1 (arg_0_0) (arg_1_0)
         member this.Mem2 (arg_0_0, arg_0_1) (arg_1_0) = this.Mem2 (arg_0_0, arg_0_1) (arg_1_0)
-        member this.Mem3 (arg_0_0, arg_0_1) (arg_1_0) = this.Mem3 (arg_0_0, arg_0_1) (arg_1_0)
+        member this.Mem3 ((arg_0_0, arg_0_1)) (arg_1_0) = this.Mem3 (arg_0_0, arg_0_1) (arg_1_0)
 
-        member this.Mem4 (arg_0_0, arg_0_1) (arg_1_0, arg_1_1) =
+        member this.Mem4 ((arg_0_0, arg_0_1)) ((arg_1_0, arg_1_1)) =
             this.Mem4 (arg_0_0, arg_0_1) (arg_1_0, arg_1_1)
 
-        member this.Mem5 (arg_0_0, arg_0_1) (arg_1_0, arg_1_1) =
+        member this.Mem5 (arg_0_0, arg_0_1) ((arg_1_0, arg_1_1)) =
             this.Mem5 (arg_0_0, arg_0_1) (arg_1_0, arg_1_1)
 
         member this.Mem6 (arg_0_0, arg_0_1) (arg_1_0, arg_1_1) =

--- a/ConsumePlugin/GeneratedMock.fs
+++ b/ConsumePlugin/GeneratedMock.fs
@@ -68,7 +68,7 @@ type internal VeryPublicTypeMock<'a, 'b> =
         Mem1 : 'a -> 'b
     }
 
-    static member Empty<'a, 'b> () : VeryPublicTypeMock<'a, 'b> =
+    static member Empty () : VeryPublicTypeMock<'a, 'b> =
         {
             Mem1 = (fun x -> raise (System.NotImplementedException "Unimplemented mock function"))
         }
@@ -88,7 +88,7 @@ type internal CurriedMock<'a> =
         Mem6 : int * string -> 'a * int -> string
     }
 
-    static member Empty<'a> () : CurriedMock<'a> =
+    static member Empty () : CurriedMock<'a> =
         {
             Mem1 = (fun x -> raise (System.NotImplementedException "Unimplemented mock function"))
             Mem2 = (fun x -> raise (System.NotImplementedException "Unimplemented mock function"))

--- a/ConsumePlugin/GeneratedMock.fs
+++ b/ConsumePlugin/GeneratedMock.fs
@@ -10,17 +10,20 @@ type internal PublicTypeMock =
     {
         Mem1 : string * int -> string list
         Mem2 : string -> int
+        Mem3 : int * System.Threading.CancellationToken -> string
     }
 
     static member Empty : PublicTypeMock =
         {
             Mem1 = (fun x -> raise (System.NotImplementedException "Unimplemented mock function"))
             Mem2 = (fun x -> raise (System.NotImplementedException "Unimplemented mock function"))
+            Mem3 = (fun x -> raise (System.NotImplementedException "Unimplemented mock function"))
         }
 
     interface IPublicType with
-        member this.Mem1 (arg0, arg1) = this.Mem1 (arg0, arg1)
-        member this.Mem2 (arg0) = this.Mem2 (arg0)
+        member this.Mem1 (arg_0_0, arg_0_1) = this.Mem1 (arg_0_0, arg_0_1)
+        member this.Mem2 (arg_0_0) = this.Mem2 (arg_0_0)
+        member this.Mem3 (arg_0_0, arg_0_1) = this.Mem3 (arg_0_0, arg_0_1)
 namespace SomeNamespace
 
 /// Mock record type for an interface
@@ -37,8 +40,8 @@ type internal InternalTypeMock =
         }
 
     interface InternalType with
-        member this.Mem1 (arg0, arg1) = this.Mem1 (arg0, arg1)
-        member this.Mem2 (arg0) = this.Mem2 (arg0)
+        member this.Mem1 (arg_0_0, arg_0_1) = this.Mem1 (arg_0_0, arg_0_1)
+        member this.Mem2 (arg_0_0) = this.Mem2 (arg_0_0)
 namespace SomeNamespace
 
 /// Mock record type for an interface
@@ -55,8 +58,8 @@ type private PrivateTypeMock =
         }
 
     interface PrivateType with
-        member this.Mem1 (arg0, arg1) = this.Mem1 (arg0, arg1)
-        member this.Mem2 (arg0) = this.Mem2 (arg0)
+        member this.Mem1 (arg_0_0, arg_0_1) = this.Mem1 (arg_0_0, arg_0_1)
+        member this.Mem2 (arg_0_0) = this.Mem2 (arg_0_0)
 namespace SomeNamespace
 
 /// Mock record type for an interface
@@ -71,4 +74,40 @@ type internal VeryPublicTypeMock<'a, 'b> =
         }
 
     interface VeryPublicType<'a, 'b> with
-        member this.Mem1 (arg0) = this.Mem1 (arg0)
+        member this.Mem1 (arg_0_0) = this.Mem1 (arg_0_0)
+namespace SomeNamespace
+
+/// Mock record type for an interface
+type internal CurriedMock<'a> =
+    {
+        Mem1 : int -> 'a -> string
+        Mem2 : int * string -> 'a -> string
+        Mem3 : int * string -> 'a -> string
+        Mem4 : int * string -> 'a * int -> string
+        Mem5 : int * string -> 'a * int -> string
+        Mem6 : int * string -> 'a * int -> string
+    }
+
+    static member Empty<'a> () : CurriedMock<'a> =
+        {
+            Mem1 = (fun x -> raise (System.NotImplementedException "Unimplemented mock function"))
+            Mem2 = (fun x -> raise (System.NotImplementedException "Unimplemented mock function"))
+            Mem3 = (fun x -> raise (System.NotImplementedException "Unimplemented mock function"))
+            Mem4 = (fun x -> raise (System.NotImplementedException "Unimplemented mock function"))
+            Mem5 = (fun x -> raise (System.NotImplementedException "Unimplemented mock function"))
+            Mem6 = (fun x -> raise (System.NotImplementedException "Unimplemented mock function"))
+        }
+
+    interface Curried<'a> with
+        member this.Mem1 (arg_0_0) (arg_1_0) = this.Mem1 (arg_0_0) (arg_1_0)
+        member this.Mem2 (arg_0_0, arg_0_1) (arg_1_0) = this.Mem2 (arg_0_0, arg_0_1) (arg_1_0)
+        member this.Mem3 ((arg_0_0, arg_0_1)) (arg_1_0) = this.Mem3 (arg_0_0, arg_0_1) (arg_1_0)
+
+        member this.Mem4 (arg_0_0, arg_0_1) (arg_1_0, arg_1_1) =
+            this.Mem4 (arg_0_0, arg_0_1) (arg_1_0, arg_1_1)
+
+        member this.Mem5 (arg_0_0, arg_0_1) (arg_1_0, arg_1_1) =
+            this.Mem5 (arg_0_0, arg_0_1) (arg_1_0, arg_1_1)
+
+        member this.Mem6 (arg_0_0, arg_0_1) (arg_1_0, arg_1_1) =
+            this.Mem6 (arg_0_0, arg_0_1) (arg_1_0, arg_1_1)

--- a/ConsumePlugin/GeneratedMock.fs
+++ b/ConsumePlugin/GeneratedMock.fs
@@ -10,7 +10,7 @@ type internal PublicTypeMock =
     {
         Mem1 : string * int -> string list
         Mem2 : string -> int
-        Mem3 : int * System.Threading.CancellationToken -> string
+        Mem3 : int * option<System.Threading.CancellationToken> -> string
     }
 
     static member Empty : PublicTypeMock =
@@ -101,7 +101,7 @@ type internal CurriedMock<'a> =
     interface Curried<'a> with
         member this.Mem1 (arg_0_0) (arg_1_0) = this.Mem1 (arg_0_0) (arg_1_0)
         member this.Mem2 (arg_0_0, arg_0_1) (arg_1_0) = this.Mem2 (arg_0_0, arg_0_1) (arg_1_0)
-        member this.Mem3 ((arg_0_0, arg_0_1)) (arg_1_0) = this.Mem3 (arg_0_0, arg_0_1) (arg_1_0)
+        member this.Mem3 (arg_0_0, arg_0_1) (arg_1_0) = this.Mem3 (arg_0_0, arg_0_1) (arg_1_0)
 
         member this.Mem4 (arg_0_0, arg_0_1) (arg_1_0, arg_1_1) =
             this.Mem4 (arg_0_0, arg_0_1) (arg_1_0, arg_1_1)

--- a/ConsumePlugin/GeneratedRestClient.fs
+++ b/ConsumePlugin/GeneratedRestClient.fs
@@ -644,7 +644,7 @@ open RestEase
 /// Module for constructing a REST client.
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 [<RequireQualifiedAccess>]
-module ApiWithoutBaseAddress =
+module internal ApiWithoutBaseAddress =
     /// Create a REST client.
     let make (client : System.Net.Http.HttpClient) : IApiWithoutBaseAddress =
         { new IApiWithoutBaseAddress with

--- a/ConsumePlugin/MockExample.fs
+++ b/ConsumePlugin/MockExample.fs
@@ -6,6 +6,7 @@ open WoofWare.Myriad.Plugins
 type IPublicType =
     abstract Mem1 : string * int -> string list
     abstract Mem2 : string -> int
+    abstract Mem3 : x : int * ?ct : System.Threading.CancellationToken -> string
 
 [<GenerateMock>]
 type internal InternalType =
@@ -20,3 +21,12 @@ type private PrivateType =
 [<GenerateMock>]
 type VeryPublicType<'a, 'b> =
     abstract Mem1 : 'a -> 'b
+
+[<GenerateMock>]
+type Curried<'a> =
+    abstract Mem1 : int -> 'a -> string
+    abstract Mem2 : int * string -> 'a -> string
+    abstract Mem3 : (int * string) -> 'a -> string
+    abstract Mem4 : (int * string) -> ('a * int) -> string
+    abstract Mem5 : x : int * string -> ('a * int) -> string
+    abstract Mem6 : int * string -> y : 'a * int -> string

--- a/ConsumePlugin/RestApiExample.fs
+++ b/ConsumePlugin/RestApiExample.fs
@@ -83,7 +83,7 @@ type IPureGymApi =
     abstract GetWithoutAnyReturnCode : ?ct : CancellationToken -> Task<HttpResponseMessage>
 
 [<WoofWare.Myriad.Plugins.HttpClient>]
-type IApiWithoutBaseAddress =
+type internal IApiWithoutBaseAddress =
     [<Get "endpoint/{param}">]
     abstract GetPathParam : [<Path "param">] parameter : string * ?ct : CancellationToken -> Task<string>
 

--- a/WoofWare.Myriad.Plugins.Test/TestMockGenerator/TestMockGenerator.fs
+++ b/WoofWare.Myriad.Plugins.Test/TestMockGenerator/TestMockGenerator.fs
@@ -10,7 +10,7 @@ module TestMockGenerator =
 
     [<Test>]
     let ``Example of use: IPublicType`` () =
-        let mock =
+        let mock : IPublicType =
             { PublicTypeMock.Empty with
                 Mem1 = fun (s, count) -> List.replicate count s
             }
@@ -19,3 +19,16 @@ module TestMockGenerator =
             Assert.Throws<NotImplementedException> (fun () -> mock.Mem2 "hi" |> ignore<int>)
 
         mock.Mem1 ("hi", 3) |> shouldEqual [ "hi" ; "hi" ; "hi" ]
+
+    [<Test>]
+    let ``Example of use: curried args`` () =
+        let mock : Curried<_> =
+            { CurriedMock.Empty () with
+                Mem1 = fun i c -> Array.replicate i c |> String
+                Mem2 = fun (i, s) c -> String.concat $"%c{c}" (List.replicate i s)
+                Mem3 = fun (i, s) c -> String.concat $"%c{c}" (List.replicate i s)
+            }
+
+        mock.Mem1 3 'a' |> shouldEqual "aaa"
+        mock.Mem2 (3, "hi") 'a' |> shouldEqual "hiahiahi"
+        mock.Mem3 (3, "hi") 'a' |> shouldEqual "hiahiahi"

--- a/WoofWare.Myriad.Plugins/HttpClientGenerator.fs
+++ b/WoofWare.Myriad.Plugins/HttpClientGenerator.fs
@@ -678,7 +678,7 @@ module internal HttpClientGenerator =
                 let args =
                     match mem.Args with
                     | [ args ] ->
-                        args
+                        args.Args
                         |> List.map (fun arg ->
                             {
                                 Attributes = arg.Attributes |> getHttpAttributes

--- a/WoofWare.Myriad.Plugins/InterfaceMockGenerator.fs
+++ b/WoofWare.Myriad.Plugins/InterfaceMockGenerator.fs
@@ -278,8 +278,14 @@ module internal InterfaceMockGenerator =
 
         SynModuleDecl.Types ([ typeDecl ], range0)
 
+    let private buildType (x : ParameterInfo) : SynType =
+        if x.IsOptional then
+            SynType.App (SynType.CreateLongIdent "option", Some range0, [ x.Type ], [], Some range0, false, range0)
+        else
+            x.Type
+
     let private constructMemberSinglePlace (tuple : ParameterInfo list) : SynType =
-        match tuple |> List.rev |> List.map (fun arg -> arg.Type) with
+        match tuple |> List.rev |> List.map buildType with
         | [] -> failwith "no-arg functions not supported yet"
         | [ x ] -> x
         | last :: rest ->
@@ -294,7 +300,7 @@ module internal InterfaceMockGenerator =
 
         SynField.SynField (
             [],
-            true,
+            false,
             Some mem.Identifier,
             funcType,
             false,

--- a/WoofWare.Myriad.Plugins/InterfaceMockGenerator.fs
+++ b/WoofWare.Myriad.Plugins/InterfaceMockGenerator.fs
@@ -62,7 +62,7 @@ module internal InterfaceMockGenerator =
             SynPat.LongIdent (
                 SynLongIdent.CreateString "Empty",
                 None,
-                generics,
+                None, // no generics on the "Empty", only on the return type
                 SynArgPats.Pats (
                     if generics.IsNone then
                         []


### PR DESCRIPTION
Strictly speaking this is a breaking change, because I've changed the type signature of `Empty`. But nobody is using this at all, according to nuget.org, so I just won't bump the version.