### PR TITLE
Correctly deal with JsonNull

### DIFF
--- a/ConsumePlugin/RestApiExample.fs
+++ b/ConsumePlugin/RestApiExample.fs
@@ -29,6 +29,10 @@ type IPureGymApi =
     [<Get "some/url">]
     abstract GetUrl : ?ct : CancellationToken -> Task<UriThing>
 
+    [<Post "some/url">]
+    abstract PostStringToString :
+        [<Body>] foo : Map<string, string> option * ?ct : CancellationToken -> Task<Map<string, string> option>
+
     // We'll use this one to check handling of absolute URIs too
     [<Get "/v2/gymSessions/member">]
     abstract GetSessions :

--- a/WoofWare.Myriad.Plugins.Test/TestHttpClient/TestPureGymRestApi.fs
+++ b/WoofWare.Myriad.Plugins.Test/TestHttpClient/TestPureGymRestApi.fs
@@ -257,3 +257,37 @@ module TestPureGymRestApi =
         uri.ToString () |> shouldEqual "https://patrick@en.wikipedia.org/wiki/foo"
         uri.UserInfo |> shouldEqual "patrick"
         uri.Host |> shouldEqual "en.wikipedia.org"
+
+    [<TestCase false>]
+    [<TestCase true>]
+    let ``Map<string, string> option example`` (isSome : bool) =
+        let proc (message : HttpRequestMessage) : HttpResponseMessage Async =
+            async {
+                message.Method |> shouldEqual HttpMethod.Get
+
+                message.RequestUri.ToString () |> shouldEqual "https://whatnot.com/some/url"
+                let! content = message.Content.ReadAsStringAsync () |> Async.AwaitTask
+
+                if isSome then
+                    content |> shouldEqual """{"hi":"bye"}"""
+                else
+                    content |> shouldEqual "null"
+
+                let content = new StringContent (content)
+
+                let resp = new HttpResponseMessage (HttpStatusCode.OK)
+                resp.Content <- content
+                return resp
+            }
+
+        use client = HttpClientMock.makeNoUri proc
+        let api = PureGymApi.make client
+
+        let expected =
+            if isSome then
+                [ "hi", "bye" ] |> Map.ofList |> Some
+            else
+                None
+
+        let actual = api.PostStringToString(expected).Result
+        actual |> shouldEqual expected

--- a/WoofWare.Myriad.Plugins.Test/TestHttpClient/TestPureGymRestApi.fs
+++ b/WoofWare.Myriad.Plugins.Test/TestHttpClient/TestPureGymRestApi.fs
@@ -263,7 +263,7 @@ module TestPureGymRestApi =
     let ``Map<string, string> option example`` (isSome : bool) =
         let proc (message : HttpRequestMessage) : HttpResponseMessage Async =
             async {
-                message.Method |> shouldEqual HttpMethod.Get
+                message.Method |> shouldEqual HttpMethod.Post
 
                 message.RequestUri.ToString () |> shouldEqual "https://whatnot.com/some/url"
                 let! content = message.Content.ReadAsStringAsync () |> Async.AwaitTask

--- a/WoofWare.Myriad.Plugins.Test/TestJsonSerialize/TestJsonSerde.fs
+++ b/WoofWare.Myriad.Plugins.Test/TestJsonSerialize/TestJsonSerde.fs
@@ -2,6 +2,9 @@ namespace WoofWare.Myriad.Plugins.Test
 
 open System
 open System.Collections.Generic
+open System.IO
+open System.Text
+open System.Text.Json
 open System.Text.Json.Nodes
 open NUnit.Framework
 open FsCheck

--- a/WoofWare.Myriad.Plugins/HttpClientGenerator.fs
+++ b/WoofWare.Myriad.Plugins/HttpClientGenerator.fs
@@ -516,12 +516,18 @@ module internal HttpClientGenerator =
                                     |> SynExpr.pipeThroughFunction (
                                         SynExpr.createLambda
                                             "node"
-                                            (SynExpr.CreateApp (
-                                                SynExpr.CreateLongIdent (
-                                                    SynLongIdent.Create [ "node" ; "ToJsonString" ]
-                                                ),
-                                                SynExpr.CreateConst SynConst.Unit
-                                            ))
+                                            (SynExpr.ifThenElse
+                                                (SynExpr.CreateApp (
+                                                    SynExpr.CreateIdentString "isNull",
+                                                    SynExpr.CreateIdentString "node"
+                                                ))
+                                                (SynExpr.CreateApp (
+                                                    SynExpr.CreateLongIdent (
+                                                        SynLongIdent.Create [ "node" ; "ToJsonString" ]
+                                                    ),
+                                                    SynExpr.CreateConst SynConst.Unit
+                                                ))
+                                                (SynExpr.CreateConst (SynConst.CreateString "null")))
                                     )
                                 ),
                                 range0

--- a/WoofWare.Myriad.Plugins/JsonSerializeGenerator.fs
+++ b/WoofWare.Myriad.Plugins/JsonSerializeGenerator.fs
@@ -65,11 +65,14 @@ module internal JsonSerializeGenerator =
                     SynMatchClause.Create (
                         SynPat.CreateLongIdent (SynLongIdent.CreateString "None", []),
                         None,
-                        SynExpr.CreateApp (
-                            SynExpr.CreateLongIdent (
-                                SynLongIdent.Create [ "System" ; "Text" ; "Json" ; "Nodes" ; "JsonValue" ; "Create" ]
-                            ),
-                            SynExpr.CreateNull
+                        // The absolutely galaxy-brained implementation of JsonValue has `JsonValue.Parse "null"`
+                        // identically equal to null. We have to work around this later, but we might as well just
+                        // be efficient here and whip up the null directly.
+                        SynExpr.CreateNull
+                        |> SynExpr.upcast' (
+                            SynType.CreateLongIdent (
+                                SynLongIdent.Create [ "System" ; "Text" ; "Json" ; "Nodes" ; "JsonNode" ]
+                            )
                         )
                     )
 
@@ -80,6 +83,12 @@ module internal JsonSerializeGenerator =
                         ),
                         None,
                         SynExpr.CreateApp (serializeNode ty, SynExpr.CreateIdentString "field")
+                        |> SynExpr.CreateParen
+                        |> SynExpr.upcast' (
+                            SynType.CreateLongIdent (
+                                SynLongIdent.Create [ "System" ; "Text" ; "Json" ; "Nodes" ; "JsonNode" ]
+                            )
+                        )
                     )
                 ]
             )

--- a/WoofWare.Myriad.Plugins/SynExpr.fs
+++ b/WoofWare.Myriad.Plugins/SynExpr.fs
@@ -263,6 +263,8 @@ module internal SynExpr =
             |> callMethodArg "ToString" (SynExpr.CreateConstString "yyyy-MM-ddTHH:mm:ss")
         | _ -> callMethod "ToString" ident
 
+    let upcast' (ty : SynType) (e : SynExpr) = SynExpr.Upcast (e, ty, range0)
+
     let synBindingTriviaZero (isMember : bool) =
         {
             SynBindingTrivia.EqualsRange = Some range0


### PR DESCRIPTION
Sigh, `JsonValue.Parse "null"` is identically `null`, so `JsonValue.Parse >> _.ToJsonString()` is not a round-trip.