### PR TITLE
Interpret `JsonExtensionData`

### DIFF
--- a/ConsumePlugin/GeneratedSerde.fs
+++ b/ConsumePlugin/GeneratedSerde.fs
@@ -322,6 +322,27 @@ module CollectRemainingJsonSerializeExtension =
                     node.Add (key, value)
 
             node :> _
+namespace ConsumePlugin
+
+open System
+open System.Collections.Generic
+open System.Text.Json.Serialization
+
+/// Module containing JSON serializing extension members for the OuterCollectRemaining type
+[<AutoOpen>]
+module OuterCollectRemainingJsonSerializeExtension =
+    /// Extension methods for JSON parsing
+    type OuterCollectRemaining with
+
+        /// Serialize to a JSON node
+        static member toJsonNode (input : OuterCollectRemaining) : System.Text.Json.Nodes.JsonNode =
+            let node = System.Text.Json.Nodes.JsonObject ()
+
+            do
+                node.Add ("thing", (input.Thing |> System.Text.Json.Nodes.JsonValue.Create<string>))
+                node.Add ("remaining", (input.Remaining |> CollectRemaining.toJsonNode))
+
+            node :> _
 
 namespace ConsumePlugin
 
@@ -899,4 +920,42 @@ module CollectRemainingJsonParseExtension =
             {
                 Message = arg_0
                 Rest = arg_1
+            }
+namespace ConsumePlugin
+
+/// Module containing JSON parsing extension members for the OuterCollectRemaining type
+[<AutoOpen>]
+module OuterCollectRemainingJsonParseExtension =
+    /// Extension methods for JSON parsing
+    type OuterCollectRemaining with
+
+        /// Parse from a JSON node.
+        static member jsonParse (node : System.Text.Json.Nodes.JsonNode) : OuterCollectRemaining =
+            let arg_1 =
+                CollectRemaining.jsonParse (
+                    match node.["remaining"] with
+                    | null ->
+                        raise (
+                            System.Collections.Generic.KeyNotFoundException (
+                                sprintf "Required key '%s' not found on JSON object" ("remaining")
+                            )
+                        )
+                    | v -> v
+                )
+
+            let arg_0 =
+                (match node.["thing"] with
+                 | null ->
+                     raise (
+                         System.Collections.Generic.KeyNotFoundException (
+                             sprintf "Required key '%s' not found on JSON object" ("thing")
+                         )
+                     )
+                 | v -> v)
+                    .AsValue()
+                    .GetValue<System.String> ()
+
+            {
+                Thing = arg_0
+                Remaining = arg_1
             }

--- a/ConsumePlugin/GeneratedSerde.fs
+++ b/ConsumePlugin/GeneratedSerde.fs
@@ -884,22 +884,12 @@ module CollectRemainingJsonParseExtension =
         /// Parse from a JSON node.
         static member jsonParse (node : System.Text.Json.Nodes.JsonNode) : CollectRemaining =
             let arg_1 =
-                (match node.["rest"] with
-                 | null ->
-                     raise (
-                         System.Collections.Generic.KeyNotFoundException (
-                             sprintf "Required key '%s' not found on JSON object" ("rest")
-                         )
-                     )
-                 | v -> v)
-                    .AsObject ()
-                |> Seq.map (fun kvp ->
-                    let key = (kvp.Key)
-                    let value = System.Text.Json.Nodes.JsonNode.jsonParse (kvp.Value)
-                    key, value
-                )
-                |> Seq.map System.Collections.Generic.KeyValuePair
-                |> System.Collections.Generic.Dictionary
+                let result = System.Collections.Generic.Dictionary ()
+
+                for KeyValue (key, value) in node.AsObject () do
+                    if key = "message" then () else result.Add (key, value)
+
+                result
 
             let arg_0 =
                 match node.["message"] with

--- a/ConsumePlugin/SerializationAndDeserialization.fs
+++ b/ConsumePlugin/SerializationAndDeserialization.fs
@@ -73,3 +73,12 @@ type Foo =
     {
         Message : HeaderAndValue option
     }
+
+[<WoofWare.Myriad.Plugins.JsonSerialize true>]
+[<WoofWare.Myriad.Plugins.JsonParse true>]
+type CollectRemaining =
+    {
+        Message : HeaderAndValue option
+        [<JsonExtensionData>]
+        Rest : Dictionary<string, System.Text.Json.Nodes.JsonNode>
+    }

--- a/ConsumePlugin/SerializationAndDeserialization.fs
+++ b/ConsumePlugin/SerializationAndDeserialization.fs
@@ -87,6 +87,7 @@ type CollectRemaining =
 [<WoofWare.Myriad.Plugins.JsonParse true>]
 type OuterCollectRemaining =
     {
-        Thing : string
+        [<JsonExtensionData>]
+        Others : Dictionary<string, int>
         Remaining : CollectRemaining
     }

--- a/ConsumePlugin/SerializationAndDeserialization.fs
+++ b/ConsumePlugin/SerializationAndDeserialization.fs
@@ -82,3 +82,11 @@ type CollectRemaining =
         [<JsonExtensionData>]
         Rest : Dictionary<string, System.Text.Json.Nodes.JsonNode>
     }
+
+[<WoofWare.Myriad.Plugins.JsonSerialize true>]
+[<WoofWare.Myriad.Plugins.JsonParse true>]
+type OuterCollectRemaining =
+    {
+        Thing : string
+        Remaining : CollectRemaining
+    }

--- a/WoofWare.Myriad.Plugins.Test/TestJsonSerialize/TestJsonSerde.fs
+++ b/WoofWare.Myriad.Plugins.Test/TestJsonSerialize/TestJsonSerde.fs
@@ -306,3 +306,27 @@ module TestJsonSerde =
 
         for i in counts do
             i |> shouldBeGreaterThan 0
+
+    [<Test>]
+    let ``Can collect extension data`` () =
+        let str =
+            """{
+    "message": { "header": "hi", "value": "bye" },
+    "something": 3,
+    "arr": ["egg", "toast"],
+    "str": "whatnot"
+}"""
+            |> JsonNode.Parse
+        let expected =
+            {
+                Rest =
+                    [
+                        "something", box 3
+                        "arr", box [| "egg" ; "toast" |]
+                        "str", box "whatnot"
+                    ]
+                    |> dict
+                Message = Some { Header = "hi" ; Value = "bye" }
+            }
+
+        let actual = CollectRemaining.jsonParse str

--- a/WoofWare.Myriad.Plugins/JsonParseGenerator.fs
+++ b/WoofWare.Myriad.Plugins/JsonParseGenerator.fs
@@ -385,6 +385,13 @@ module internal JsonParseGenerator =
                             .EndsWith ("JsonPropertyName", StringComparison.Ordinal)
                     )
 
+                let extensionDataAttr =
+                    fieldData.Attrs
+                    |> List.tryFind (fun attr ->
+                        (SynLongIdent.toString attr.TypeName)
+                            .EndsWith ("JsonExtensionData", StringComparison.Ordinal)
+                    )
+
                 let options = getParseOptions fieldData.Attrs
 
                 let propertyName =

--- a/WoofWare.Myriad.Plugins/JsonParseGenerator.fs
+++ b/WoofWare.Myriad.Plugins/JsonParseGenerator.fs
@@ -59,7 +59,7 @@ module internal JsonParseGenerator =
         | None -> node
         | Some propertyName -> assertNotNull propertyName node
         |> SynExpr.callMethod "AsValue"
-        |> SynExpr.callGenericMethod "GetValue" typeName
+        |> SynExpr.callGenericMethod (SynLongIdent.createS "GetValue") [ SynType.createLongIdent typeName ]
 
     /// {node}.AsObject()
     /// If `propertyName` is Some, uses `assertNotNull {node}` instead of `{node}`.
@@ -279,7 +279,7 @@ module internal JsonParseGenerator =
         | Measure (_measure, primType) ->
             parseNumberType options propertyName node primType
             |> SynExpr.pipeThroughFunction (Measure.getLanguagePrimitivesMeasure primType)
-        | JsonNode -> SynExpr.createIdent "node"
+        | JsonNode -> node
         | _ ->
             // Let's just hope that we've also got our own type annotation!
             let typeName =
@@ -437,16 +437,25 @@ module internal JsonParseGenerator =
                 | Some _ ->
                     // Can't go through the usual parse logic here, because that will try and identify the node that's
                     // been labelled. The whole point of JsonExtensionData is that there is no such node!
+                    let valType =
+                        match fieldData.Type with
+                        | DictionaryType (String, v) -> v
+                        | _ -> failwith "Expected JsonExtensionData to be Dictionary<string, _>"
+
                     SynExpr.ifThenElse
                         isNamedPropertyField
                         (SynExpr.callMethodArg
                             "Add"
-                            (SynExpr.tuple [ SynExpr.createIdent "key" ; SynExpr.createIdent "value" ])
+                            (SynExpr.tuple
+                                [
+                                    SynExpr.createIdent "key"
+                                    createParseRhs options (SynExpr.createIdent "key") valType
+                                ])
                             (SynExpr.createIdent "result"))
                         (SynExpr.CreateConst ())
                     |> SynExpr.createForEach
                         (SynPat.nameWithArgs "KeyValue" [ SynPat.named "key" ; SynPat.named "value" ])
-                        (SynExpr.createIdent "node" |> SynExpr.callMethod "AsObject")
+                        (SynExpr.createIdent "node")
                     |> fun forEach -> [ forEach ; SynExpr.createIdent "result" ]
                     |> SynExpr.sequential
                     |> SynExpr.createLet
@@ -454,8 +463,15 @@ module internal JsonParseGenerator =
                             SynBinding.basic
                                 [ Ident.create "result" ]
                                 []
-                                (SynExpr.createLongIdent [ "System" ; "Collections" ; "Generic" ; "Dictionary" ]
+                                (SynExpr.typeApp
+                                    [ SynType.string ; valType ]
+                                    (SynExpr.createLongIdent [ "System" ; "Collections" ; "Generic" ; "Dictionary" ])
                                  |> SynExpr.applyTo (SynExpr.CreateConst ()))
+
+                            SynBinding.basic
+                                [ Ident.create "node" ]
+                                []
+                                (SynExpr.createIdent "node" |> SynExpr.callMethod "AsObject")
                         ]
                     |> SynBinding.basic [ accIdent ] []
                 | None ->
@@ -542,9 +558,7 @@ module internal JsonParseGenerator =
                 |> SynExpr.index property
                 |> assertNotNull property
                 |> SynExpr.pipeThroughFunction (
-                    SynExpr.createLambda
-                        "v"
-                        (SynExpr.callGenericMethod "GetValue" [ Ident.create "string" ] (SynExpr.createIdent "v"))
+                    SynExpr.createLambda "v" (SynExpr.callGenericMethod' "GetValue" "string" (SynExpr.createIdent "v"))
                 )
                 |> SynBinding.basic [ Ident.create "ty" ] []
             ]

--- a/WoofWare.Myriad.Plugins/SynExpr/SynExpr.fs
+++ b/WoofWare.Myriad.Plugins/SynExpr/SynExpr.fs
@@ -141,16 +141,15 @@ module internal SynExpr =
     let typeApp (types : SynType list) (operand : SynExpr) =
         SynExpr.TypeApp (operand, range0, types, List.replicate (types.Length - 1) range0, Some range0, range0, range0)
 
-    let callGenericMethod (meth : string) (ty : LongIdent) (obj : SynExpr) : SynExpr =
-        SynExpr.DotGet (obj, range0, SynLongIdent.createS meth, range0)
-        |> typeApp [ SynType.LongIdent (SynLongIdent.create ty) ]
+    /// {obj}.{meth}<types,...>()
+    let callGenericMethod (meth : SynLongIdent) (types : SynType list) (obj : SynExpr) : SynExpr =
+        SynExpr.DotGet (obj, range0, meth, range0)
+        |> typeApp types
         |> applyTo (SynExpr.CreateConst ())
 
     /// {obj}.{meth}<ty>()
     let callGenericMethod' (meth : string) (ty : string) (obj : SynExpr) : SynExpr =
-        SynExpr.DotGet (obj, range0, SynLongIdent.createS meth, range0)
-        |> typeApp [ SynType.createLongIdent' [ ty ] ]
-        |> applyTo (SynExpr.CreateConst ())
+        callGenericMethod (SynLongIdent.createS meth) [ SynType.createLongIdent' [ ty ] ] obj
 
     let inline index (property : SynExpr) (obj : SynExpr) : SynExpr =
         SynExpr.DotIndexedGet (obj, property, range0, range0)

--- a/WoofWare.Myriad.Plugins/SynExpr/SynExpr.fs
+++ b/WoofWare.Myriad.Plugins/SynExpr/SynExpr.fs
@@ -85,6 +85,11 @@ module internal SynExpr =
         SynExpr.CreateAppInfix (SynExpr.CreateLongIdent SynLongIdent.booleanAnd, a)
         |> applyTo b
 
+    /// {a} || {b}
+    let booleanOr (a : SynExpr) (b : SynExpr) =
+        SynExpr.CreateAppInfix (SynExpr.CreateLongIdent SynLongIdent.booleanOr, a)
+        |> applyTo b
+
     /// {a} + {b}
     let plus (a : SynExpr) (b : SynExpr) =
         SynExpr.CreateAppInfix (
@@ -236,6 +241,8 @@ module internal SynExpr =
 
     let inline createLet (bindings : SynBinding list) (body : SynExpr) : SynExpr =
         SynExpr.LetOrUse (false, false, bindings, body, range0, SynExprLetOrUseTrivia.empty)
+
+    let inline createDo (body : SynExpr) : SynExpr = SynExpr.Do (body, range0)
 
     let inline createMatch (matchOn : SynExpr) (cases : SynMatchClause list) : SynExpr =
         SynExpr.Match (

--- a/WoofWare.Myriad.Plugins/SynExpr/SynLongIdent.fs
+++ b/WoofWare.Myriad.Plugins/SynExpr/SynLongIdent.fs
@@ -36,6 +36,9 @@ module internal SynLongIdent =
     let booleanAnd =
         SynLongIdent.SynLongIdent ([ Ident.create "op_BooleanAnd" ], [], [ Some (IdentTrivia.OriginalNotation "&&") ])
 
+    let booleanOr =
+        SynLongIdent.SynLongIdent ([ Ident.create "op_BooleanOr" ], [], [ Some (IdentTrivia.OriginalNotation "||") ])
+
     let pipe =
         SynLongIdent.SynLongIdent ([ Ident.create "op_PipeRight" ], [], [ Some (IdentTrivia.OriginalNotation "|>") ])
 

--- a/WoofWare.Myriad.Plugins/SynExpr/SynType.fs
+++ b/WoofWare.Myriad.Plugins/SynExpr/SynType.fs
@@ -181,6 +181,18 @@ module internal SynTypePatterns =
                        _) -> Some (ident, outer)
         | _ -> None
 
+    let (|JsonNode|_|) (fieldType : SynType) : unit option =
+        match fieldType with
+        | SynType.LongIdent (SynLongIdent.SynLongIdent (ident, _, _)) ->
+            match ident |> List.map (fun i -> i.idText) with
+            | [ "System" ; "Text" ; "Json" ; "Nodes" ; "JsonNode" ]
+            | [ "Text" ; "Json" ; "Nodes" ; "JsonNode" ]
+            | [ "Json" ; "Nodes" ; "JsonNode" ]
+            | [ "Nodes" ; "JsonNode" ]
+            | [ "JsonNode" ] -> Some ()
+            | _ -> None
+        | _ -> None
+
     let (|DateOnly|_|) (fieldType : SynType) =
         match fieldType with
         | SynType.LongIdent (SynLongIdent.SynLongIdent (ident, _, _)) ->


### PR DESCRIPTION
Currently bare-bones, this *requires* JsonNode to be the type of the values.