### PR TITLE
Allow cancellation token arg to have another name

### DIFF
--- a/ConsumePlugin/GeneratedRestClient.fs
+++ b/ConsumePlugin/GeneratedRestClient.fs
@@ -1034,7 +1034,7 @@ module ApiWithBasePath =
     /// Create a REST client.
     let make (client : System.Net.Http.HttpClient) : IApiWithBasePath =
         { new IApiWithBasePath with
-            member _.GetPathParam (parameter : string, ct : CancellationToken option) =
+            member _.GetPathParam (parameter : string, cancellationToken : CancellationToken option) =
                 async {
                     let! ct = Async.CancellationToken
 
@@ -1067,7 +1067,7 @@ module ApiWithBasePath =
                     let! responseString = response.Content.ReadAsStringAsync ct |> Async.AwaitTask
                     return responseString
                 }
-                |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
+                |> (fun a -> Async.StartAsTask (a, ?cancellationToken = cancellationToken))
         }
 namespace PureGym
 

--- a/ConsumePlugin/RestApiExample.fs
+++ b/ConsumePlugin/RestApiExample.fs
@@ -121,7 +121,7 @@ type internal IApiWithoutBaseAddress =
 [<BasePath "foo">]
 type IApiWithBasePath =
     [<Get "endpoint/{param}">]
-    abstract GetPathParam : [<Path "param">] parameter : string * ?ct : CancellationToken -> Task<string>
+    abstract GetPathParam : [<Path "param">] parameter : string * ?cancellationToken : CancellationToken -> Task<string>
 
 [<WoofWare.Myriad.Plugins.HttpClient>]
 [<BaseAddress "https://whatnot.com">]

--- a/README.md
+++ b/README.md
@@ -322,10 +322,9 @@ The [Grug-brained developer](https://grugbrain.dev/) would prefer to do this wit
 But since F# does not let you partially update an interface definition, we instead stamp out a record,
 thereby allowing the programmer to use F#'s record-update syntax.
 
-### Limitations
+### Features
 
-* We make the resulting record type at most internal (never public), since this is intended only to be used in tests.
-  You will therefore need an `AssemblyInfo.fs` file [like the one in WoofWare.Myriad's own tests](./ConsumePlugin/AssemblyInfo.fs).
+* You may supply an `isInternal : bool` argument to the attribute. By default, we make the resulting record type at most internal (never public), since this is intended only to be used in tests; but you can instead make it public with `[<GenerateMock false>]`.
 
 # Detailed examples
 

--- a/WoofWare.Myriad.Plugins/SynExpr.fs
+++ b/WoofWare.Myriad.Plugins/SynExpr.fs
@@ -180,7 +180,7 @@ module internal SynExpr =
         SynExpr.CreateApp (SynExpr.CreateIdent (Ident.Create "reraise"), SynExpr.CreateConst SynConst.Unit)
 
     /// {body} |> fun a -> Async.StartAsTask (a, ?cancellationToken=ct)
-    let startAsTask (body : SynExpr) =
+    let startAsTask (ct : SynLongIdent) (body : SynExpr) =
         let lambda =
             SynExpr.CreateApp (
                 SynExpr.CreateLongIdent (SynLongIdent.Create [ "Async" ; "StartAsTask" ]),
@@ -189,7 +189,7 @@ module internal SynExpr =
                         SynExpr.CreateLongIdent (SynLongIdent.CreateString "a")
                         equals
                             (SynExpr.LongIdent (true, SynLongIdent.CreateString "cancellationToken", None, range0))
-                            (SynExpr.CreateLongIdent (SynLongIdent.CreateString "ct"))
+                            (SynExpr.CreateLongIdent ct)
                     ]
             )
             |> createLambda "a"


### PR DESCRIPTION
It was previously forced to be `ct`.