### PR TITLE
Properly exclude test project

### DIFF
--- a/WoofWare.Myriad.Plugins.Attributes/version.json
+++ b/WoofWare.Myriad.Plugins.Attributes/version.json
@@ -10,6 +10,6 @@
     ":/Directory.Build.props",
     ":/global.json",
     "./",
-    "^./Test"
+    ":^Test"
   ]
 }

--- a/WoofWare.Myriad.Plugins/version.json
+++ b/WoofWare.Myriad.Plugins/version.json
@@ -6,7 +6,7 @@
   "pathFilters": [
     "./",
     ":/WoofWare.Myriad.Plugins.Attributes",
-    "^:/WoofWare.Myriad.Plugins.Attributes/Test",
+    ":^/WoofWare.Myriad.Plugins.Attributes/Test",
     ":/global.json",
     ":/README.md",
     ":/Directory.Build.props"


### PR DESCRIPTION
Docs at https://github.com/dotnet/Nerdbank.GitVersioning/blob/976fc101715546380c2f8bb8abef83fb2bb84dea/doc/pathFilters.md suggest the : prefix is actually required here.