### PR TITLE
Get rid of more of Myriad.Core

### DIFF
--- a/ConsumePlugin/GeneratedFileSystem.fs
+++ b/ConsumePlugin/GeneratedFileSystem.fs
@@ -31,7 +31,7 @@ module FileSystemItemCata =
     [<RequireQualifiedAccess>]
     type private Instruction =
         | Process__FileSystemItem of FileSystemItem
-        | FileSystemItem_Directory of string * int * int
+        | FileSystemItem_Directory of name : string * dirSize : int * contents : int
 
     let private loop (cata : FileSystemCata<'FileSystemItem>) (instructions : ResizeArray<Instruction>) =
         let fileSystemItemStack = ResizeArray<'FileSystemItem> ()
@@ -106,7 +106,7 @@ module GiftCata =
         | Process__Gift of Gift
         | Gift_Wrapped of WrappingPaperStyle
         | Gift_Boxed
-        | Gift_WithACard of string
+        | Gift_WithACard of message : string
 
     let private loop (cata : GiftCata<'Gift>) (instructions : ResizeArray<Instruction>) =
         let giftStack = ResizeArray<'Gift> ()

--- a/ConsumePlugin/ListCata.fs
+++ b/ConsumePlugin/ListCata.fs
@@ -31,7 +31,7 @@ module MyListCata =
     [<RequireQualifiedAccess>]
     type private Instruction<'a> =
         | Process__MyList of MyList<'a>
-        | MyList_Cons of 'a
+        | MyList_Cons of head : 'a
 
     let private loop (cata : MyListCata<'a, 'MyList>) (instructions : ResizeArray<Instruction<'a>>) =
         let myListStack = ResizeArray<'MyList> ()

--- a/WoofWare.Myriad.Plugins/HttpClientGenerator.fs
+++ b/WoofWare.Myriad.Plugins/HttpClientGenerator.fs
@@ -1008,7 +1008,7 @@ type HttpClientGenerator () =
                 |> List.choose (fun (ns, types) ->
                     types
                     |> List.choose (fun typeDef ->
-                        match Ast.getAttribute<HttpClientAttribute> typeDef with
+                        match SynTypeDefn.getAttribute typeof<HttpClientAttribute>.Name typeDef with
                         | None ->
                             let name = SynTypeDefn.getName typeDef |> List.map _.idText |> String.concat "."
 

--- a/WoofWare.Myriad.Plugins/JsonParseGenerator.fs
+++ b/WoofWare.Myriad.Plugins/JsonParseGenerator.fs
@@ -727,7 +727,7 @@ type JsonParseGenerator () =
                 |> List.choose (fun (ns, types) ->
                     types
                     |> List.choose (fun typeDef ->
-                        match Ast.getAttribute<JsonParseAttribute> typeDef with
+                        match SynTypeDefn.getAttribute typeof<JsonParseAttribute>.Name typeDef with
                         | None ->
                             let name = SynTypeDefn.getName typeDef |> List.map _.idText |> String.concat "."
 

--- a/WoofWare.Myriad.Plugins/JsonSerializeGenerator.fs
+++ b/WoofWare.Myriad.Plugins/JsonSerializeGenerator.fs
@@ -544,7 +544,7 @@ type JsonSerializeGenerator () =
                 |> List.choose (fun (ns, types) ->
                     types
                     |> List.choose (fun typeDef ->
-                        match Ast.getAttribute<JsonSerializeAttribute> typeDef with
+                        match SynTypeDefn.getAttribute typeof<JsonSerializeAttribute>.Name typeDef with
                         | None ->
                             let name = SynTypeDefn.getName typeDef |> List.map _.idText |> String.concat "."
 

--- a/WoofWare.Myriad.Plugins/RemoveOptionsGenerator.fs
+++ b/WoofWare.Myriad.Plugins/RemoveOptionsGenerator.fs
@@ -150,7 +150,10 @@ type RemoveOptionsGenerator () =
             let namespaceAndRecords =
                 records
                 |> List.choose (fun (ns, types) ->
-                    match types |> List.filter Ast.hasAttribute<RemoveOptionsAttribute> with
+                    match
+                        types
+                        |> List.filter (SynTypeDefn.hasAttribute typeof<RemoveOptionsAttribute>.Name)
+                    with
                     | [] -> None
                     | types ->
                         let types =

--- a/WoofWare.Myriad.Plugins/SynExpr/SynArgInfo.fs
+++ b/WoofWare.Myriad.Plugins/SynExpr/SynArgInfo.fs
@@ -1,0 +1,7 @@
+namespace WoofWare.Myriad.Plugins
+
+open Fantomas.FCS.Syntax
+
+[<RequireQualifiedAccess>]
+module internal SynArgInfo =
+    let empty = SynArgInfo.SynArgInfo ([], false, None)

--- a/WoofWare.Myriad.Plugins/SynExpr/SynConst.fs
+++ b/WoofWare.Myriad.Plugins/SynExpr/SynConst.fs
@@ -1,0 +1,10 @@
+namespace WoofWare.Myriad.Plugins
+
+open Fantomas.FCS.Syntax
+open Fantomas.FCS.Text.Range
+
+[<AutoOpen>]
+module internal SynConstExt =
+    type SynConst with
+        static member Create (s : string) : SynConst =
+            SynConst.String (s, SynStringKind.Regular, range0)

--- a/WoofWare.Myriad.Plugins/SynExpr/SynLongIdent.fs
+++ b/WoofWare.Myriad.Plugins/SynExpr/SynLongIdent.fs
@@ -39,6 +39,12 @@ module internal SynLongIdent =
     let booleanOr =
         SynLongIdent.SynLongIdent ([ Ident.create "op_BooleanOr" ], [], [ Some (IdentTrivia.OriginalNotation "||") ])
 
+    let plus =
+        SynLongIdent.SynLongIdent ([ Ident.create "op_Addition" ], [], [ Some (IdentTrivia.OriginalNotation "+") ])
+
+    let times =
+        SynLongIdent.SynLongIdent ([ Ident.create "op_Multiply" ], [], [ Some (IdentTrivia.OriginalNotation "*") ])
+
     let pipe =
         SynLongIdent.SynLongIdent ([ Ident.create "op_PipeRight" ], [], [ Some (IdentTrivia.OriginalNotation "|>") ])
 

--- a/WoofWare.Myriad.Plugins/SynExpr/SynSimplePat.fs
+++ b/WoofWare.Myriad.Plugins/SynExpr/SynSimplePat.fs
@@ -1,0 +1,10 @@
+namespace WoofWare.Myriad.Plugins
+
+open Fantomas.FCS.Syntax
+open Fantomas.FCS.Text.Range
+
+[<RequireQualifiedAccess>]
+module internal SynSimplePat =
+
+    let createId (id : Ident) : SynSimplePat =
+        SynSimplePat.Id (id, None, false, false, false, range0)

--- a/WoofWare.Myriad.Plugins/SynExpr/SynSimplePats.fs
+++ b/WoofWare.Myriad.Plugins/SynExpr/SynSimplePats.fs
@@ -1,0 +1,12 @@
+namespace WoofWare.Myriad.Plugins
+
+open Fantomas.FCS.Syntax
+open Fantomas.FCS.Text.Range
+
+[<RequireQualifiedAccess>]
+module internal SynSimplePats =
+
+    let create (pats : SynSimplePat list) : SynSimplePats =
+        match pats with
+        | [] -> SynSimplePats.SimplePats ([], [], range0)
+        | pats -> SynSimplePats.SimplePats (pats, List.replicate (pats.Length - 1) range0, range0)

--- a/WoofWare.Myriad.Plugins/SynExpr/SynTypeDefn.fs
+++ b/WoofWare.Myriad.Plugins/SynExpr/SynTypeDefn.fs
@@ -29,3 +29,18 @@ module internal SynTypeDefn =
     let getName (defn : SynTypeDefn) : LongIdent =
         match defn with
         | SynTypeDefn (SynComponentInfo.SynComponentInfo (_, _, _, id, _, _, _, _), _, _, _, _, _) -> id
+
+    let getAttribute (attrName : string) (defn : SynTypeDefn) : SynAttribute option =
+        match defn with
+        | SynTypeDefn (SynComponentInfo.SynComponentInfo (attrs, _, _, _, _, _, _, _), _, _, _, _, _) ->
+            attrs
+            |> List.collect (fun a -> a.Attributes)
+            |> List.tryFind (fun i ->
+                match i.TypeName with
+                | SynLongIdent.SynLongIdent (id, _, _) ->
+                    let name = List.last(id).idText
+                    name = attrName || name + "Attribute" = attrName
+            )
+
+    let hasAttribute (attrName : string) (defn : SynTypeDefn) : bool =
+        getAttribute attrName defn |> Option.isSome

--- a/WoofWare.Myriad.Plugins/SynExpr/SynUnionCase.fs
+++ b/WoofWare.Myriad.Plugins/SynExpr/SynUnionCase.fs
@@ -23,14 +23,14 @@ type UnionCase<'ident> =
 
 [<RequireQualifiedAccess>]
 module internal SynUnionCase =
-    let create (case : UnionCase<Ident>) : SynUnionCase =
+    let create (case : UnionCase<Ident option>) : SynUnionCase =
         let fields =
             case.Fields
             |> List.map (fun field ->
                 SynField.SynField (
                     SynAttributes.ofAttrs field.Attrs,
                     false,
-                    Some field.Ident,
+                    field.Ident,
                     field.Type,
                     false,
                     PreXmlDoc.Empty,

--- a/WoofWare.Myriad.Plugins/SynExpr/SynValInfo.fs
+++ b/WoofWare.Myriad.Plugins/SynExpr/SynValInfo.fs
@@ -1,0 +1,7 @@
+namespace WoofWare.Myriad.Plugins
+
+open Fantomas.FCS.Syntax
+
+[<RequireQualifiedAccess>]
+module internal SynValInfo =
+    let empty = SynValInfo.SynValInfo ([], SynArgInfo.empty)

--- a/WoofWare.Myriad.Plugins/WoofWare.Myriad.Plugins.fsproj
+++ b/WoofWare.Myriad.Plugins/WoofWare.Myriad.Plugins.fsproj
@@ -29,8 +29,13 @@
     <Compile Include="Teq.fs" />
     <Compile Include="Primitives.fs" />
     <Compile Include="SynExpr\SynAttributes.fs" />
+    <Compile Include="SynExpr\SynConst.fs" />
+    <Compile Include="SynExpr\SynArgInfo.fs" />
+    <Compile Include="SynExpr\SynValInfo.fs" />
     <Compile Include="SynExpr\PreXmlDoc.fs" />
     <Compile Include="SynExpr\Ident.fs" />
+    <Compile Include="SynExpr\SynSimplePat.fs" />
+    <Compile Include="SynExpr\SynSimplePats.fs" />
     <Compile Include="SynExpr\SynIdent.fs" />
     <Compile Include="SynExpr\SynLongIdent.fs" />
     <Compile Include="SynExpr\SynExprLetOrUseTrivia.fs" />


### PR DESCRIPTION
There's now one usage remaining of Myriad's AST-manipulating functions.