### PR TITLE
Fix record/union impl accessibility

### DIFF
--- a/ConsumePlugin/Args.fs
+++ b/ConsumePlugin/Args.fs
@@ -190,3 +190,8 @@ type ManyLongForms =
         [<ArgumentLongForm "dont-turn-it-off">]
         SomeFlag : bool
     }
+
+[<RequireQualifiedAccess>]
+type private IrrelevantDu =
+    | Foo
+    | Bar

--- a/WoofWare.Myriad.Plugins/InterfaceMockGenerator.fs
+++ b/WoofWare.Myriad.Plugins/InterfaceMockGenerator.fs
@@ -212,7 +212,8 @@ module internal InterfaceMockGenerator =
                 Members = Some ([ constructor ; interfaceMembers ] @ extraInterfaces)
                 XmlDoc = Some xmlDoc
                 Generics = interfaceType.Generics
-                Accessibility = Some access
+                TypeAccessibility = Some access
+                ImplAccessibility = None
                 Attributes = []
             }
 

--- a/WoofWare.Myriad.Plugins/SynExpr/SynTypeDefnRepr.fs
+++ b/WoofWare.Myriad.Plugins/SynExpr/SynTypeDefnRepr.fs
@@ -13,8 +13,12 @@ module internal SynTypeDefnRepr =
     let inline augmentation () : SynTypeDefnRepr =
         SynTypeDefnRepr.ObjectModel (SynTypeDefnKind.Augmentation range0, [], range0)
 
-    let inline union (cases : SynUnionCase list) : SynTypeDefnRepr =
-        SynTypeDefnRepr.Simple (SynTypeDefnSimpleRepr.Union (None, cases, range0), range0)
+    let inline unionWithAccess (implAccess : SynAccess option) (cases : SynUnionCase list) : SynTypeDefnRepr =
+        SynTypeDefnRepr.Simple (SynTypeDefnSimpleRepr.Union (implAccess, cases, range0), range0)
 
-    let inline record (fields : SynField list) : SynTypeDefnRepr =
-        SynTypeDefnRepr.Simple (SynTypeDefnSimpleRepr.Record (None, fields, range0), range0)
+    let inline union (cases : SynUnionCase list) : SynTypeDefnRepr = unionWithAccess None cases
+
+    let inline recordWithAccess (implAccess : SynAccess option) (fields : SynField list) : SynTypeDefnRepr =
+        SynTypeDefnRepr.Simple (SynTypeDefnSimpleRepr.Record (implAccess, fields, range0), range0)
+
+    let inline record (fields : SynField list) : SynTypeDefnRepr = recordWithAccess None fields


### PR DESCRIPTION
We previously threw when the type's accessibility did not match its implementation's accessibility.