### PR TITLE
Express HttpClient as extension method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 Notable changes are recorded here.
 
-# WoofWare.Myriad.Plugins 1.4 -> 2.0
+# WoofWare.Myriad.Plugins 2.1.20, WoofWare.Myriad.Plugins.Attributes 3.0.1
+
+We now bundle copies of the RestEase attributes in `WoofWare.Myriad.Plugins.Attributes`, in case you don't want to take a dependency on RestEase.
+
+# WoofWare.Myriad.Plugins 2.1.15
+
+The `GenerateMock` generator now permits a limited amount of inheritance in the record we're mocking out (specifically, `IDisposable`).
+
+# WoofWare.Myriad.Plugins 2.1.8
+
+No change to the packages, but this is when we started creating and tagging GitHub releases, which are a better source of truth than this file.
+
+# WoofWare.Myriad.Plugins 2.0
 
 This transition split the attributes (e.g. `[<JsonParseAttribute>]`) into their own assembly, WoofWare.Myriad.Plugins.Attributes.
 The new assembly has minimal dependencies, so you may safely use it from your own code.

--- a/ConsumePlugin/GeneratedVault.fs
+++ b/ConsumePlugin/GeneratedVault.fs
@@ -653,7 +653,7 @@ open RestEase
 /// Module for constructing a REST client.
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 [<RequireQualifiedAccess>]
-module VaultClientExtensionMethod =
+module VaultClientExtensionMethodHttpClientExtension =
     /// Create a REST client.
     let make (client : System.Net.Http.HttpClient) : IVaultClientExtensionMethod =
         { new IVaultClientExtensionMethod with

--- a/ConsumePlugin/GeneratedVault.fs
+++ b/ConsumePlugin/GeneratedVault.fs
@@ -651,8 +651,7 @@ open System.Threading.Tasks
 open RestEase
 
 /// Module for constructing a REST client.
-[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
-[<RequireQualifiedAccess>]
+[<AutoOpen>]
 module VaultClientExtensionMethodHttpClientExtension =
     /// Create a REST client.
     let make (client : System.Net.Http.HttpClient) : IVaultClientExtensionMethod =

--- a/ConsumePlugin/GeneratedVault.fs
+++ b/ConsumePlugin/GeneratedVault.fs
@@ -543,3 +543,199 @@ module VaultClient =
                 }
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
         }
+namespace ConsumePlugin
+
+open System
+open System.Collections.Generic
+open System.Text.Json.Serialization
+open System.Threading
+open System.Threading.Tasks
+open RestEase
+
+/// Module for constructing a REST client.
+[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+[<RequireQualifiedAccess>]
+module VaultClientNonExtensionMethod =
+    /// Create a REST client.
+    let make (client : System.Net.Http.HttpClient) : IVaultClientNonExtensionMethod =
+        { new IVaultClientNonExtensionMethod with
+            member _.GetSecret
+                (jwt : JwtVaultResponse, path : string, mountPoint : string, ct : CancellationToken option)
+                =
+                async {
+                    let! ct = Async.CancellationToken
+
+                    let uri =
+                        System.Uri (
+                            (match client.BaseAddress with
+                             | null ->
+                                 raise (
+                                     System.ArgumentNullException (
+                                         nameof (client.BaseAddress),
+                                         "No base address was supplied on the type, and no BaseAddress was on the HttpClient."
+                                     )
+                                 )
+                             | v -> v),
+                            System.Uri (
+                                "v1/{mountPoint}/{path}"
+                                    .Replace("{path}", path.ToString () |> System.Web.HttpUtility.UrlEncode)
+                                    .Replace (
+                                        "{mountPoint}",
+                                        mountPoint.ToString () |> System.Web.HttpUtility.UrlEncode
+                                    ),
+                                System.UriKind.Relative
+                            )
+                        )
+
+                    let httpMessage =
+                        new System.Net.Http.HttpRequestMessage (
+                            Method = System.Net.Http.HttpMethod.Get,
+                            RequestUri = uri
+                        )
+
+                    let! response = client.SendAsync (httpMessage, ct) |> Async.AwaitTask
+                    let response = response.EnsureSuccessStatusCode ()
+                    let! responseStream = response.Content.ReadAsStreamAsync ct |> Async.AwaitTask
+
+                    let! jsonNode =
+                        System.Text.Json.Nodes.JsonNode.ParseAsync (responseStream, cancellationToken = ct)
+                        |> Async.AwaitTask
+
+                    return JwtSecretResponse.jsonParse jsonNode
+                }
+                |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
+
+            member _.GetJwt (role : string, jwt : string, ct : CancellationToken option) =
+                async {
+                    let! ct = Async.CancellationToken
+
+                    let uri =
+                        System.Uri (
+                            (match client.BaseAddress with
+                             | null ->
+                                 raise (
+                                     System.ArgumentNullException (
+                                         nameof (client.BaseAddress),
+                                         "No base address was supplied on the type, and no BaseAddress was on the HttpClient."
+                                     )
+                                 )
+                             | v -> v),
+                            System.Uri ("v1/auth/jwt/login", System.UriKind.Relative)
+                        )
+
+                    let httpMessage =
+                        new System.Net.Http.HttpRequestMessage (
+                            Method = System.Net.Http.HttpMethod.Get,
+                            RequestUri = uri
+                        )
+
+                    let! response = client.SendAsync (httpMessage, ct) |> Async.AwaitTask
+                    let response = response.EnsureSuccessStatusCode ()
+                    let! responseStream = response.Content.ReadAsStreamAsync ct |> Async.AwaitTask
+
+                    let! jsonNode =
+                        System.Text.Json.Nodes.JsonNode.ParseAsync (responseStream, cancellationToken = ct)
+                        |> Async.AwaitTask
+
+                    return JwtVaultResponse.jsonParse jsonNode
+                }
+                |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
+        }
+namespace ConsumePlugin
+
+open System
+open System.Collections.Generic
+open System.Text.Json.Serialization
+open System.Threading
+open System.Threading.Tasks
+open RestEase
+
+/// Module for constructing a REST client.
+[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+[<RequireQualifiedAccess>]
+module VaultClientExtensionMethod =
+    /// Create a REST client.
+    let make (client : System.Net.Http.HttpClient) : IVaultClientExtensionMethod =
+        { new IVaultClientExtensionMethod with
+            member _.GetSecret
+                (jwt : JwtVaultResponse, path : string, mountPoint : string, ct : CancellationToken option)
+                =
+                async {
+                    let! ct = Async.CancellationToken
+
+                    let uri =
+                        System.Uri (
+                            (match client.BaseAddress with
+                             | null ->
+                                 raise (
+                                     System.ArgumentNullException (
+                                         nameof (client.BaseAddress),
+                                         "No base address was supplied on the type, and no BaseAddress was on the HttpClient."
+                                     )
+                                 )
+                             | v -> v),
+                            System.Uri (
+                                "v1/{mountPoint}/{path}"
+                                    .Replace("{path}", path.ToString () |> System.Web.HttpUtility.UrlEncode)
+                                    .Replace (
+                                        "{mountPoint}",
+                                        mountPoint.ToString () |> System.Web.HttpUtility.UrlEncode
+                                    ),
+                                System.UriKind.Relative
+                            )
+                        )
+
+                    let httpMessage =
+                        new System.Net.Http.HttpRequestMessage (
+                            Method = System.Net.Http.HttpMethod.Get,
+                            RequestUri = uri
+                        )
+
+                    let! response = client.SendAsync (httpMessage, ct) |> Async.AwaitTask
+                    let response = response.EnsureSuccessStatusCode ()
+                    let! responseStream = response.Content.ReadAsStreamAsync ct |> Async.AwaitTask
+
+                    let! jsonNode =
+                        System.Text.Json.Nodes.JsonNode.ParseAsync (responseStream, cancellationToken = ct)
+                        |> Async.AwaitTask
+
+                    return JwtSecretResponse.jsonParse jsonNode
+                }
+                |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
+
+            member _.GetJwt (role : string, jwt : string, ct : CancellationToken option) =
+                async {
+                    let! ct = Async.CancellationToken
+
+                    let uri =
+                        System.Uri (
+                            (match client.BaseAddress with
+                             | null ->
+                                 raise (
+                                     System.ArgumentNullException (
+                                         nameof (client.BaseAddress),
+                                         "No base address was supplied on the type, and no BaseAddress was on the HttpClient."
+                                     )
+                                 )
+                             | v -> v),
+                            System.Uri ("v1/auth/jwt/login", System.UriKind.Relative)
+                        )
+
+                    let httpMessage =
+                        new System.Net.Http.HttpRequestMessage (
+                            Method = System.Net.Http.HttpMethod.Get,
+                            RequestUri = uri
+                        )
+
+                    let! response = client.SendAsync (httpMessage, ct) |> Async.AwaitTask
+                    let response = response.EnsureSuccessStatusCode ()
+                    let! responseStream = response.Content.ReadAsStreamAsync ct |> Async.AwaitTask
+
+                    let! jsonNode =
+                        System.Text.Json.Nodes.JsonNode.ParseAsync (responseStream, cancellationToken = ct)
+                        |> Async.AwaitTask
+
+                    return JwtVaultResponse.jsonParse jsonNode
+                }
+                |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
+        }

--- a/ConsumePlugin/GeneratedVault.fs
+++ b/ConsumePlugin/GeneratedVault.fs
@@ -653,88 +653,91 @@ open RestEase
 /// Extension methods for constructing a REST client.
 [<AutoOpen>]
 module VaultClientExtensionMethodHttpClientExtension =
-    /// Create a REST client.
-    let make (client : System.Net.Http.HttpClient) : IVaultClientExtensionMethod =
-        { new IVaultClientExtensionMethod with
-            member _.GetSecret
-                (jwt : JwtVaultResponse, path : string, mountPoint : string, ct : CancellationToken option)
-                =
-                async {
-                    let! ct = Async.CancellationToken
+    /// Extension methods for HTTP clients
+    type VaultClientExtensionMethod with
 
-                    let uri =
-                        System.Uri (
-                            (match client.BaseAddress with
-                             | null ->
-                                 raise (
-                                     System.ArgumentNullException (
-                                         nameof (client.BaseAddress),
-                                         "No base address was supplied on the type, and no BaseAddress was on the HttpClient."
-                                     )
-                                 )
-                             | v -> v),
+        /// Create a REST client.
+        static member make (client : System.Net.Http.HttpClient) : IVaultClientExtensionMethod =
+            { new IVaultClientExtensionMethod with
+                member _.GetSecret
+                    (jwt : JwtVaultResponse, path : string, mountPoint : string, ct : CancellationToken option)
+                    =
+                    async {
+                        let! ct = Async.CancellationToken
+
+                        let uri =
                             System.Uri (
-                                "v1/{mountPoint}/{path}"
-                                    .Replace("{path}", path.ToString () |> System.Web.HttpUtility.UrlEncode)
-                                    .Replace (
-                                        "{mountPoint}",
-                                        mountPoint.ToString () |> System.Web.HttpUtility.UrlEncode
-                                    ),
-                                System.UriKind.Relative
-                            )
-                        )
-
-                    let httpMessage =
-                        new System.Net.Http.HttpRequestMessage (
-                            Method = System.Net.Http.HttpMethod.Get,
-                            RequestUri = uri
-                        )
-
-                    let! response = client.SendAsync (httpMessage, ct) |> Async.AwaitTask
-                    let response = response.EnsureSuccessStatusCode ()
-                    let! responseStream = response.Content.ReadAsStreamAsync ct |> Async.AwaitTask
-
-                    let! jsonNode =
-                        System.Text.Json.Nodes.JsonNode.ParseAsync (responseStream, cancellationToken = ct)
-                        |> Async.AwaitTask
-
-                    return JwtSecretResponse.jsonParse jsonNode
-                }
-                |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
-
-            member _.GetJwt (role : string, jwt : string, ct : CancellationToken option) =
-                async {
-                    let! ct = Async.CancellationToken
-
-                    let uri =
-                        System.Uri (
-                            (match client.BaseAddress with
-                             | null ->
-                                 raise (
-                                     System.ArgumentNullException (
-                                         nameof (client.BaseAddress),
-                                         "No base address was supplied on the type, and no BaseAddress was on the HttpClient."
+                                (match client.BaseAddress with
+                                 | null ->
+                                     raise (
+                                         System.ArgumentNullException (
+                                             nameof (client.BaseAddress),
+                                             "No base address was supplied on the type, and no BaseAddress was on the HttpClient."
+                                         )
                                      )
-                                 )
-                             | v -> v),
-                            System.Uri ("v1/auth/jwt/login", System.UriKind.Relative)
-                        )
+                                 | v -> v),
+                                System.Uri (
+                                    "v1/{mountPoint}/{path}"
+                                        .Replace("{path}", path.ToString () |> System.Web.HttpUtility.UrlEncode)
+                                        .Replace (
+                                            "{mountPoint}",
+                                            mountPoint.ToString () |> System.Web.HttpUtility.UrlEncode
+                                        ),
+                                    System.UriKind.Relative
+                                )
+                            )
 
-                    let httpMessage =
-                        new System.Net.Http.HttpRequestMessage (
-                            Method = System.Net.Http.HttpMethod.Get,
-                            RequestUri = uri
-                        )
+                        let httpMessage =
+                            new System.Net.Http.HttpRequestMessage (
+                                Method = System.Net.Http.HttpMethod.Get,
+                                RequestUri = uri
+                            )
 
-                    let! response = client.SendAsync (httpMessage, ct) |> Async.AwaitTask
-                    let response = response.EnsureSuccessStatusCode ()
-                    let! responseStream = response.Content.ReadAsStreamAsync ct |> Async.AwaitTask
+                        let! response = client.SendAsync (httpMessage, ct) |> Async.AwaitTask
+                        let response = response.EnsureSuccessStatusCode ()
+                        let! responseStream = response.Content.ReadAsStreamAsync ct |> Async.AwaitTask
 
-                    let! jsonNode =
-                        System.Text.Json.Nodes.JsonNode.ParseAsync (responseStream, cancellationToken = ct)
-                        |> Async.AwaitTask
+                        let! jsonNode =
+                            System.Text.Json.Nodes.JsonNode.ParseAsync (responseStream, cancellationToken = ct)
+                            |> Async.AwaitTask
 
-                    return JwtVaultResponse.jsonParse jsonNode
-                }
-                |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
-        }
+                        return JwtSecretResponse.jsonParse jsonNode
+                    }
+                    |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
+
+                member _.GetJwt (role : string, jwt : string, ct : CancellationToken option) =
+                    async {
+                        let! ct = Async.CancellationToken
+
+                        let uri =
+                            System.Uri (
+                                (match client.BaseAddress with
+                                 | null ->
+                                     raise (
+                                         System.ArgumentNullException (
+                                             nameof (client.BaseAddress),
+                                             "No base address was supplied on the type, and no BaseAddress was on the HttpClient."
+                                         )
+                                     )
+                                 | v -> v),
+                                System.Uri ("v1/auth/jwt/login", System.UriKind.Relative)
+                            )
+
+                        let httpMessage =
+                            new System.Net.Http.HttpRequestMessage (
+                                Method = System.Net.Http.HttpMethod.Get,
+                                RequestUri = uri
+                            )
+
+                        let! response = client.SendAsync (httpMessage, ct) |> Async.AwaitTask
+                        let response = response.EnsureSuccessStatusCode ()
+                        let! responseStream = response.Content.ReadAsStreamAsync ct |> Async.AwaitTask
+
+                        let! jsonNode =
+                            System.Text.Json.Nodes.JsonNode.ParseAsync (responseStream, cancellationToken = ct)
+                            |> Async.AwaitTask
+
+                        return JwtVaultResponse.jsonParse jsonNode
+                    }
+                    |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
+            }

--- a/ConsumePlugin/GeneratedVault.fs
+++ b/ConsumePlugin/GeneratedVault.fs
@@ -650,7 +650,7 @@ open System.Threading
 open System.Threading.Tasks
 open RestEase
 
-/// Module for constructing a REST client.
+/// Extension methods for constructing a REST client.
 [<AutoOpen>]
 module VaultClientExtensionMethodHttpClientExtension =
     /// Create a REST client.

--- a/ConsumePlugin/Vault.fs
+++ b/ConsumePlugin/Vault.fs
@@ -104,5 +104,5 @@ type IVaultClientExtensionMethod =
     abstract GetJwt : role : string * jwt : string * ?ct : CancellationToken -> Task<JwtVaultResponse>
 
 [<RequireQualifiedAccess>]
-module VaultClientExtensionMethod =
-    let thisClashes = 99
+type VaultClientExtensionMethod =
+    static member thisClashes = 99

--- a/ConsumePlugin/Vault.fs
+++ b/ConsumePlugin/Vault.fs
@@ -76,3 +76,33 @@ type IVaultClient =
 
     [<Get "v1/auth/jwt/login">]
     abstract GetJwt : role : string * jwt : string * ?ct : CancellationToken -> Task<JwtVaultResponse>
+
+[<WoofWare.Myriad.Plugins.HttpClient false>]
+type IVaultClientNonExtensionMethod =
+    [<Get "v1/{mountPoint}/{path}">]
+    abstract GetSecret :
+        jwt : JwtVaultResponse *
+        [<Path "path">] path : string *
+        [<Path "mountPoint">] mountPoint : string *
+        ?ct : CancellationToken ->
+            Task<JwtSecretResponse>
+
+    [<Get "v1/auth/jwt/login">]
+    abstract GetJwt : role : string * jwt : string * ?ct : CancellationToken -> Task<JwtVaultResponse>
+
+[<WoofWare.Myriad.Plugins.HttpClient(true)>]
+type IVaultClientExtensionMethod =
+    [<Get "v1/{mountPoint}/{path}">]
+    abstract GetSecret :
+        jwt : JwtVaultResponse *
+        [<Path "path">] path : string *
+        [<Path "mountPoint">] mountPoint : string *
+        ?ct : CancellationToken ->
+            Task<JwtSecretResponse>
+
+    [<Get "v1/auth/jwt/login">]
+    abstract GetJwt : role : string * jwt : string * ?ct : CancellationToken -> Task<JwtVaultResponse>
+
+[<RequireQualifiedAccess>]
+module VaultClientExtensionMethod =
+    let thisClashes = 99

--- a/WoofWare.Myriad.Plugins.Attributes/Attributes.fs
+++ b/WoofWare.Myriad.Plugins.Attributes/Attributes.fs
@@ -60,8 +60,17 @@ type JsonParseAttribute (isExtensionMethod : bool) =
 /// generator should apply during build.
 /// This generator is intended to replicate much of the functionality of RestEase,
 /// i.e. to stamp out HTTP REST clients from interfaces defining the API.
-type HttpClientAttribute () =
+///
+/// If you supply isExtensionMethod = true, you will get extension methods.
+/// These can only be consumed from F#, but the benefit is that they don't use up the module name
+/// (since by default we create a module called "{TypeName}").
+type HttpClientAttribute (isExtensionMethod : bool) =
     inherit Attribute ()
+    /// The default value of `isExtensionMethod`, the optional argument to the HttpClientAttribute constructor.
+    static member DefaultIsExtensionMethod = false
+
+    /// Shorthand for the "isExtensionMethod = false" constructor; see documentation there for details.
+    new () = HttpClientAttribute HttpClientAttribute.DefaultIsExtensionMethod
 
 /// Attribute indicating a DU type to which the "create catamorphism" Myriad
 /// generator should apply during build.

--- a/WoofWare.Myriad.Plugins.Attributes/SurfaceBaseline.txt
+++ b/WoofWare.Myriad.Plugins.Attributes/SurfaceBaseline.txt
@@ -6,7 +6,10 @@ WoofWare.Myriad.Plugins.GenerateMockAttribute..ctor [constructor]: unit
 WoofWare.Myriad.Plugins.GenerateMockAttribute.DefaultIsInternal [static property]: [read-only] bool
 WoofWare.Myriad.Plugins.GenerateMockAttribute.get_DefaultIsInternal [static method]: unit -> bool
 WoofWare.Myriad.Plugins.HttpClientAttribute inherit System.Attribute
+WoofWare.Myriad.Plugins.HttpClientAttribute..ctor [constructor]: bool
 WoofWare.Myriad.Plugins.HttpClientAttribute..ctor [constructor]: unit
+WoofWare.Myriad.Plugins.HttpClientAttribute.DefaultIsExtensionMethod [static property]: [read-only] bool
+WoofWare.Myriad.Plugins.HttpClientAttribute.get_DefaultIsExtensionMethod [static method]: unit -> bool
 WoofWare.Myriad.Plugins.JsonParseAttribute inherit System.Attribute
 WoofWare.Myriad.Plugins.JsonParseAttribute..ctor [constructor]: bool
 WoofWare.Myriad.Plugins.JsonParseAttribute..ctor [constructor]: unit

--- a/WoofWare.Myriad.Plugins.Attributes/version.json
+++ b/WoofWare.Myriad.Plugins.Attributes/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0",
+  "version": "3.1",
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],

--- a/WoofWare.Myriad.Plugins.Test/TestHttpClient/TestVaultClient.fs
+++ b/WoofWare.Myriad.Plugins.Test/TestHttpClient/TestVaultClient.fs
@@ -168,3 +168,5 @@ module TestVaultClient =
                 "key8_1", "https://example.com/data8/1"
                 "key8_2", "https://example.com/data8/2"
             ]
+
+    let _canSeePastExtensionMethod = VaultClientExtensionMethod.thisClashes

--- a/WoofWare.Myriad.Plugins.Test/TestHttpClient/TestVaultClient.fs
+++ b/WoofWare.Myriad.Plugins.Test/TestHttpClient/TestVaultClient.fs
@@ -87,8 +87,10 @@ module TestVaultClient =
     }
 }"""
 
-    [<Test>]
-    let ``URI example`` () =
+    [<TestCase 1>]
+    [<TestCase 2>]
+    [<TestCase 3>]
+    let ``URI example`` (vaultClientId : int) =
         let proc (message : HttpRequestMessage) : HttpResponseMessage Async =
             async {
                 message.Method |> shouldEqual HttpMethod.Get
@@ -112,10 +114,25 @@ module TestVaultClient =
             }
 
         use client = HttpClientMock.make (Uri "https://my-vault.com") proc
-        let api = VaultClient.make client
 
-        let vaultResponse = api.GetJwt("role", "jwt").Result
-        let value = api.GetSecret(vaultResponse, "path", "mount").Result
+        let value =
+            match vaultClientId with
+            | 1 ->
+                let api = VaultClient.make client
+                let vaultResponse = api.GetJwt("role", "jwt").Result
+                let value = api.GetSecret(vaultResponse, "path", "mount").Result
+                value
+            | 2 ->
+                let api = VaultClientNonExtensionMethod.make client
+                let vaultResponse = api.GetJwt("role", "jwt").Result
+                let value = api.GetSecret(vaultResponse, "path", "mount").Result
+                value
+            | 3 ->
+                let api = VaultClientExtensionMethod.make client
+                let vaultResponse = api.GetJwt("role", "jwt").Result
+                let value = api.GetSecret(vaultResponse, "path", "mount").Result
+                value
+            | _ -> failwith $"Unrecognised ID: %i{vaultClientId}"
 
         value.Data
         |> Seq.toList

--- a/WoofWare.Myriad.Plugins.Test/TestJsonParse/TestJsonParse.fs
+++ b/WoofWare.Myriad.Plugins.Test/TestJsonParse/TestJsonParse.fs
@@ -7,6 +7,8 @@ open FsUnitTyped
 
 [<TestFixture>]
 module TestJsonParse =
+    let _canSeePastExtensionMethod = ToGetExtensionMethod.thisModuleWouldClash
+
     [<Test>]
     let ``Single example`` () =
         let s =

--- a/WoofWare.Myriad.Plugins/HttpClientGenerator.fs
+++ b/WoofWare.Myriad.Plugins/HttpClientGenerator.fs
@@ -1047,10 +1047,13 @@ module internal HttpClientGenerator =
                 [ Ident.Create name ]
 
         let attribs =
-            [
-                SynAttributeList.Create SynAttribute.compilationRepresentation
-                SynAttributeList.Create (SynAttribute.RequireQualifiedAccess ())
-            ]
+            if spec.ExtensionMethods then
+                [ SynAttributeList.Create SynAttribute.autoOpen ]
+            else
+                [
+                    SynAttributeList.Create SynAttribute.compilationRepresentation
+                    SynAttributeList.Create (SynAttribute.RequireQualifiedAccess ())
+                ]
 
         let modInfo =
             SynComponentInfo.Create (

--- a/WoofWare.Myriad.Plugins/HttpClientGenerator.fs
+++ b/WoofWare.Myriad.Plugins/HttpClientGenerator.fs
@@ -816,7 +816,7 @@ module internal HttpClientGenerator =
     let createModule
         (opens : SynOpenDeclTarget list)
         (ns : LongIdent)
-        (interfaceType : SynTypeDefn, outputSpec : HttpClientGeneratorOutputSpec)
+        (interfaceType : SynTypeDefn, spec : HttpClientGeneratorOutputSpec)
         : SynModuleOrNamespace
         =
         let interfaceType = AstHelper.parseInterface interfaceType
@@ -1032,15 +1032,19 @@ module internal HttpClientGenerator =
             |> SynModuleDecl.CreateLet
 
         let moduleName : LongIdent =
-            List.last interfaceType.Name
-            |> _.idText
-            |> fun s ->
-                if s.StartsWith 'I' then
-                    s.[1..]
-                else
-                    failwith $"Expected interface type to start with 'I', but was: %s{s}"
-            |> Ident.Create
-            |> List.singleton
+            let name =
+                List.last interfaceType.Name
+                |> _.idText
+                |> fun s ->
+                    if s.StartsWith 'I' then
+                        s.[1..]
+                    else
+                        failwith $"Expected interface type to start with 'I', but was: %s{s}"
+
+            if spec.ExtensionMethods then
+                [ Ident.Create (name + "HttpClientExtension") ]
+            else
+                [ Ident.Create name ]
 
         let attribs =
             [

--- a/WoofWare.Myriad.Plugins/HttpClientGenerator.fs
+++ b/WoofWare.Myriad.Plugins/HttpClientGenerator.fs
@@ -964,7 +964,13 @@ module internal HttpClientGenerator =
 
         let members = propertyMembers @ nonPropertyMembers
 
-        let docString = PreXmlDoc.Create " Module for constructing a REST client."
+        let docString =
+            (if spec.ExtensionMethods then
+                 "Extension methods"
+             else
+                 "Module")
+            |> sprintf " %s for constructing a REST client."
+            |> PreXmlDoc.Create
 
         let interfaceImpl =
             SynExpr.ObjExpr (


### PR DESCRIPTION
Ref: #60 

Sadly you can't put an extension method on a module, so there's no way to combine `module Foo =` and `type Foo with`. Ideally we'd be able to cope with this:

```fsharp
// user code:
type IFoo = ...
module Foo = ...

// generated code:
type Foo with
    static member make ...
```
But we can't do that.