### PR TITLE
Skip duplicates during push

### DIFF
--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -198,11 +198,11 @@ jobs:
           name: nuget-package-plugin
           path: packed-plugin
       - name: Publish to NuGet (plugin)
-        run: nix develop --command dotnet nuget push "packed-plugin/WoofWare.Myriad.Plugins.*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+        run: nix develop --command dotnet nuget push "packed-plugin/WoofWare.Myriad.Plugins.*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
       - name: Download NuGet artifact (attribute)
         uses: actions/download-artifact@v4
         with:
           name: nuget-package-attribute
           path: packed-attribute
       - name: Publish to NuGet (attribute)
-        run: nix develop --command dotnet nuget push "packed-attribute/WoofWare.Myriad.Plugins.Attributes.*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+        run: nix develop --command dotnet nuget push "packed-attribute/WoofWare.Myriad.Plugins.Attributes.*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ For example, [PureGymDto.fs](./ConsumePlugin/PureGymDto.fs) is a real-world set 
 * Take a reference on `WoofWare.Myriad.Plugins.Attributes` (which has no other dependencies), to obtain access to the attributes which the generator will recognise:
     ```xml
     <ItemGroup>
-        <PackageReference Include="WoofWare.Myriad.Plugins.Attributes" Version="2.0" />
+        <PackageReference Include="WoofWare.Myriad.Plugins.Attributes" Version="2.0.2" />
     </ItemGroup>
     ```
 * Take a reference (with private assets, to prevent these from propagating to your own assembly) on `WoofWare.Myriad.Plugins`, to obtain the plugins which Myriad will run, and on `Myriad.Sdk`, to obtain the Myriad binary itself:


### PR DESCRIPTION
This is so that it becomes possible to rerun the publish pipeline.