### PR TITLE
Allow general expressions in GET attribute

### DIFF
--- a/ConsumePlugin/GeneratedRestClient.fs
+++ b/ConsumePlugin/GeneratedRestClient.fs
@@ -32,7 +32,7 @@ module PureGymApi =
                             (match client.BaseAddress with
                              | null -> System.Uri "https://whatnot.com"
                              | v -> v),
-                            System.Uri ("v1/gyms/", System.UriKind.Relative)
+                            System.Uri (("v1/gyms/"), System.UriKind.Relative)
                         )
 
                     let httpMessage =

--- a/ConsumePlugin/RestApiExample.fs
+++ b/ConsumePlugin/RestApiExample.fs
@@ -11,7 +11,7 @@ open RestEase
 [<WoofWare.Myriad.Plugins.HttpClient>]
 [<BaseAddress "https://whatnot.com">]
 type IPureGymApi =
-    [<Get "v1/gyms/">]
+    [<Get("v1/gyms/")>]
     abstract GetGyms : ?ct : CancellationToken -> Task<Gym list>
 
     [<Get "v1/gyms/{gym_id}/attendance">]


### PR DESCRIPTION
There was no reason to restrict it in this way.