### PR TITLE
Honour the int64 integer format

### DIFF
--- a/ConsumePlugin/Generated2SwaggerGitea.fs
+++ b/ConsumePlugin/Generated2SwaggerGitea.fs
@@ -101,13 +101,13 @@ module AccessTokenJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -363,13 +363,13 @@ module AddTimeOptionJsonSerializeExtension =
                     "time",
                     (input.Time
                      |> (fun field ->
-                         let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                         let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                          (match field with
                           | null ->
                               raise (
                                   System.ArgumentNullException
-                                      "Expected type int32 to be non-null, but received a null value when serialising"
+                                      "Expected type int64 to be non-null, but received a null value when serialising"
                               )
                           | field -> field)
                      ))
@@ -572,13 +572,13 @@ module AttachmentJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -597,13 +597,13 @@ module AttachmentJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -647,13 +647,13 @@ module AttachmentJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -1276,13 +1276,13 @@ module BranchProtectionJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -1430,13 +1430,13 @@ module ChangedFileJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -1455,13 +1455,13 @@ module ChangedFileJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -1505,13 +1505,13 @@ module ChangedFileJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -1881,13 +1881,13 @@ module CommitStatsJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -1906,13 +1906,13 @@ module CommitStatsJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -1931,13 +1931,13 @@ module CommitStatsJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -2674,13 +2674,13 @@ module CreateBranchProtectionOptionJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -3254,13 +3254,13 @@ module CreateIssueOptionJsonSerializeExtension =
                                   for mem in field do
                                       arr.Add (
                                           (fun field ->
-                                              let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                              let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                               (match field with
                                                | null ->
                                                    raise (
                                                        System.ArgumentNullException
-                                                           "Expected type int32 to be non-null, but received a null value when serialising"
+                                                           "Expected type int64 to be non-null, but received a null value when serialising"
                                                    )
                                                | field -> field)
                                           )
@@ -3284,13 +3284,13 @@ module CreateIssueOptionJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -4119,13 +4119,13 @@ module CreatePullRequestOptionJsonSerializeExtension =
                                   for mem in field do
                                       arr.Add (
                                           (fun field ->
-                                              let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                              let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                               (match field with
                                                | null ->
                                                    raise (
                                                        System.ArgumentNullException
-                                                           "Expected type int32 to be non-null, but received a null value when serialising"
+                                                           "Expected type int64 to be non-null, but received a null value when serialising"
                                                    )
                                                | field -> field)
                                           )
@@ -4149,13 +4149,13 @@ module CreatePullRequestOptionJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -4243,13 +4243,13 @@ module CreatePullReviewCommentJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -4268,13 +4268,13 @@ module CreatePullReviewCommentJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -5526,13 +5526,13 @@ module CreateUserOptionJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -5705,13 +5705,13 @@ module CronJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -6526,13 +6526,13 @@ module EditBranchProtectionOptionJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -7027,13 +7027,13 @@ module EditIssueOptionJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -7743,13 +7743,13 @@ module EditPullRequestOptionJsonSerializeExtension =
                                   for mem in field do
                                       arr.Add (
                                           (fun field ->
-                                              let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                              let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                               (match field with
                                                | null ->
                                                    raise (
                                                        System.ArgumentNullException
-                                                           "Expected type int32 to be non-null, but received a null value when serialising"
+                                                           "Expected type int64 to be non-null, but received a null value when serialising"
                                                    )
                                                | field -> field)
                                           )
@@ -7773,13 +7773,13 @@ module EditPullRequestOptionJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -8560,13 +8560,13 @@ module EditUserOptionJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -8680,13 +8680,13 @@ module EditUserOptionJsonSerializeExtension =
                     "source_id",
                     (input.SourceId
                      |> (fun field ->
-                         let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                         let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                          (match field with
                           | null ->
                               raise (
                                   System.ArgumentNullException
-                                      "Expected type int32 to be non-null, but received a null value when serialising"
+                                      "Expected type int64 to be non-null, but received a null value when serialising"
                               )
                           | field -> field)
                      ))
@@ -9389,13 +9389,13 @@ module GeneralAPISettingsJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -9414,13 +9414,13 @@ module GeneralAPISettingsJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -9439,13 +9439,13 @@ module GeneralAPISettingsJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -9464,13 +9464,13 @@ module GeneralAPISettingsJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -9558,13 +9558,13 @@ module GeneralAttachmentSettingsJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -9583,13 +9583,13 @@ module GeneralAttachmentSettingsJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -10261,13 +10261,13 @@ module GitBlobResponseJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -10405,13 +10405,13 @@ module GitEntryJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -10687,13 +10687,13 @@ module GitTreeResponseJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -10737,13 +10737,13 @@ module GitTreeResponseJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -11007,13 +11007,13 @@ module HookJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -11351,13 +11351,13 @@ module IssueLabelsOptionJsonSerializeExtension =
                                   for mem in field do
                                       arr.Add (
                                           (fun field ->
-                                              let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                              let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                               (match field with
                                                | null ->
                                                    raise (
                                                        System.ArgumentNullException
-                                                           "Expected type int32 to be non-null, but received a null value when serialising"
+                                                           "Expected type int64 to be non-null, but received a null value when serialising"
                                                    )
                                                | field -> field)
                                           )
@@ -11475,13 +11475,13 @@ module LabelJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -12330,13 +12330,13 @@ module MigrateRepoOptionsJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -12626,13 +12626,13 @@ module NodeInfoUsageUsersJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -12651,13 +12651,13 @@ module NodeInfoUsageUsersJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -12676,13 +12676,13 @@ module NodeInfoUsageUsersJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -12720,13 +12720,13 @@ module NotificationCountJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -12864,13 +12864,13 @@ module OAuth2ApplicationJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -13043,13 +13043,13 @@ module OrganizationJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -13381,13 +13381,13 @@ module PackageFileJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -13406,13 +13406,13 @@ module PackageFileJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -14299,13 +14299,13 @@ module RepositoryMetaJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -14487,13 +14487,13 @@ module StopWatchJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -14587,13 +14587,13 @@ module StopWatchJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -14938,13 +14938,13 @@ module TeamJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -15193,13 +15193,13 @@ module TopicResponseJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -15218,13 +15218,13 @@ module TopicResponseJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -15333,13 +15333,13 @@ module TransferRepoOptionJsonSerializeExtension =
                                   for mem in field do
                                       arr.Add (
                                           (fun field ->
-                                              let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                              let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                               (match field with
                                                | null ->
                                                    raise (
                                                        System.ArgumentNullException
-                                                           "Expected type int32 to be non-null, but received a null value when serialising"
+                                                           "Expected type int64 to be non-null, but received a null value when serialising"
                                                    )
                                                | field -> field)
                                           )
@@ -15716,13 +15716,13 @@ module UserJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -15741,13 +15741,13 @@ module UserJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -15791,13 +15791,13 @@ module UserJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -16016,13 +16016,13 @@ module UserJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -16110,13 +16110,13 @@ module UserHeatmapDataJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -16135,13 +16135,13 @@ module UserHeatmapDataJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -16938,13 +16938,13 @@ module WikiCommitListJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -16982,13 +16982,13 @@ module WikiPageJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -17389,13 +17389,13 @@ module CommentJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -17464,13 +17464,13 @@ module CommentJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -17655,13 +17655,13 @@ module CommitStatusJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -18035,13 +18035,13 @@ module ContentsResponseJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -19772,13 +19772,13 @@ module MilestoneJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -19872,13 +19872,13 @@ module MilestoneJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -19897,13 +19897,13 @@ module MilestoneJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -20016,13 +20016,13 @@ module NodeInfoUsageJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -20041,13 +20041,13 @@ module NodeInfoUsageJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -20470,13 +20470,13 @@ module PublicKeyJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -20675,13 +20675,13 @@ module PullReviewJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -20775,13 +20775,13 @@ module PullReviewJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -21116,13 +21116,13 @@ module PullReviewCommentJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -21241,13 +21241,13 @@ module PullReviewCommentJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -21570,13 +21570,13 @@ module ReleaseJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -22492,13 +22492,13 @@ module RepositoryJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -22667,13 +22667,13 @@ module RepositoryJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -22928,13 +22928,13 @@ module RepositoryJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -22953,13 +22953,13 @@ module RepositoryJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -23061,13 +23061,13 @@ module RepositoryJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -23097,13 +23097,13 @@ module RepositoryJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -23147,13 +23147,13 @@ module RepositoryJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -23222,13 +23222,13 @@ module RepositoryJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -23617,13 +23617,13 @@ module CombinedStatusJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -23943,13 +23943,13 @@ module DeployKeyJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -23993,13 +23993,13 @@ module DeployKeyJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -24335,13 +24335,13 @@ module IssueJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -24435,13 +24435,13 @@ module IssueJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -24518,13 +24518,13 @@ module IssueJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -24568,13 +24568,13 @@ module IssueJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -24973,13 +24973,13 @@ module NotificationThreadJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -25200,13 +25200,13 @@ module PRBranchInfoJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -25305,13 +25305,13 @@ module PackageJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -25822,13 +25822,13 @@ module PullRequestJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -25958,13 +25958,13 @@ module PullRequestJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -26177,13 +26177,13 @@ module PullRequestJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -26382,13 +26382,13 @@ module TrackedTimeJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -26418,13 +26418,13 @@ module TrackedTimeJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -26443,13 +26443,13 @@ module TrackedTimeJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -26468,13 +26468,13 @@ module TrackedTimeJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -26648,13 +26648,13 @@ module BranchJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -26885,13 +26885,13 @@ module TimelineCommentJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -27018,13 +27018,13 @@ module TimelineCommentJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -27093,13 +27093,13 @@ module TimelineCommentJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -27251,13 +27251,13 @@ module TimelineCommentJsonSerializeExtension =
                          | Some field ->
                              (field
                               |> (fun field ->
-                                  let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                                  let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                                   (match field with
                                    | null ->
                                        raise (
                                            System.ArgumentNullException
-                                               "Expected type int32 to be non-null, but received a null value when serialising"
+                                               "Expected type int64 to be non-null, but received a null value when serialising"
                                        )
                                    | field -> field)
                               ))
@@ -27359,13 +27359,13 @@ module LanguageStatisticsJsonSerializeExtension =
                     node.Add (
                         key,
                         (fun field ->
-                            let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+                            let field = System.Text.Json.Nodes.JsonValue.Create<int64> field
 
                             (match field with
                              | null ->
                                  raise (
                                      System.ArgumentNullException
-                                         "Expected type int32 to be non-null, but received a null value when serialising"
+                                         "Expected type int64 to be non-null, but received a null value when serialising"
                                  )
                              | field -> field)
                         )
@@ -27600,7 +27600,7 @@ module AccessTokenJsonParseExtension =
             let arg_1 =
                 match node.["id"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_0 =
                 let result =
@@ -27749,7 +27749,7 @@ module AddTimeOptionJsonParseExtension =
                             sprintf "Required key '%s' not found on JSON object" ("time")
                         )
                     )
-                | Some node -> node.AsValue().GetValue<System.Int32> ()
+                | Some node -> node.AsValue().GetValue<System.Int64> ()
 
             let arg_1 =
                 match node.["created"] |> Option.ofObj with
@@ -27859,7 +27859,7 @@ module AttachmentJsonParseExtension =
             let arg_6 =
                 match node.["size"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_5 =
                 match node.["name"] |> Option.ofObj with
@@ -27869,12 +27869,12 @@ module AttachmentJsonParseExtension =
             let arg_4 =
                 match node.["id"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_3 =
                 match node.["download_count"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_2 =
                 match node.["created_at"] |> Option.ofObj with
@@ -27973,7 +27973,7 @@ module BranchProtectionJsonParseExtension =
             let arg_21 =
                 match node.["required_approvals"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_20 =
                 match node.["require_signed_commits"] |> Option.ofObj with
@@ -28263,7 +28263,7 @@ module ChangedFileJsonParseExtension =
             let arg_4 =
                 match node.["deletions"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_3 =
                 match node.["contents_url"] |> Option.ofObj with
@@ -28273,12 +28273,12 @@ module ChangedFileJsonParseExtension =
             let arg_2 =
                 match node.["changes"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_1 =
                 match node.["additions"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_0 =
                 let result =
@@ -28486,17 +28486,17 @@ module CommitStatsJsonParseExtension =
             let arg_3 =
                 match node.["total"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_2 =
                 match node.["deletions"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_1 =
                 match node.["additions"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_0 =
                 let result =
@@ -28689,7 +28689,7 @@ module CreateBranchProtectionOptionJsonParseExtension =
             let arg_20 =
                 match node.["required_approvals"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_19 =
                 match node.["require_signed_commits"] |> Option.ofObj with
@@ -29255,7 +29255,7 @@ module CreateIssueOptionJsonParseExtension =
             let arg_7 =
                 match node.["milestone"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_6 =
                 match node.["labels"] |> Option.ofObj with
@@ -29267,9 +29267,9 @@ module CreateIssueOptionJsonParseExtension =
                          | null ->
                              raise (
                                  System.ArgumentNullException
-                                     "Expected element of array (element type int32) to be non-null, but found a null element"
+                                     "Expected element of array (element type int64) to be non-null, but found a null element"
                              )
-                         | elt -> elt.AsValue().GetValue<System.Int32> ())
+                         | elt -> elt.AsValue().GetValue<System.Int64> ())
                     )
                     |> List.ofSeq
                     |> Some
@@ -29731,7 +29731,7 @@ module CreatePullRequestOptionJsonParseExtension =
             let arg_8 =
                 match node.["milestone"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_7 =
                 match node.["labels"] |> Option.ofObj with
@@ -29743,9 +29743,9 @@ module CreatePullRequestOptionJsonParseExtension =
                          | null ->
                              raise (
                                  System.ArgumentNullException
-                                     "Expected element of array (element type int32) to be non-null, but found a null element"
+                                     "Expected element of array (element type int64) to be non-null, but found a null element"
                              )
-                         | elt -> elt.AsValue().GetValue<System.Int32> ())
+                         | elt -> elt.AsValue().GetValue<System.Int64> ())
                     )
                     |> List.ofSeq
                     |> Some
@@ -29856,12 +29856,12 @@ module CreatePullReviewCommentJsonParseExtension =
             let arg_3 =
                 match node.["old_position"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_2 =
                 match node.["new_position"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_1 =
                 match node.["body"] |> Option.ofObj with
@@ -30465,7 +30465,7 @@ module CreateUserOptionJsonParseExtension =
             let arg_9 =
                 match node.["source_id"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_8 =
                 match node.["send_notify"] |> Option.ofObj with
@@ -30655,7 +30655,7 @@ module CronJsonParseExtension =
             let arg_1 =
                 match node.["exec_times"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_0 =
                 let result =
@@ -30877,7 +30877,7 @@ module EditBranchProtectionOptionJsonParseExtension =
             let arg_19 =
                 match node.["required_approvals"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_18 =
                 match node.["require_signed_commits"] |> Option.ofObj with
@@ -31403,7 +31403,7 @@ module EditIssueOptionJsonParseExtension =
             let arg_5 =
                 match node.["milestone"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_4 =
                 match node.["due_date"] |> Option.ofObj with
@@ -31713,7 +31713,7 @@ module EditPullRequestOptionJsonParseExtension =
             let arg_8 =
                 match node.["milestone"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_7 =
                 match node.["labels"] |> Option.ofObj with
@@ -31725,9 +31725,9 @@ module EditPullRequestOptionJsonParseExtension =
                          | null ->
                              raise (
                                  System.ArgumentNullException
-                                     "Expected element of array (element type int32) to be non-null, but found a null element"
+                                     "Expected element of array (element type int64) to be non-null, but found a null element"
                              )
-                         | elt -> elt.AsValue().GetValue<System.Int32> ())
+                         | elt -> elt.AsValue().GetValue<System.Int64> ())
                     )
                     |> List.ofSeq
                     |> Some
@@ -32114,7 +32114,7 @@ module EditUserOptionJsonParseExtension =
                             sprintf "Required key '%s' not found on JSON object" ("source_id")
                         )
                     )
-                | Some node -> node.AsValue().GetValue<System.Int32> ()
+                | Some node -> node.AsValue().GetValue<System.Int64> ()
 
             let arg_15 =
                 match node.["restricted"] |> Option.ofObj with
@@ -32139,7 +32139,7 @@ module EditUserOptionJsonParseExtension =
             let arg_11 =
                 match node.["max_repo_creation"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_10 =
                 match node.["login_name"] |> Option.ofObj with
@@ -32654,22 +32654,22 @@ module GeneralAPISettingsJsonParseExtension =
             let arg_4 =
                 match node.["max_response_items"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_3 =
                 match node.["default_paging_num"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_2 =
                 match node.["default_max_blob_size"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_1 =
                 match node.["default_git_trees_per_page"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_0 =
                 let result =
@@ -32720,12 +32720,12 @@ module GeneralAttachmentSettingsJsonParseExtension =
             let arg_4 =
                 match node.["max_size"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_3 =
                 match node.["max_files"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_2 =
                 match node.["enabled"] |> Option.ofObj with
@@ -33075,7 +33075,7 @@ module GitBlobResponseJsonParseExtension =
             let arg_4 =
                 match node.["size"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_3 =
                 match node.["sha"] |> Option.ofObj with
@@ -33153,7 +33153,7 @@ module GitEntryJsonParseExtension =
             let arg_4 =
                 match node.["size"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_3 =
                 match node.["sha"] |> Option.ofObj with
@@ -33360,7 +33360,7 @@ module GitTreeResponseJsonParseExtension =
             let arg_3 =
                 match node.["total_count"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_2 =
                 match node.["sha"] |> Option.ofObj with
@@ -33370,7 +33370,7 @@ module GitTreeResponseJsonParseExtension =
             let arg_1 =
                 match node.["page"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_0 =
                 let result =
@@ -33470,7 +33470,7 @@ module HookJsonParseExtension =
             let arg_6 =
                 match node.["id"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_5 =
                 match node.["events"] |> Option.ofObj with
@@ -33794,9 +33794,9 @@ module IssueLabelsOptionJsonParseExtension =
                          | null ->
                              raise (
                                  System.ArgumentNullException
-                                     "Expected element of array (element type int32) to be non-null, but found a null element"
+                                     "Expected element of array (element type int64) to be non-null, but found a null element"
                              )
-                         | elt -> elt.AsValue().GetValue<System.Int32> ())
+                         | elt -> elt.AsValue().GetValue<System.Int64> ())
                     )
                     |> List.ofSeq
                     |> Some
@@ -33852,7 +33852,7 @@ module LabelJsonParseExtension =
             let arg_4 =
                 match node.["id"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_3 =
                 match node.["exclusive"] |> Option.ofObj with
@@ -34087,7 +34087,7 @@ module MigrateRepoOptionsJsonParseExtension =
             let arg_19 =
                 match node.["uid"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_18 =
                 match node.["service"] |> Option.ofObj with
@@ -34441,17 +34441,17 @@ module NodeInfoUsageUsersJsonParseExtension =
             let arg_3 =
                 match node.["total"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_2 =
                 match node.["activeMonth"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_1 =
                 match node.["activeHalfyear"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_0 =
                 let result =
@@ -34496,7 +34496,7 @@ module NotificationCountJsonParseExtension =
             let arg_1 =
                 match node.["new"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_0 =
                 let result =
@@ -34561,7 +34561,7 @@ module OAuth2ApplicationJsonParseExtension =
             let arg_5 =
                 match node.["id"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_4 =
                 match node.["created"] |> Option.ofObj with
@@ -34668,7 +34668,7 @@ module OrganizationJsonParseExtension =
             let arg_4 =
                 match node.["id"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_3 =
                 match node.["full_name"] |> Option.ofObj with
@@ -34844,12 +34844,12 @@ module PackageFileJsonParseExtension =
             let arg_2 =
                 match node.["id"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_1 =
                 match node.["Size"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_0 =
                 let result =
@@ -35352,7 +35352,7 @@ module RepositoryMetaJsonParseExtension =
             let arg_2 =
                 match node.["id"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_1 =
                 match node.["full_name"] |> Option.ofObj with
@@ -35446,7 +35446,7 @@ module StopWatchJsonParseExtension =
             let arg_7 =
                 match node.["seconds"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_6 =
                 match node.["repo_owner_name"] |> Option.ofObj with
@@ -35466,7 +35466,7 @@ module StopWatchJsonParseExtension =
             let arg_3 =
                 match node.["issue_index"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_2 =
                 match node.["duration"] |> Option.ofObj with
@@ -35739,7 +35739,7 @@ module TeamJsonParseExtension =
             let arg_3 =
                 match node.["id"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_2 =
                 match node.["description"] |> Option.ofObj with
@@ -35875,12 +35875,12 @@ module TopicResponseJsonParseExtension =
             let arg_3 =
                 match node.["repo_count"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_2 =
                 match node.["id"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_1 =
                 match node.["created"] |> Option.ofObj with
@@ -35945,9 +35945,9 @@ module TransferRepoOptionJsonParseExtension =
                          | null ->
                              raise (
                                  System.ArgumentNullException
-                                     "Expected element of array (element type int32) to be non-null, but found a null element"
+                                     "Expected element of array (element type int64) to be non-null, but found a null element"
                              )
-                         | elt -> elt.AsValue().GetValue<System.Int32> ())
+                         | elt -> elt.AsValue().GetValue<System.Int64> ())
                     )
                     |> List.ofSeq
                     |> Some
@@ -36132,7 +36132,7 @@ module UserJsonParseExtension =
             let arg_18 =
                 match node.["starred_repos_count"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_17 =
                 match node.["restricted"] |> Option.ofObj with
@@ -36177,7 +36177,7 @@ module UserJsonParseExtension =
             let arg_9 =
                 match node.["id"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_8 =
                 match node.["full_name"] |> Option.ofObj with
@@ -36187,12 +36187,12 @@ module UserJsonParseExtension =
             let arg_7 =
                 match node.["following_count"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_6 =
                 match node.["followers_count"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_5 =
                 match node.["email"] |> Option.ofObj with
@@ -36300,12 +36300,12 @@ module UserHeatmapDataJsonParseExtension =
             let arg_2 =
                 match node.["timestamp"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_1 =
                 match node.["contributions"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_0 =
                 let result =
@@ -36692,7 +36692,7 @@ module WikiCommitListJsonParseExtension =
             let arg_2 =
                 match node.["count"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_1 =
                 match node.["commits"] |> Option.ofObj with
@@ -36788,7 +36788,7 @@ module WikiPageJsonParseExtension =
             let arg_1 =
                 match node.["commit_count"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_0 =
                 let result =
@@ -36923,7 +36923,7 @@ module CommentJsonParseExtension =
             let arg_8 =
                 match node.["original_author_id"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_7 =
                 match node.["original_author"] |> Option.ofObj with
@@ -36938,7 +36938,7 @@ module CommentJsonParseExtension =
             let arg_5 =
                 match node.["id"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_4 =
                 match node.["html_url"] |> Option.ofObj with
@@ -37055,7 +37055,7 @@ module CommitStatusJsonParseExtension =
             let arg_5 =
                 match node.["id"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_4 =
                 match node.["description"] |> Option.ofObj with
@@ -37156,7 +37156,7 @@ module ContentsResponseJsonParseExtension =
             let arg_11 =
                 match node.["size"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_10 =
                 match node.["sha"] |> Option.ofObj with
@@ -38073,12 +38073,12 @@ module MilestoneJsonParseExtension =
             let arg_7 =
                 match node.["open_issues"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_6 =
                 match node.["id"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_5 =
                 match node.["due_on"] |> Option.ofObj with
@@ -38098,7 +38098,7 @@ module MilestoneJsonParseExtension =
             let arg_2 =
                 match node.["closed_issues"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_1 =
                 match node.["closed_at"] |> Option.ofObj with
@@ -38171,12 +38171,12 @@ module NodeInfoUsageJsonParseExtension =
             let arg_2 =
                 match node.["localPosts"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_1 =
                 match node.["localComments"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_0 =
                 let result =
@@ -38411,7 +38411,7 @@ module PublicKeyJsonParseExtension =
             let arg_3 =
                 match node.["id"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_2 =
                 match node.["fingerprint"] |> Option.ofObj with
@@ -38522,7 +38522,7 @@ module PullReviewJsonParseExtension =
             let arg_6 =
                 match node.["id"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_5 =
                 match node.["html_url"] |> Option.ofObj with
@@ -38542,7 +38542,7 @@ module PullReviewJsonParseExtension =
             let arg_2 =
                 match node.["comments_count"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_1 =
                 match node.["body"] |> Option.ofObj with
@@ -38638,7 +38638,7 @@ module PullReviewCommentJsonParseExtension =
             let arg_11 =
                 match node.["pull_request_review_id"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_10 =
                 match node.["position"] |> Option.ofObj with
@@ -38663,7 +38663,7 @@ module PullReviewCommentJsonParseExtension =
             let arg_6 =
                 match node.["id"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_5 =
                 match node.["html_url"] |> Option.ofObj with
@@ -38856,7 +38856,7 @@ module ReleaseJsonParseExtension =
             let arg_7 =
                 match node.["id"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_6 =
                 match node.["html_url"] |> Option.ofObj with
@@ -39178,7 +39178,7 @@ module RepositoryJsonParseExtension =
             let arg_51 =
                 match node.["watchers_count"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_50 =
                 match node.["updated_at"] |> Option.ofObj with
@@ -39193,7 +39193,7 @@ module RepositoryJsonParseExtension =
             let arg_48 =
                 match node.["stars_count"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_47 =
                 match node.["ssh_url"] |> Option.ofObj with
@@ -39203,7 +39203,7 @@ module RepositoryJsonParseExtension =
             let arg_46 =
                 match node.["size"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_45 =
                 match node.["repo_transfer"] |> Option.ofObj with
@@ -39213,7 +39213,7 @@ module RepositoryJsonParseExtension =
             let arg_44 =
                 match node.["release_counter"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_43 =
                 match node.["private"] |> Option.ofObj with
@@ -39243,12 +39243,12 @@ module RepositoryJsonParseExtension =
             let arg_38 =
                 match node.["open_pr_counter"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_37 =
                 match node.["open_issues_count"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_36 =
                 match node.["name"] |> Option.ofObj with
@@ -39303,7 +39303,7 @@ module RepositoryJsonParseExtension =
             let arg_26 =
                 match node.["id"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_25 =
                 match node.["html_url"] |> Option.ofObj with
@@ -39338,7 +39338,7 @@ module RepositoryJsonParseExtension =
             let arg_19 =
                 match node.["forks_count"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_18 =
                 match node.["fork"] |> Option.ofObj with
@@ -39728,7 +39728,7 @@ module CombinedStatusJsonParseExtension =
             let arg_6 =
                 match node.["total_count"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_5 =
                 match node.["statuses"] |> Option.ofObj with
@@ -39974,7 +39974,7 @@ module DeployKeyJsonParseExtension =
             let arg_5 =
                 match node.["key_id"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_4 =
                 match node.["key"] |> Option.ofObj with
@@ -39984,7 +39984,7 @@ module DeployKeyJsonParseExtension =
             let arg_3 =
                 match node.["id"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_2 =
                 match node.["fingerprint"] |> Option.ofObj with
@@ -40205,7 +40205,7 @@ module IssueJsonParseExtension =
             let arg_16 =
                 match node.["original_author_id"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_15 =
                 match node.["original_author"] |> Option.ofObj with
@@ -40215,7 +40215,7 @@ module IssueJsonParseExtension =
             let arg_14 =
                 match node.["number"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_13 =
                 match node.["milestone"] |> Option.ofObj with
@@ -40247,7 +40247,7 @@ module IssueJsonParseExtension =
             let arg_10 =
                 match node.["id"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_9 =
                 match node.["html_url"] |> Option.ofObj with
@@ -40267,7 +40267,7 @@ module IssueJsonParseExtension =
             let arg_6 =
                 match node.["comments"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_5 =
                 match node.["closed_at"] |> Option.ofObj with
@@ -40585,7 +40585,7 @@ module NotificationThreadJsonParseExtension =
             let arg_1 =
                 match node.["id"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_0 =
                 let result =
@@ -40647,7 +40647,7 @@ module PRBranchInfoJsonParseExtension =
             let arg_4 =
                 match node.["repo_id"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_3 =
                 match node.["repo"] |> Option.ofObj with
@@ -40734,7 +40734,7 @@ module PackageJsonParseExtension =
             let arg_3 =
                 match node.["id"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_2 =
                 match node.["creator"] |> Option.ofObj with
@@ -40977,7 +40977,7 @@ module PullRequestJsonParseExtension =
             let arg_23 =
                 match node.["number"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_22 =
                 match node.["milestone"] |> Option.ofObj with
@@ -41039,7 +41039,7 @@ module PullRequestJsonParseExtension =
             let arg_13 =
                 match node.["id"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_12 =
                 match node.["html_url"] |> Option.ofObj with
@@ -41069,7 +41069,7 @@ module PullRequestJsonParseExtension =
             let arg_7 =
                 match node.["comments"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_6 =
                 match node.["closed_at"] |> Option.ofObj with
@@ -41217,17 +41217,17 @@ module TrackedTimeJsonParseExtension =
             let arg_6 =
                 match node.["user_id"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_5 =
                 match node.["time"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_4 =
                 match node.["issue_id"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_3 =
                 match node.["issue"] |> Option.ofObj with
@@ -41237,7 +41237,7 @@ module TrackedTimeJsonParseExtension =
             let arg_2 =
                 match node.["id"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_1 =
                 match node.["created"] |> Option.ofObj with
@@ -41326,7 +41326,7 @@ module BranchJsonParseExtension =
             let arg_6 =
                 match node.["required_approvals"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_5 =
                 match node.["protected"] |> Option.ofObj with
@@ -41432,7 +41432,7 @@ module TimelineCommentJsonParseExtension =
             let arg_25 =
                 match node.["review_id"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_24 =
                 match node.["resolve_doer"] |> Option.ofObj with
@@ -41472,7 +41472,7 @@ module TimelineCommentJsonParseExtension =
             let arg_17 =
                 match node.["project_id"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_16 =
                 match node.["old_title"] |> Option.ofObj with
@@ -41487,7 +41487,7 @@ module TimelineCommentJsonParseExtension =
             let arg_14 =
                 match node.["old_project_id"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_13 =
                 match node.["old_milestone"] |> Option.ofObj with
@@ -41522,7 +41522,7 @@ module TimelineCommentJsonParseExtension =
             let arg_7 =
                 match node.["id"] |> Option.ofObj with
                 | None -> None
-                | Some v -> v.AsValue().GetValue<System.Int32> () |> Some
+                | Some v -> v.AsValue().GetValue<System.Int64> () |> Some
 
             let arg_6 =
                 match node.["html_url"] |> Option.ofObj with
@@ -41651,7 +41651,7 @@ module LanguageStatisticsJsonParseExtension =
         /// Parse from a JSON node.
         static member jsonParse (node : System.Text.Json.Nodes.JsonNode) : LanguageStatistics =
             let arg_0 =
-                let result = System.Collections.Generic.Dictionary<string, int> ()
+                let result = System.Collections.Generic.Dictionary<string, int64> ()
                 let node = node.AsObject ()
 
                 for KeyValue (key, value) in node do
@@ -41667,7 +41667,7 @@ module LanguageStatisticsJsonParseExtension =
                                         sprintf "Required key '%s' not found on JSON object" (key)
                                     )
                                 )
-                            | Some node -> node.AsValue().GetValue<System.Int32> ()
+                            | Some node -> node.AsValue().GetValue<System.Int64> ()
                         )
 
                 result
@@ -42129,7 +42129,7 @@ module Gitea =
                 }
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
-            member _.AdminGetHook (id : int, ct : System.Threading.CancellationToken option) =
+            member _.AdminGetHook (id : int64, ct : System.Threading.CancellationToken option) =
                 async {
                     let! ct = Async.CancellationToken
 
@@ -42181,7 +42181,7 @@ module Gitea =
                 }
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
-            member _.AdminEditHook (id : int, body : EditHookOption, ct : System.Threading.CancellationToken option) =
+            member _.AdminEditHook (id : int64, body : EditHookOption, ct : System.Threading.CancellationToken option) =
                 async {
                     let! ct = Async.CancellationToken
 
@@ -42762,7 +42762,7 @@ module Gitea =
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
             member _.AdminDeleteUserPublicKey
-                (username : string, id : int, ct : System.Threading.CancellationToken option)
+                (username : string, id : int64, ct : System.Threading.CancellationToken option)
                 =
                 async {
                     let! ct = Async.CancellationToken
@@ -42928,7 +42928,7 @@ module Gitea =
                 }
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
-            member _.AdminDeleteHook (id : int, ct : System.Threading.CancellationToken option) =
+            member _.AdminDeleteHook (id : int64, ct : System.Threading.CancellationToken option) =
                 async {
                     let! ct = Async.CancellationToken
 
@@ -43897,7 +43897,7 @@ module Gitea =
                 }
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
-            member _.OrgGetHook (org : string, id : int, ct : System.Threading.CancellationToken option) =
+            member _.OrgGetHook (org : string, id : int64, ct : System.Threading.CancellationToken option) =
                 async {
                     let! ct = Async.CancellationToken
 
@@ -43951,7 +43951,7 @@ module Gitea =
                 }
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
-            member _.OrgDeleteHook (org : string, id : int, ct : System.Threading.CancellationToken option) =
+            member _.OrgDeleteHook (org : string, id : int64, ct : System.Threading.CancellationToken option) =
                 async {
                     let! ct = Async.CancellationToken
 
@@ -43991,7 +43991,7 @@ module Gitea =
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
             member _.OrgEditHook
-                (org : string, id : int, body : EditHookOption, ct : System.Threading.CancellationToken option)
+                (org : string, id : int64, body : EditHookOption, ct : System.Threading.CancellationToken option)
                 =
                 async {
                     let! ct = Async.CancellationToken
@@ -44189,7 +44189,7 @@ module Gitea =
                 }
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
-            member _.OrgGetLabel (org : string, id : int, ct : System.Threading.CancellationToken option) =
+            member _.OrgGetLabel (org : string, id : int64, ct : System.Threading.CancellationToken option) =
                 async {
                     let! ct = Async.CancellationToken
 
@@ -44243,7 +44243,7 @@ module Gitea =
                 }
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
-            member _.OrgDeleteLabel (org : string, id : int, ct : System.Threading.CancellationToken option) =
+            member _.OrgDeleteLabel (org : string, id : int64, ct : System.Threading.CancellationToken option) =
                 async {
                     let! ct = Async.CancellationToken
 
@@ -44283,7 +44283,7 @@ module Gitea =
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
             member _.OrgEditLabel
-                (org : string, id : int, body : EditLabelOption, ct : System.Threading.CancellationToken option)
+                (org : string, id : int64, body : EditLabelOption, ct : System.Threading.CancellationToken option)
                 =
                 async {
                     let! ct = Async.CancellationToken
@@ -45317,7 +45317,7 @@ module Gitea =
                     labels : string,
                     milestones : string,
                     q : string,
-                    priority_repo_id : int,
+                    priority_repo_id : int64,
                     type' : string,
                     since : string,
                     before : string,
@@ -45492,10 +45492,10 @@ module Gitea =
                     q : string,
                     topic : bool,
                     includeDesc : bool,
-                    uid : int,
-                    priority_owner_id : int,
-                    team_id : int,
-                    starredBy : int,
+                    uid : int64,
+                    priority_owner_id : int64,
+                    team_id : int64,
+                    starredBy : int64,
                     private' : bool,
                     is_private : bool,
                     template : bool,
@@ -48410,7 +48410,7 @@ module Gitea =
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
             member _.RepoGetHook
-                (owner : string, repo : string, id : int, ct : System.Threading.CancellationToken option)
+                (owner : string, repo : string, id : int64, ct : System.Threading.CancellationToken option)
                 =
                 async {
                     let! ct = Async.CancellationToken
@@ -48467,7 +48467,7 @@ module Gitea =
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
             member _.RepoDeleteHook
-                (owner : string, repo : string, id : int, ct : System.Threading.CancellationToken option)
+                (owner : string, repo : string, id : int64, ct : System.Threading.CancellationToken option)
                 =
                 async {
                     let! ct = Async.CancellationToken
@@ -48512,7 +48512,7 @@ module Gitea =
                 (
                     owner : string,
                     repo : string,
-                    id : int,
+                    id : int64,
                     body : EditHookOption,
                     ct : System.Threading.CancellationToken option
                 )
@@ -48580,7 +48580,7 @@ module Gitea =
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
             member _.RepoTestHook
-                (owner : string, repo : string, id : int, ref : string, ct : System.Threading.CancellationToken option)
+                (owner : string, repo : string, id : int64, ref : string, ct : System.Threading.CancellationToken option)
                 =
                 async {
                     let! ct = Async.CancellationToken
@@ -48957,7 +48957,7 @@ module Gitea =
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
             member _.IssueDeleteComment
-                (owner : string, repo : string, id : int, ct : System.Threading.CancellationToken option)
+                (owner : string, repo : string, id : int64, ct : System.Threading.CancellationToken option)
                 =
                 async {
                     let! ct = Async.CancellationToken
@@ -48999,7 +48999,7 @@ module Gitea =
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
             member _.IssueListIssueCommentAttachments
-                (owner : string, repo : string, id : int, ct : System.Threading.CancellationToken option)
+                (owner : string, repo : string, id : int64, ct : System.Threading.CancellationToken option)
                 =
                 async {
                     let! ct = Async.CancellationToken
@@ -49070,8 +49070,8 @@ module Gitea =
                 (
                     owner : string,
                     repo : string,
-                    id : int,
-                    attachment_id : int,
+                    id : int64,
+                    attachment_id : int64,
                     ct : System.Threading.CancellationToken option
                 )
                 =
@@ -49137,8 +49137,8 @@ module Gitea =
                 (
                     owner : string,
                     repo : string,
-                    id : int,
-                    attachment_id : int,
+                    id : int64,
+                    attachment_id : int64,
                     ct : System.Threading.CancellationToken option
                 )
                 =
@@ -49189,8 +49189,8 @@ module Gitea =
                 (
                     owner : string,
                     repo : string,
-                    id : int,
-                    attachment_id : int,
+                    id : int64,
+                    attachment_id : int64,
                     body : EditAttachmentOptions,
                     ct : System.Threading.CancellationToken option
                 )
@@ -49262,7 +49262,7 @@ module Gitea =
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
             member _.IssueGetCommentReactions
-                (owner : string, repo : string, id : int, ct : System.Threading.CancellationToken option)
+                (owner : string, repo : string, id : int64, ct : System.Threading.CancellationToken option)
                 =
                 async {
                     let! ct = Async.CancellationToken
@@ -49333,7 +49333,7 @@ module Gitea =
                 (
                     owner : string,
                     repo : string,
-                    id : int,
+                    id : int64,
                     content : EditReactionOption,
                     ct : System.Threading.CancellationToken option
                 )
@@ -49386,7 +49386,7 @@ module Gitea =
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
             member _.IssueGetIssue
-                (owner : string, repo : string, index : int, ct : System.Threading.CancellationToken option)
+                (owner : string, repo : string, index : int64, ct : System.Threading.CancellationToken option)
                 =
                 async {
                     let! ct = Async.CancellationToken
@@ -49443,7 +49443,7 @@ module Gitea =
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
             member _.IssueDelete
-                (owner : string, repo : string, index : int, ct : System.Threading.CancellationToken option)
+                (owner : string, repo : string, index : int64, ct : System.Threading.CancellationToken option)
                 =
                 async {
                     let! ct = Async.CancellationToken
@@ -49488,7 +49488,7 @@ module Gitea =
                 (
                     owner : string,
                     repo : string,
-                    index : int,
+                    index : int64,
                     body : EditIssueOption,
                     ct : System.Threading.CancellationToken option
                 )
@@ -49556,7 +49556,7 @@ module Gitea =
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
             member _.IssueListIssueAttachments
-                (owner : string, repo : string, index : int, ct : System.Threading.CancellationToken option)
+                (owner : string, repo : string, index : int64, ct : System.Threading.CancellationToken option)
                 =
                 async {
                     let! ct = Async.CancellationToken
@@ -49627,8 +49627,8 @@ module Gitea =
                 (
                     owner : string,
                     repo : string,
-                    index : int,
-                    attachment_id : int,
+                    index : int64,
+                    attachment_id : int64,
                     ct : System.Threading.CancellationToken option
                 )
                 =
@@ -49694,8 +49694,8 @@ module Gitea =
                 (
                     owner : string,
                     repo : string,
-                    index : int,
-                    attachment_id : int,
+                    index : int64,
+                    attachment_id : int64,
                     ct : System.Threading.CancellationToken option
                 )
                 =
@@ -49746,8 +49746,8 @@ module Gitea =
                 (
                     owner : string,
                     repo : string,
-                    index : int,
-                    attachment_id : int,
+                    index : int64,
+                    attachment_id : int64,
                     body : EditAttachmentOptions,
                     ct : System.Threading.CancellationToken option
                 )
@@ -49822,7 +49822,7 @@ module Gitea =
                 (
                     owner : string,
                     repo : string,
-                    index : int,
+                    index : int64,
                     since : string,
                     before : string,
                     ct : System.Threading.CancellationToken option
@@ -49905,7 +49905,7 @@ module Gitea =
                 (
                     owner : string,
                     repo : string,
-                    index : int,
+                    index : int64,
                     body : CreateIssueCommentOption,
                     ct : System.Threading.CancellationToken option
                 )
@@ -49975,7 +49975,7 @@ module Gitea =
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
             member _.IssueDeleteCommentDeprecated
-                (owner : string, repo : string, index : int, id : int, ct : System.Threading.CancellationToken option)
+                (owner : string, repo : string, index : int, id : int64, ct : System.Threading.CancellationToken option)
                 =
                 async {
                     let! ct = Async.CancellationToken
@@ -50021,7 +50021,7 @@ module Gitea =
                 (
                     owner : string,
                     repo : string,
-                    index : int,
+                    index : int64,
                     body : EditDeadlineOption,
                     ct : System.Threading.CancellationToken option
                 )
@@ -50089,7 +50089,7 @@ module Gitea =
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
             member _.IssueGetLabels
-                (owner : string, repo : string, index : int, ct : System.Threading.CancellationToken option)
+                (owner : string, repo : string, index : int64, ct : System.Threading.CancellationToken option)
                 =
                 async {
                     let! ct = Async.CancellationToken
@@ -50160,7 +50160,7 @@ module Gitea =
                 (
                     owner : string,
                     repo : string,
-                    index : int,
+                    index : int64,
                     body : IssueLabelsOption,
                     ct : System.Threading.CancellationToken option
                 )
@@ -50239,7 +50239,7 @@ module Gitea =
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
             member _.IssueClearLabels
-                (owner : string, repo : string, index : int, ct : System.Threading.CancellationToken option)
+                (owner : string, repo : string, index : int64, ct : System.Threading.CancellationToken option)
                 =
                 async {
                     let! ct = Async.CancellationToken
@@ -50284,7 +50284,7 @@ module Gitea =
                 (
                     owner : string,
                     repo : string,
-                    index : int,
+                    index : int64,
                     body : IssueLabelsOption,
                     ct : System.Threading.CancellationToken option
                 )
@@ -50363,7 +50363,13 @@ module Gitea =
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
             member _.IssueRemoveLabel
-                (owner : string, repo : string, index : int, id : int, ct : System.Threading.CancellationToken option)
+                (
+                    owner : string,
+                    repo : string,
+                    index : int64,
+                    id : int64,
+                    ct : System.Threading.CancellationToken option
+                )
                 =
                 async {
                     let! ct = Async.CancellationToken
@@ -50409,7 +50415,7 @@ module Gitea =
                 (
                     owner : string,
                     repo : string,
-                    index : int,
+                    index : int64,
                     page : int,
                     limit : int,
                     ct : System.Threading.CancellationToken option
@@ -50492,7 +50498,7 @@ module Gitea =
                 (
                     owner : string,
                     repo : string,
-                    index : int,
+                    index : int64,
                     content : EditReactionOption,
                     ct : System.Threading.CancellationToken option
                 )
@@ -50545,7 +50551,7 @@ module Gitea =
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
             member _.IssueDeleteStopWatch
-                (owner : string, repo : string, index : int, ct : System.Threading.CancellationToken option)
+                (owner : string, repo : string, index : int64, ct : System.Threading.CancellationToken option)
                 =
                 async {
                     let! ct = Async.CancellationToken
@@ -50587,7 +50593,7 @@ module Gitea =
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
             member _.IssueStartStopWatch
-                (owner : string, repo : string, index : int, ct : System.Threading.CancellationToken option)
+                (owner : string, repo : string, index : int64, ct : System.Threading.CancellationToken option)
                 =
                 async {
                     let! ct = Async.CancellationToken
@@ -50629,7 +50635,7 @@ module Gitea =
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
             member _.IssueStopStopWatch
-                (owner : string, repo : string, index : int, ct : System.Threading.CancellationToken option)
+                (owner : string, repo : string, index : int64, ct : System.Threading.CancellationToken option)
                 =
                 async {
                     let! ct = Async.CancellationToken
@@ -50674,7 +50680,7 @@ module Gitea =
                 (
                     owner : string,
                     repo : string,
-                    index : int,
+                    index : int64,
                     page : int,
                     limit : int,
                     ct : System.Threading.CancellationToken option
@@ -50754,7 +50760,7 @@ module Gitea =
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
             member _.IssueCheckSubscription
-                (owner : string, repo : string, index : int, ct : System.Threading.CancellationToken option)
+                (owner : string, repo : string, index : int64, ct : System.Threading.CancellationToken option)
                 =
                 async {
                     let! ct = Async.CancellationToken
@@ -50814,7 +50820,7 @@ module Gitea =
                 (
                     owner : string,
                     repo : string,
-                    index : int,
+                    index : int64,
                     since : string,
                     page : int,
                     limit : int,
@@ -50903,7 +50909,7 @@ module Gitea =
                 (
                     owner : string,
                     repo : string,
-                    index : int,
+                    index : int64,
                     user : string,
                     since : string,
                     before : string,
@@ -50995,7 +51001,7 @@ module Gitea =
                 (
                     owner : string,
                     repo : string,
-                    index : int,
+                    index : int64,
                     body : AddTimeOption,
                     ct : System.Threading.CancellationToken option
                 )
@@ -51063,7 +51069,7 @@ module Gitea =
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
             member _.IssueResetTime
-                (owner : string, repo : string, index : int, ct : System.Threading.CancellationToken option)
+                (owner : string, repo : string, index : int64, ct : System.Threading.CancellationToken option)
                 =
                 async {
                     let! ct = Async.CancellationToken
@@ -51105,7 +51111,13 @@ module Gitea =
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
             member _.IssueDeleteTime
-                (owner : string, repo : string, index : int, id : int, ct : System.Threading.CancellationToken option)
+                (
+                    owner : string,
+                    repo : string,
+                    index : int64,
+                    id : int64,
+                    ct : System.Threading.CancellationToken option
+                )
                 =
                 async {
                     let! ct = Async.CancellationToken
@@ -51299,7 +51311,7 @@ module Gitea =
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
             member _.RepoGetKey
-                (owner : string, repo : string, id : int, ct : System.Threading.CancellationToken option)
+                (owner : string, repo : string, id : int64, ct : System.Threading.CancellationToken option)
                 =
                 async {
                     let! ct = Async.CancellationToken
@@ -51356,7 +51368,7 @@ module Gitea =
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
             member _.RepoDeleteKey
-                (owner : string, repo : string, id : int, ct : System.Threading.CancellationToken option)
+                (owner : string, repo : string, id : int64, ct : System.Threading.CancellationToken option)
                 =
                 async {
                     let! ct = Async.CancellationToken
@@ -51537,7 +51549,7 @@ module Gitea =
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
             member _.IssueGetLabel
-                (owner : string, repo : string, id : int, ct : System.Threading.CancellationToken option)
+                (owner : string, repo : string, id : int64, ct : System.Threading.CancellationToken option)
                 =
                 async {
                     let! ct = Async.CancellationToken
@@ -51594,7 +51606,7 @@ module Gitea =
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
             member _.IssueDeleteLabel
-                (owner : string, repo : string, id : int, ct : System.Threading.CancellationToken option)
+                (owner : string, repo : string, id : int64, ct : System.Threading.CancellationToken option)
                 =
                 async {
                     let! ct = Async.CancellationToken
@@ -51639,7 +51651,7 @@ module Gitea =
                 (
                     owner : string,
                     repo : string,
-                    id : int,
+                    id : int64,
                     body : EditLabelOption,
                     ct : System.Threading.CancellationToken option
                 )
@@ -52368,8 +52380,8 @@ module Gitea =
                     repo : string,
                     state : string,
                     sort : string,
-                    milestone : int,
-                    labels : int list,
+                    milestone : int64,
+                    labels : int64 list,
                     page : int,
                     limit : int,
                     ct : System.Threading.CancellationToken option
@@ -52525,7 +52537,7 @@ module Gitea =
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
             member _.RepoGetPullRequest
-                (owner : string, repo : string, index : int, ct : System.Threading.CancellationToken option)
+                (owner : string, repo : string, index : int64, ct : System.Threading.CancellationToken option)
                 =
                 async {
                     let! ct = Async.CancellationToken
@@ -52585,7 +52597,7 @@ module Gitea =
                 (
                     owner : string,
                     repo : string,
-                    index : int,
+                    index : int64,
                     body : EditPullRequestOption,
                     ct : System.Threading.CancellationToken option
                 )
@@ -52656,7 +52668,7 @@ module Gitea =
                 (
                     owner : string,
                     repo : string,
-                    index : int,
+                    index : int64,
                     diffType : string,
                     binary : bool,
                     ct : System.Threading.CancellationToken option
@@ -52713,7 +52725,7 @@ module Gitea =
                 (
                     owner : string,
                     repo : string,
-                    index : int,
+                    index : int64,
                     page : int,
                     limit : int,
                     ct : System.Threading.CancellationToken option
@@ -52796,7 +52808,7 @@ module Gitea =
                 (
                     owner : string,
                     repo : string,
-                    index : int,
+                    index : int64,
                     skip_to : string,
                     whitespace : string,
                     page : int,
@@ -52882,7 +52894,7 @@ module Gitea =
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
             member _.RepoPullRequestIsMerged
-                (owner : string, repo : string, index : int, ct : System.Threading.CancellationToken option)
+                (owner : string, repo : string, index : int64, ct : System.Threading.CancellationToken option)
                 =
                 async {
                     let! ct = Async.CancellationToken
@@ -52927,7 +52939,7 @@ module Gitea =
                 (
                     owner : string,
                     repo : string,
-                    index : int,
+                    index : int64,
                     body : MergePullRequestOption,
                     ct : System.Threading.CancellationToken option
                 )
@@ -52980,7 +52992,7 @@ module Gitea =
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
             member _.RepoCancelScheduledAutoMerge
-                (owner : string, repo : string, index : int, ct : System.Threading.CancellationToken option)
+                (owner : string, repo : string, index : int64, ct : System.Threading.CancellationToken option)
                 =
                 async {
                     let! ct = Async.CancellationToken
@@ -53025,7 +53037,7 @@ module Gitea =
                 (
                     owner : string,
                     repo : string,
-                    index : int,
+                    index : int64,
                     body : PullReviewRequestOptions,
                     ct : System.Threading.CancellationToken option
                 )
@@ -53109,7 +53121,7 @@ module Gitea =
                 (
                     owner : string,
                     repo : string,
-                    index : int,
+                    index : int64,
                     body : PullReviewRequestOptions,
                     ct : System.Threading.CancellationToken option
                 )
@@ -53167,7 +53179,7 @@ module Gitea =
                 (
                     owner : string,
                     repo : string,
-                    index : int,
+                    index : int64,
                     page : int,
                     limit : int,
                     ct : System.Threading.CancellationToken option
@@ -53250,7 +53262,7 @@ module Gitea =
                 (
                     owner : string,
                     repo : string,
-                    index : int,
+                    index : int64,
                     body : CreatePullReviewOptions,
                     ct : System.Threading.CancellationToken option
                 )
@@ -53318,7 +53330,13 @@ module Gitea =
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
             member _.RepoGetPullReview
-                (owner : string, repo : string, index : int, id : int, ct : System.Threading.CancellationToken option)
+                (
+                    owner : string,
+                    repo : string,
+                    index : int64,
+                    id : int64,
+                    ct : System.Threading.CancellationToken option
+                )
                 =
                 async {
                     let! ct = Async.CancellationToken
@@ -53379,8 +53397,8 @@ module Gitea =
                 (
                     owner : string,
                     repo : string,
-                    index : int,
-                    id : int,
+                    index : int64,
+                    id : int64,
                     body : SubmitPullReviewOptions,
                     ct : System.Threading.CancellationToken option
                 )
@@ -53449,7 +53467,13 @@ module Gitea =
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
             member _.RepoDeletePullReview
-                (owner : string, repo : string, index : int, id : int, ct : System.Threading.CancellationToken option)
+                (
+                    owner : string,
+                    repo : string,
+                    index : int64,
+                    id : int64,
+                    ct : System.Threading.CancellationToken option
+                )
                 =
                 async {
                     let! ct = Async.CancellationToken
@@ -53492,7 +53516,13 @@ module Gitea =
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
             member _.RepoGetPullReviewComments
-                (owner : string, repo : string, index : int, id : int, ct : System.Threading.CancellationToken option)
+                (
+                    owner : string,
+                    repo : string,
+                    index : int64,
+                    id : int64,
+                    ct : System.Threading.CancellationToken option
+                )
                 =
                 async {
                     let! ct = Async.CancellationToken
@@ -53564,8 +53594,8 @@ module Gitea =
                 (
                     owner : string,
                     repo : string,
-                    index : int,
-                    id : int,
+                    index : int64,
+                    id : int64,
                     body : DismissPullReviewOptions,
                     ct : System.Threading.CancellationToken option
                 )
@@ -53636,7 +53666,13 @@ module Gitea =
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
             member _.RepoUnDismissPullReview
-                (owner : string, repo : string, index : int, id : int, ct : System.Threading.CancellationToken option)
+                (
+                    owner : string,
+                    repo : string,
+                    index : int64,
+                    id : int64,
+                    ct : System.Threading.CancellationToken option
+                )
                 =
                 async {
                     let! ct = Async.CancellationToken
@@ -53697,7 +53733,7 @@ module Gitea =
                 (
                     owner : string,
                     repo : string,
-                    index : int,
+                    index : int64,
                     style : string,
                     ct : System.Threading.CancellationToken option
                 )
@@ -54400,7 +54436,7 @@ module Gitea =
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
             member _.RepoGetRelease
-                (owner : string, repo : string, id : int, ct : System.Threading.CancellationToken option)
+                (owner : string, repo : string, id : int64, ct : System.Threading.CancellationToken option)
                 =
                 async {
                     let! ct = Async.CancellationToken
@@ -54457,7 +54493,7 @@ module Gitea =
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
             member _.RepoDeleteRelease
-                (owner : string, repo : string, id : int, ct : System.Threading.CancellationToken option)
+                (owner : string, repo : string, id : int64, ct : System.Threading.CancellationToken option)
                 =
                 async {
                     let! ct = Async.CancellationToken
@@ -54502,7 +54538,7 @@ module Gitea =
                 (
                     owner : string,
                     repo : string,
-                    id : int,
+                    id : int64,
                     body : EditReleaseOption,
                     ct : System.Threading.CancellationToken option
                 )
@@ -54570,7 +54606,7 @@ module Gitea =
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
             member _.RepoListReleaseAttachments
-                (owner : string, repo : string, id : int, ct : System.Threading.CancellationToken option)
+                (owner : string, repo : string, id : int64, ct : System.Threading.CancellationToken option)
                 =
                 async {
                     let! ct = Async.CancellationToken
@@ -54641,8 +54677,8 @@ module Gitea =
                 (
                     owner : string,
                     repo : string,
-                    id : int,
-                    attachment_id : int,
+                    id : int64,
+                    attachment_id : int64,
                     ct : System.Threading.CancellationToken option
                 )
                 =
@@ -54708,8 +54744,8 @@ module Gitea =
                 (
                     owner : string,
                     repo : string,
-                    id : int,
-                    attachment_id : int,
+                    id : int64,
+                    attachment_id : int64,
                     ct : System.Threading.CancellationToken option
                 )
                 =
@@ -54760,8 +54796,8 @@ module Gitea =
                 (
                     owner : string,
                     repo : string,
-                    id : int,
-                    attachment_id : int,
+                    id : int64,
+                    attachment_id : int64,
                     body : EditAttachmentOptions,
                     ct : System.Threading.CancellationToken option
                 )
@@ -56838,7 +56874,7 @@ module Gitea =
                 }
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
-            member _.RepoGetByID (id : int, ct : System.Threading.CancellationToken option) =
+            member _.RepoGetByID (id : int64, ct : System.Threading.CancellationToken option) =
                 async {
                     let! ct = Async.CancellationToken
 
@@ -57121,7 +57157,7 @@ module Gitea =
                 }
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
-            member _.OrgGetTeam (id : int, ct : System.Threading.CancellationToken option) =
+            member _.OrgGetTeam (id : int64, ct : System.Threading.CancellationToken option) =
                 async {
                     let! ct = Async.CancellationToken
 
@@ -57173,7 +57209,7 @@ module Gitea =
                 }
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
-            member _.OrgDeleteTeam (id : int, ct : System.Threading.CancellationToken option) =
+            member _.OrgDeleteTeam (id : int64, ct : System.Threading.CancellationToken option) =
                 async {
                     let! ct = Async.CancellationToken
 
@@ -57271,7 +57307,7 @@ module Gitea =
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
             member _.OrgListTeamMembers
-                (id : int, page : int, limit : int, ct : System.Threading.CancellationToken option)
+                (id : int64, page : int, limit : int, ct : System.Threading.CancellationToken option)
                 =
                 async {
                     let! ct = Async.CancellationToken
@@ -57343,7 +57379,7 @@ module Gitea =
                 }
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
-            member _.OrgListTeamMember (id : int, username : string, ct : System.Threading.CancellationToken option) =
+            member _.OrgListTeamMember (id : int64, username : string, ct : System.Threading.CancellationToken option) =
                 async {
                     let! ct = Async.CancellationToken
 
@@ -57397,7 +57433,9 @@ module Gitea =
                 }
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
-            member _.OrgRemoveTeamMember (id : int, username : string, ct : System.Threading.CancellationToken option) =
+            member _.OrgRemoveTeamMember
+                (id : int64, username : string, ct : System.Threading.CancellationToken option)
+                =
                 async {
                     let! ct = Async.CancellationToken
 
@@ -57436,7 +57474,7 @@ module Gitea =
                 }
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
-            member _.OrgAddTeamMember (id : int, username : string, ct : System.Threading.CancellationToken option) =
+            member _.OrgAddTeamMember (id : int64, username : string, ct : System.Threading.CancellationToken option) =
                 async {
                     let! ct = Async.CancellationToken
 
@@ -57476,7 +57514,7 @@ module Gitea =
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
             member _.OrgListTeamRepos
-                (id : int, page : int, limit : int, ct : System.Threading.CancellationToken option)
+                (id : int64, page : int, limit : int, ct : System.Threading.CancellationToken option)
                 =
                 async {
                     let! ct = Async.CancellationToken
@@ -57549,7 +57587,7 @@ module Gitea =
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
             member _.OrgListTeamRepo
-                (id : int, org : string, repo : string, ct : System.Threading.CancellationToken option)
+                (id : int64, org : string, repo : string, ct : System.Threading.CancellationToken option)
                 =
                 async {
                     let! ct = Async.CancellationToken
@@ -57606,7 +57644,7 @@ module Gitea =
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
             member _.OrgRemoveTeamRepository
-                (id : int, org : string, repo : string, ct : System.Threading.CancellationToken option)
+                (id : int64, org : string, repo : string, ct : System.Threading.CancellationToken option)
                 =
                 async {
                     let! ct = Async.CancellationToken
@@ -57648,7 +57686,7 @@ module Gitea =
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
             member _.OrgAddTeamRepository
-                (id : int, org : string, repo : string, ct : System.Threading.CancellationToken option)
+                (id : int64, org : string, repo : string, ct : System.Threading.CancellationToken option)
                 =
                 async {
                     let! ct = Async.CancellationToken
@@ -57942,7 +57980,7 @@ module Gitea =
                 }
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
-            member _.UserGetOAuth2Application (id : int, ct : System.Threading.CancellationToken option) =
+            member _.UserGetOAuth2Application (id : int64, ct : System.Threading.CancellationToken option) =
                 async {
                     let! ct = Async.CancellationToken
 
@@ -57995,7 +58033,7 @@ module Gitea =
                 }
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
-            member _.UserDeleteOAuth2Application (id : int, ct : System.Threading.CancellationToken option) =
+            member _.UserDeleteOAuth2Application (id : int64, ct : System.Threading.CancellationToken option) =
                 async {
                     let! ct = Async.CancellationToken
 
@@ -58034,7 +58072,7 @@ module Gitea =
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
             member _.UserUpdateOAuth2Application
-                (id : int, body : CreateOAuth2ApplicationOptions, ct : System.Threading.CancellationToken option)
+                (id : int64, body : CreateOAuth2ApplicationOptions, ct : System.Threading.CancellationToken option)
                 =
                 async {
                     let! ct = Async.CancellationToken
@@ -58557,7 +58595,7 @@ module Gitea =
                 }
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
-            member _.UserCurrentDeleteGPGKey (id : int, ct : System.Threading.CancellationToken option) =
+            member _.UserCurrentDeleteGPGKey (id : int64, ct : System.Threading.CancellationToken option) =
                 async {
                     let! ct = Async.CancellationToken
 
@@ -58723,7 +58761,7 @@ module Gitea =
                 }
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
-            member _.UserCurrentGetKey (id : int, ct : System.Threading.CancellationToken option) =
+            member _.UserCurrentGetKey (id : int64, ct : System.Threading.CancellationToken option) =
                 async {
                     let! ct = Async.CancellationToken
 
@@ -58775,7 +58813,7 @@ module Gitea =
                 }
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
-            member _.UserCurrentDeleteKey (id : int, ct : System.Threading.CancellationToken option) =
+            member _.UserCurrentDeleteKey (id : int64, ct : System.Threading.CancellationToken option) =
                 async {
                     let! ct = Async.CancellationToken
 
@@ -59617,7 +59655,7 @@ module Gitea =
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
             member _.UserSearch
-                (q : string, uid : int, page : int, limit : int, ct : System.Threading.CancellationToken option)
+                (q : string, uid : int64, page : int, limit : int, ct : System.Threading.CancellationToken option)
                 =
                 async {
                     let! ct = Async.CancellationToken

--- a/ConsumePlugin/GeneratedSwaggerGitea.fs
+++ b/ConsumePlugin/GeneratedSwaggerGitea.fs
@@ -33,7 +33,7 @@ type AccessToken =
         [<System.Text.Json.Serialization.JsonExtensionData>]
         AdditionalProperties : System.Collections.Generic.Dictionary<string, System.Text.Json.Nodes.JsonNode>
         [<System.Text.Json.Serialization.JsonPropertyName "id">]
-        Id : int option
+        Id : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "name">]
         Name : string option
         [<System.Text.Json.Serialization.JsonPropertyName "scopes">]
@@ -73,7 +73,7 @@ type AddTimeOption =
         [<System.Text.Json.Serialization.JsonPropertyName "created">]
         Created : string option
         [<System.Text.Json.Serialization.JsonPropertyName "time">]
-        Time : int
+        Time : int64
         [<System.Text.Json.Serialization.JsonPropertyName "user_name">]
         UserName : string option
     }
@@ -103,13 +103,13 @@ type Attachment =
         [<System.Text.Json.Serialization.JsonPropertyName "created_at">]
         CreatedAt : string option
         [<System.Text.Json.Serialization.JsonPropertyName "download_count">]
-        DownloadCount : int option
+        DownloadCount : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "id">]
-        Id : int option
+        Id : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "name">]
         Name : string option
         [<System.Text.Json.Serialization.JsonPropertyName "size">]
-        Size : int option
+        Size : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "uuid">]
         Uuid : string option
     }
@@ -161,7 +161,7 @@ type BranchProtection =
         [<System.Text.Json.Serialization.JsonPropertyName "require_signed_commits">]
         RequireSignedCommits : bool option
         [<System.Text.Json.Serialization.JsonPropertyName "required_approvals">]
-        RequiredApprovals : int option
+        RequiredApprovals : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "rule_name">]
         RuleName : string option
         [<System.Text.Json.Serialization.JsonPropertyName "status_check_contexts">]
@@ -179,13 +179,13 @@ type ChangedFile =
         [<System.Text.Json.Serialization.JsonExtensionData>]
         AdditionalProperties : System.Collections.Generic.Dictionary<string, System.Text.Json.Nodes.JsonNode>
         [<System.Text.Json.Serialization.JsonPropertyName "additions">]
-        Additions : int option
+        Additions : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "changes">]
-        Changes : int option
+        Changes : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "contents_url">]
         ContentsUrl : string option
         [<System.Text.Json.Serialization.JsonPropertyName "deletions">]
-        Deletions : int option
+        Deletions : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "filename">]
         Filename : string option
         [<System.Text.Json.Serialization.JsonPropertyName "html_url">]
@@ -241,11 +241,11 @@ type CommitStats =
         [<System.Text.Json.Serialization.JsonExtensionData>]
         AdditionalProperties : System.Collections.Generic.Dictionary<string, System.Text.Json.Nodes.JsonNode>
         [<System.Text.Json.Serialization.JsonPropertyName "additions">]
-        Additions : int option
+        Additions : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "deletions">]
-        Deletions : int option
+        Deletions : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "total">]
-        Total : int option
+        Total : int64 option
     }
 
 /// CommitUser contains information of a user in the context of a commit.
@@ -319,7 +319,7 @@ type CreateBranchProtectionOption =
         [<System.Text.Json.Serialization.JsonPropertyName "require_signed_commits">]
         RequireSignedCommits : bool option
         [<System.Text.Json.Serialization.JsonPropertyName "required_approvals">]
-        RequiredApprovals : int option
+        RequiredApprovals : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "rule_name">]
         RuleName : string option
         [<System.Text.Json.Serialization.JsonPropertyName "status_check_contexts">]
@@ -410,9 +410,9 @@ type CreateIssueOption =
         [<System.Text.Json.Serialization.JsonPropertyName "due_date">]
         DueDate : string option
         [<System.Text.Json.Serialization.JsonPropertyName "labels">]
-        Labels : int list option
+        Labels : int64 list option
         [<System.Text.Json.Serialization.JsonPropertyName "milestone">]
-        Milestone : int option
+        Milestone : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "ref">]
         Ref : string option
         [<System.Text.Json.Serialization.JsonPropertyName "title">]
@@ -520,9 +520,9 @@ type CreatePullRequestOption =
         [<System.Text.Json.Serialization.JsonPropertyName "head">]
         Head : string option
         [<System.Text.Json.Serialization.JsonPropertyName "labels">]
-        Labels : int list option
+        Labels : int64 list option
         [<System.Text.Json.Serialization.JsonPropertyName "milestone">]
-        Milestone : int option
+        Milestone : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "title">]
         Title : string option
     }
@@ -536,9 +536,9 @@ type CreatePullReviewComment =
         [<System.Text.Json.Serialization.JsonPropertyName "body">]
         Body : string option
         [<System.Text.Json.Serialization.JsonPropertyName "new_position">]
-        NewPosition : int option
+        NewPosition : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "old_position">]
-        OldPosition : int option
+        OldPosition : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "path">]
         Path : string option
     }
@@ -693,7 +693,7 @@ type CreateUserOption =
         [<System.Text.Json.Serialization.JsonPropertyName "send_notify">]
         SendNotify : bool option
         [<System.Text.Json.Serialization.JsonPropertyName "source_id">]
-        SourceId : int option
+        SourceId : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "username">]
         Username : string
         [<System.Text.Json.Serialization.JsonPropertyName "visibility">]
@@ -721,7 +721,7 @@ type Cron =
         [<System.Text.Json.Serialization.JsonExtensionData>]
         AdditionalProperties : System.Collections.Generic.Dictionary<string, System.Text.Json.Nodes.JsonNode>
         [<System.Text.Json.Serialization.JsonPropertyName "exec_times">]
-        ExecTimes : int option
+        ExecTimes : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "name">]
         Name : string option
         [<System.Text.Json.Serialization.JsonPropertyName "next">]
@@ -807,7 +807,7 @@ type EditBranchProtectionOption =
         [<System.Text.Json.Serialization.JsonPropertyName "require_signed_commits">]
         RequireSignedCommits : bool option
         [<System.Text.Json.Serialization.JsonPropertyName "required_approvals">]
-        RequiredApprovals : int option
+        RequiredApprovals : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "status_check_contexts">]
         StatusCheckContexts : string list option
         [<System.Text.Json.Serialization.JsonPropertyName "unprotected_file_patterns">]
@@ -884,7 +884,7 @@ type EditIssueOption =
         [<System.Text.Json.Serialization.JsonPropertyName "due_date">]
         DueDate : string option
         [<System.Text.Json.Serialization.JsonPropertyName "milestone">]
-        Milestone : int option
+        Milestone : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "ref">]
         Ref : string option
         [<System.Text.Json.Serialization.JsonPropertyName "state">]
@@ -966,9 +966,9 @@ type EditPullRequestOption =
         [<System.Text.Json.Serialization.JsonPropertyName "due_date">]
         DueDate : string option
         [<System.Text.Json.Serialization.JsonPropertyName "labels">]
-        Labels : int list option
+        Labels : int64 list option
         [<System.Text.Json.Serialization.JsonPropertyName "milestone">]
-        Milestone : int option
+        Milestone : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "state">]
         State : string option
         [<System.Text.Json.Serialization.JsonPropertyName "title">]
@@ -1063,7 +1063,7 @@ type EditUserOption =
         [<System.Text.Json.Serialization.JsonPropertyName "login_name">]
         LoginName : string
         [<System.Text.Json.Serialization.JsonPropertyName "max_repo_creation">]
-        MaxRepoCreation : int option
+        MaxRepoCreation : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "must_change_password">]
         MustChangePassword : bool option
         [<System.Text.Json.Serialization.JsonPropertyName "password">]
@@ -1073,7 +1073,7 @@ type EditUserOption =
         [<System.Text.Json.Serialization.JsonPropertyName "restricted">]
         Restricted : bool option
         [<System.Text.Json.Serialization.JsonPropertyName "source_id">]
-        SourceId : int
+        SourceId : int64
         [<System.Text.Json.Serialization.JsonPropertyName "visibility">]
         Visibility : string option
         [<System.Text.Json.Serialization.JsonPropertyName "website">]
@@ -1179,13 +1179,13 @@ type GeneralAPISettings =
         [<System.Text.Json.Serialization.JsonExtensionData>]
         AdditionalProperties : System.Collections.Generic.Dictionary<string, System.Text.Json.Nodes.JsonNode>
         [<System.Text.Json.Serialization.JsonPropertyName "default_git_trees_per_page">]
-        DefaultGitTreesPerPage : int option
+        DefaultGitTreesPerPage : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "default_max_blob_size">]
-        DefaultMaxBlobSize : int option
+        DefaultMaxBlobSize : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "default_paging_num">]
-        DefaultPagingNum : int option
+        DefaultPagingNum : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "max_response_items">]
-        MaxResponseItems : int option
+        MaxResponseItems : int64 option
     }
 
 /// GeneralAttachmentSettings contains global Attachment settings exposed by API
@@ -1199,9 +1199,9 @@ type GeneralAttachmentSettings =
         [<System.Text.Json.Serialization.JsonPropertyName "enabled">]
         Enabled : bool option
         [<System.Text.Json.Serialization.JsonPropertyName "max_files">]
-        MaxFiles : int option
+        MaxFiles : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "max_size">]
-        MaxSize : int option
+        MaxSize : int64 option
     }
 
 /// GeneralRepoSettings contains global repository settings exposed by API
@@ -1281,7 +1281,7 @@ type GitBlobResponse =
         [<System.Text.Json.Serialization.JsonPropertyName "sha">]
         Sha : string option
         [<System.Text.Json.Serialization.JsonPropertyName "size">]
-        Size : int option
+        Size : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "url">]
         Url : string option
     }
@@ -1299,7 +1299,7 @@ type GitEntry =
         [<System.Text.Json.Serialization.JsonPropertyName "sha">]
         Sha : string option
         [<System.Text.Json.Serialization.JsonPropertyName "size">]
-        Size : int option
+        Size : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "type">]
         Type : string option
         [<System.Text.Json.Serialization.JsonPropertyName "url">]
@@ -1341,11 +1341,11 @@ type GitTreeResponse =
         [<System.Text.Json.Serialization.JsonExtensionData>]
         AdditionalProperties : System.Collections.Generic.Dictionary<string, System.Text.Json.Nodes.JsonNode>
         [<System.Text.Json.Serialization.JsonPropertyName "page">]
-        Page : int option
+        Page : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "sha">]
         Sha : string option
         [<System.Text.Json.Serialization.JsonPropertyName "total_count">]
-        TotalCount : int option
+        TotalCount : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "tree">]
         Tree : GitEntry list option
         [<System.Text.Json.Serialization.JsonPropertyName "truncated">]
@@ -1378,7 +1378,7 @@ type Hook =
         [<System.Text.Json.Serialization.JsonPropertyName "events">]
         Events : string list option
         [<System.Text.Json.Serialization.JsonPropertyName "id">]
-        Id : int option
+        Id : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "type">]
         Type : string option
         [<System.Text.Json.Serialization.JsonPropertyName "updated_at">]
@@ -1442,7 +1442,7 @@ type IssueLabelsOption =
         [<System.Text.Json.Serialization.JsonExtensionData>]
         AdditionalProperties : System.Collections.Generic.Dictionary<string, System.Text.Json.Nodes.JsonNode>
         [<System.Text.Json.Serialization.JsonPropertyName "labels">]
-        Labels : int list option
+        Labels : int64 list option
     }
 
 /// Label a label to an issue or a pr
@@ -1458,7 +1458,7 @@ type Label =
         [<System.Text.Json.Serialization.JsonPropertyName "exclusive">]
         Exclusive : bool option
         [<System.Text.Json.Serialization.JsonPropertyName "id">]
-        Id : int option
+        Id : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "name">]
         Name : string option
         [<System.Text.Json.Serialization.JsonPropertyName "url">]
@@ -1549,7 +1549,7 @@ type MigrateRepoOptions =
         [<System.Text.Json.Serialization.JsonPropertyName "service">]
         Service : string option
         [<System.Text.Json.Serialization.JsonPropertyName "uid">]
-        Uid : int option
+        Uid : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "wiki">]
         Wiki : bool option
     }
@@ -1596,11 +1596,11 @@ type NodeInfoUsageUsers =
         [<System.Text.Json.Serialization.JsonExtensionData>]
         AdditionalProperties : System.Collections.Generic.Dictionary<string, System.Text.Json.Nodes.JsonNode>
         [<System.Text.Json.Serialization.JsonPropertyName "activeHalfyear">]
-        ActiveHalfyear : int option
+        ActiveHalfyear : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "activeMonth">]
-        ActiveMonth : int option
+        ActiveMonth : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "total">]
-        Total : int option
+        Total : int64 option
     }
 
 /// NotificationCount number of unread notifications
@@ -1610,7 +1610,7 @@ type NotificationCount =
         [<System.Text.Json.Serialization.JsonExtensionData>]
         AdditionalProperties : System.Collections.Generic.Dictionary<string, System.Text.Json.Nodes.JsonNode>
         [<System.Text.Json.Serialization.JsonPropertyName "new">]
-        New : int option
+        New : int64 option
     }
 
 /// OAuth2Application represents an OAuth2 application.
@@ -1628,7 +1628,7 @@ type OAuth2Application =
         [<System.Text.Json.Serialization.JsonPropertyName "created">]
         Created : string option
         [<System.Text.Json.Serialization.JsonPropertyName "id">]
-        Id : int option
+        Id : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "name">]
         Name : string option
         [<System.Text.Json.Serialization.JsonPropertyName "redirect_uris">]
@@ -1648,7 +1648,7 @@ type Organization =
         [<System.Text.Json.Serialization.JsonPropertyName "full_name">]
         FullName : string option
         [<System.Text.Json.Serialization.JsonPropertyName "id">]
-        Id : int option
+        Id : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "location">]
         Location : string option
         [<System.Text.Json.Serialization.JsonPropertyName "name">]
@@ -1688,9 +1688,9 @@ type PackageFile =
         [<System.Text.Json.Serialization.JsonExtensionData>]
         AdditionalProperties : System.Collections.Generic.Dictionary<string, System.Text.Json.Nodes.JsonNode>
         [<System.Text.Json.Serialization.JsonPropertyName "Size">]
-        Size : int option
+        Size : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "id">]
-        Id : int option
+        Id : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "md5">]
         Md5 : string option
         [<System.Text.Json.Serialization.JsonPropertyName "name">]
@@ -1812,7 +1812,7 @@ type RepositoryMeta =
         [<System.Text.Json.Serialization.JsonPropertyName "full_name">]
         FullName : string option
         [<System.Text.Json.Serialization.JsonPropertyName "id">]
-        Id : int option
+        Id : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "name">]
         Name : string option
         [<System.Text.Json.Serialization.JsonPropertyName "owner">]
@@ -1840,7 +1840,7 @@ type StopWatch =
         [<System.Text.Json.Serialization.JsonPropertyName "duration">]
         Duration : string option
         [<System.Text.Json.Serialization.JsonPropertyName "issue_index">]
-        IssueIndex : int option
+        IssueIndex : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "issue_title">]
         IssueTitle : string option
         [<System.Text.Json.Serialization.JsonPropertyName "repo_name">]
@@ -1848,7 +1848,7 @@ type StopWatch =
         [<System.Text.Json.Serialization.JsonPropertyName "repo_owner_name">]
         RepoOwnerName : string option
         [<System.Text.Json.Serialization.JsonPropertyName "seconds">]
-        Seconds : int option
+        Seconds : int64 option
     }
 
 /// SubmitPullReviewOptions are options to submit a pending pull review
@@ -1901,7 +1901,7 @@ type Team =
         [<System.Text.Json.Serialization.JsonPropertyName "description">]
         Description : string option
         [<System.Text.Json.Serialization.JsonPropertyName "id">]
-        Id : int option
+        Id : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "includes_all_repositories">]
         IncludesAllRepositories : bool option
         [<System.Text.Json.Serialization.JsonPropertyName "name">]
@@ -1935,9 +1935,9 @@ type TopicResponse =
         [<System.Text.Json.Serialization.JsonPropertyName "created">]
         Created : string option
         [<System.Text.Json.Serialization.JsonPropertyName "id">]
-        Id : int option
+        Id : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "repo_count">]
-        RepoCount : int option
+        RepoCount : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "topic_name">]
         TopicName : string option
         [<System.Text.Json.Serialization.JsonPropertyName "updated">]
@@ -1953,7 +1953,7 @@ type TransferRepoOption =
         [<System.Text.Json.Serialization.JsonPropertyName "new_owner">]
         NewOwner : string
         [<System.Text.Json.Serialization.JsonPropertyName "team_ids">]
-        TeamIds : int list option
+        TeamIds : int64 list option
     }
 
 /// UpdateFileOptions options for updating files
@@ -2002,13 +2002,13 @@ type User =
         [<System.Text.Json.Serialization.JsonPropertyName "email">]
         Email : string option
         [<System.Text.Json.Serialization.JsonPropertyName "followers_count">]
-        FollowersCount : int option
+        FollowersCount : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "following_count">]
-        FollowingCount : int option
+        FollowingCount : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "full_name">]
         FullName : string option
         [<System.Text.Json.Serialization.JsonPropertyName "id">]
-        Id : int option
+        Id : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "is_admin">]
         IsAdmin : bool option
         [<System.Text.Json.Serialization.JsonPropertyName "language">]
@@ -2026,7 +2026,7 @@ type User =
         [<System.Text.Json.Serialization.JsonPropertyName "restricted">]
         Restricted : bool option
         [<System.Text.Json.Serialization.JsonPropertyName "starred_repos_count">]
-        StarredReposCount : int option
+        StarredReposCount : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "visibility">]
         Visibility : string option
         [<System.Text.Json.Serialization.JsonPropertyName "website">]
@@ -2040,9 +2040,9 @@ type UserHeatmapData =
         [<System.Text.Json.Serialization.JsonExtensionData>]
         AdditionalProperties : System.Collections.Generic.Dictionary<string, System.Text.Json.Nodes.JsonNode>
         [<System.Text.Json.Serialization.JsonPropertyName "contributions">]
-        Contributions : int option
+        Contributions : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "timestamp">]
-        Timestamp : int option
+        Timestamp : int64 option
     }
 
 /// UserSettings represents user settings
@@ -2142,7 +2142,7 @@ type WikiCommitList =
         [<System.Text.Json.Serialization.JsonPropertyName "commits">]
         Commits : WikiCommit list option
         [<System.Text.Json.Serialization.JsonPropertyName "count">]
-        Count : int option
+        Count : int64 option
     }
 
 /// WikiPage a wiki page
@@ -2152,7 +2152,7 @@ type WikiPage =
         [<System.Text.Json.Serialization.JsonExtensionData>]
         AdditionalProperties : System.Collections.Generic.Dictionary<string, System.Text.Json.Nodes.JsonNode>
         [<System.Text.Json.Serialization.JsonPropertyName "commit_count">]
-        CommitCount : int option
+        CommitCount : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "content_base64">]
         ContentBase64 : string option
         [<System.Text.Json.Serialization.JsonPropertyName "footer">]
@@ -2200,13 +2200,13 @@ type Comment =
         [<System.Text.Json.Serialization.JsonPropertyName "html_url">]
         HtmlUrl : string option
         [<System.Text.Json.Serialization.JsonPropertyName "id">]
-        Id : int option
+        Id : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "issue_url">]
         IssueUrl : string option
         [<System.Text.Json.Serialization.JsonPropertyName "original_author">]
         OriginalAuthor : string option
         [<System.Text.Json.Serialization.JsonPropertyName "original_author_id">]
-        OriginalAuthorId : int option
+        OriginalAuthorId : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "pull_request_url">]
         PullRequestUrl : string option
         [<System.Text.Json.Serialization.JsonPropertyName "updated_at">]
@@ -2230,7 +2230,7 @@ type CommitStatus =
         [<System.Text.Json.Serialization.JsonPropertyName "description">]
         Description : string option
         [<System.Text.Json.Serialization.JsonPropertyName "id">]
-        Id : int option
+        Id : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "status">]
         Status : string option
         [<System.Text.Json.Serialization.JsonPropertyName "target_url">]
@@ -2268,7 +2268,7 @@ type ContentsResponse =
         [<System.Text.Json.Serialization.JsonPropertyName "sha">]
         Sha : string option
         [<System.Text.Json.Serialization.JsonPropertyName "size">]
-        Size : int option
+        Size : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "submodule_git_url">]
         SubmoduleGitUrl : string option
         [<System.Text.Json.Serialization.JsonPropertyName "target">]
@@ -2476,7 +2476,7 @@ type Milestone =
         [<System.Text.Json.Serialization.JsonPropertyName "closed_at">]
         ClosedAt : string option
         [<System.Text.Json.Serialization.JsonPropertyName "closed_issues">]
-        ClosedIssues : int option
+        ClosedIssues : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "created_at">]
         CreatedAt : string option
         [<System.Text.Json.Serialization.JsonPropertyName "description">]
@@ -2484,9 +2484,9 @@ type Milestone =
         [<System.Text.Json.Serialization.JsonPropertyName "due_on">]
         DueOn : string option
         [<System.Text.Json.Serialization.JsonPropertyName "id">]
-        Id : int option
+        Id : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "open_issues">]
-        OpenIssues : int option
+        OpenIssues : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "state">]
         State : string option
         [<System.Text.Json.Serialization.JsonPropertyName "title">]
@@ -2502,9 +2502,9 @@ type NodeInfoUsage =
         [<System.Text.Json.Serialization.JsonExtensionData>]
         AdditionalProperties : System.Collections.Generic.Dictionary<string, System.Text.Json.Nodes.JsonNode>
         [<System.Text.Json.Serialization.JsonPropertyName "localComments">]
-        LocalComments : int option
+        LocalComments : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "localPosts">]
-        LocalPosts : int option
+        LocalPosts : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "users">]
         Users : NodeInfoUsageUsers option
     }
@@ -2560,7 +2560,7 @@ type PublicKey =
         [<System.Text.Json.Serialization.JsonPropertyName "fingerprint">]
         Fingerprint : string option
         [<System.Text.Json.Serialization.JsonPropertyName "id">]
-        Id : int option
+        Id : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "key">]
         Key : string option
         [<System.Text.Json.Serialization.JsonPropertyName "key_type">]
@@ -2584,7 +2584,7 @@ type PullReview =
         [<System.Text.Json.Serialization.JsonPropertyName "body">]
         Body : string option
         [<System.Text.Json.Serialization.JsonPropertyName "comments_count">]
-        CommentsCount : int option
+        CommentsCount : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "commit_id">]
         CommitId : string option
         [<System.Text.Json.Serialization.JsonPropertyName "dismissed">]
@@ -2592,7 +2592,7 @@ type PullReview =
         [<System.Text.Json.Serialization.JsonPropertyName "html_url">]
         HtmlUrl : string option
         [<System.Text.Json.Serialization.JsonPropertyName "id">]
-        Id : int option
+        Id : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "official">]
         Official : bool option
         [<System.Text.Json.Serialization.JsonPropertyName "pull_request_url">]
@@ -2628,7 +2628,7 @@ type PullReviewComment =
         [<System.Text.Json.Serialization.JsonPropertyName "html_url">]
         HtmlUrl : string option
         [<System.Text.Json.Serialization.JsonPropertyName "id">]
-        Id : int option
+        Id : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "original_commit_id">]
         OriginalCommitId : string option
         [<System.Text.Json.Serialization.JsonPropertyName "original_position">]
@@ -2638,7 +2638,7 @@ type PullReviewComment =
         [<System.Text.Json.Serialization.JsonPropertyName "position">]
         Position : int option
         [<System.Text.Json.Serialization.JsonPropertyName "pull_request_review_id">]
-        PullRequestReviewId : int option
+        PullRequestReviewId : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "pull_request_url">]
         PullRequestUrl : string option
         [<System.Text.Json.Serialization.JsonPropertyName "resolver">]
@@ -2682,7 +2682,7 @@ type Release =
         [<System.Text.Json.Serialization.JsonPropertyName "html_url">]
         HtmlUrl : string option
         [<System.Text.Json.Serialization.JsonPropertyName "id">]
-        Id : int option
+        Id : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "name">]
         Name : string option
         [<System.Text.Json.Serialization.JsonPropertyName "prerelease">]
@@ -2792,7 +2792,7 @@ type Repository =
         [<System.Text.Json.Serialization.JsonPropertyName "fork">]
         Fork : bool option
         [<System.Text.Json.Serialization.JsonPropertyName "forks_count">]
-        ForksCount : int option
+        ForksCount : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "full_name">]
         FullName : string option
         [<System.Text.Json.Serialization.JsonPropertyName "has_issues">]
@@ -2806,7 +2806,7 @@ type Repository =
         [<System.Text.Json.Serialization.JsonPropertyName "html_url">]
         HtmlUrl : string option
         [<System.Text.Json.Serialization.JsonPropertyName "id">]
-        Id : int option
+        Id : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "ignore_whitespace_conflicts">]
         IgnoreWhitespaceConflicts : bool option
         [<System.Text.Json.Serialization.JsonPropertyName "internal">]
@@ -2828,9 +2828,9 @@ type Repository =
         [<System.Text.Json.Serialization.JsonPropertyName "name">]
         Name : string option
         [<System.Text.Json.Serialization.JsonPropertyName "open_issues_count">]
-        OpenIssuesCount : int option
+        OpenIssuesCount : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "open_pr_counter">]
-        OpenPrCounter : int option
+        OpenPrCounter : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "original_url">]
         OriginalUrl : string option
         [<System.Text.Json.Serialization.JsonPropertyName "owner">]
@@ -2842,21 +2842,21 @@ type Repository =
         [<System.Text.Json.Serialization.JsonPropertyName "private">]
         Private : bool option
         [<System.Text.Json.Serialization.JsonPropertyName "release_counter">]
-        ReleaseCounter : int option
+        ReleaseCounter : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "repo_transfer">]
         RepoTransfer : RepoTransfer option
         [<System.Text.Json.Serialization.JsonPropertyName "size">]
-        Size : int option
+        Size : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "ssh_url">]
         SshUrl : string option
         [<System.Text.Json.Serialization.JsonPropertyName "stars_count">]
-        StarsCount : int option
+        StarsCount : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "template">]
         Template : bool option
         [<System.Text.Json.Serialization.JsonPropertyName "updated_at">]
         UpdatedAt : string option
         [<System.Text.Json.Serialization.JsonPropertyName "watchers_count">]
-        WatchersCount : int option
+        WatchersCount : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "website">]
         Website : string option
     }
@@ -2912,7 +2912,7 @@ type CombinedStatus =
         [<System.Text.Json.Serialization.JsonPropertyName "statuses">]
         Statuses : CommitStatus list option
         [<System.Text.Json.Serialization.JsonPropertyName "total_count">]
-        TotalCount : int option
+        TotalCount : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "url">]
         Url : string option
     }
@@ -2956,11 +2956,11 @@ type DeployKey =
         [<System.Text.Json.Serialization.JsonPropertyName "fingerprint">]
         Fingerprint : string option
         [<System.Text.Json.Serialization.JsonPropertyName "id">]
-        Id : int option
+        Id : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "key">]
         Key : string option
         [<System.Text.Json.Serialization.JsonPropertyName "key_id">]
-        KeyId : int option
+        KeyId : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "read_only">]
         ReadOnly : bool option
         [<System.Text.Json.Serialization.JsonPropertyName "repository">]
@@ -3016,7 +3016,7 @@ type Issue =
         [<System.Text.Json.Serialization.JsonPropertyName "closed_at">]
         ClosedAt : string option
         [<System.Text.Json.Serialization.JsonPropertyName "comments">]
-        Comments : int option
+        Comments : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "created_at">]
         CreatedAt : string option
         [<System.Text.Json.Serialization.JsonPropertyName "due_date">]
@@ -3024,7 +3024,7 @@ type Issue =
         [<System.Text.Json.Serialization.JsonPropertyName "html_url">]
         HtmlUrl : string option
         [<System.Text.Json.Serialization.JsonPropertyName "id">]
-        Id : int option
+        Id : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "is_locked">]
         IsLocked : bool option
         [<System.Text.Json.Serialization.JsonPropertyName "labels">]
@@ -3032,11 +3032,11 @@ type Issue =
         [<System.Text.Json.Serialization.JsonPropertyName "milestone">]
         Milestone : Milestone option
         [<System.Text.Json.Serialization.JsonPropertyName "number">]
-        Number : int option
+        Number : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "original_author">]
         OriginalAuthor : string option
         [<System.Text.Json.Serialization.JsonPropertyName "original_author_id">]
-        OriginalAuthorId : int option
+        OriginalAuthorId : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "pull_request">]
         PullRequest : PullRequestMeta option
         [<System.Text.Json.Serialization.JsonPropertyName "ref">]
@@ -3096,7 +3096,7 @@ type NotificationThread =
         [<System.Text.Json.Serialization.JsonExtensionData>]
         AdditionalProperties : System.Collections.Generic.Dictionary<string, System.Text.Json.Nodes.JsonNode>
         [<System.Text.Json.Serialization.JsonPropertyName "id">]
-        Id : int option
+        Id : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "pinned">]
         Pinned : bool option
         [<System.Text.Json.Serialization.JsonPropertyName "repository">]
@@ -3124,7 +3124,7 @@ type PRBranchInfo =
         [<System.Text.Json.Serialization.JsonPropertyName "repo">]
         Repo : Repository option
         [<System.Text.Json.Serialization.JsonPropertyName "repo_id">]
-        RepoId : int option
+        RepoId : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "sha">]
         Sha : string option
     }
@@ -3140,7 +3140,7 @@ type Package =
         [<System.Text.Json.Serialization.JsonPropertyName "creator">]
         Creator : User option
         [<System.Text.Json.Serialization.JsonPropertyName "id">]
-        Id : int option
+        Id : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "name">]
         Name : string option
         [<System.Text.Json.Serialization.JsonPropertyName "owner">]
@@ -3200,7 +3200,7 @@ type PullRequest =
         [<System.Text.Json.Serialization.JsonPropertyName "closed_at">]
         ClosedAt : string option
         [<System.Text.Json.Serialization.JsonPropertyName "comments">]
-        Comments : int option
+        Comments : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "created_at">]
         CreatedAt : string option
         [<System.Text.Json.Serialization.JsonPropertyName "diff_url">]
@@ -3212,7 +3212,7 @@ type PullRequest =
         [<System.Text.Json.Serialization.JsonPropertyName "html_url">]
         HtmlUrl : string option
         [<System.Text.Json.Serialization.JsonPropertyName "id">]
-        Id : int option
+        Id : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "is_locked">]
         IsLocked : bool option
         [<System.Text.Json.Serialization.JsonPropertyName "labels">]
@@ -3232,7 +3232,7 @@ type PullRequest =
         [<System.Text.Json.Serialization.JsonPropertyName "milestone">]
         Milestone : Milestone option
         [<System.Text.Json.Serialization.JsonPropertyName "number">]
-        Number : int option
+        Number : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "patch_url">]
         PatchUrl : string option
         [<System.Text.Json.Serialization.JsonPropertyName "state">]
@@ -3256,15 +3256,15 @@ type TrackedTime =
         [<System.Text.Json.Serialization.JsonPropertyName "created">]
         Created : string option
         [<System.Text.Json.Serialization.JsonPropertyName "id">]
-        Id : int option
+        Id : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "issue">]
         Issue : Issue option
         [<System.Text.Json.Serialization.JsonPropertyName "issue_id">]
-        IssueId : int option
+        IssueId : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "time">]
-        Time : int option
+        Time : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "user_id">]
-        UserId : int option
+        UserId : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "user_name">]
         UserName : string option
     }
@@ -3286,7 +3286,7 @@ type Branch =
         [<System.Text.Json.Serialization.JsonPropertyName "protected">]
         Protected : bool option
         [<System.Text.Json.Serialization.JsonPropertyName "required_approvals">]
-        RequiredApprovals : int option
+        RequiredApprovals : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "status_check_contexts">]
         StatusCheckContexts : string list option
         [<System.Text.Json.Serialization.JsonPropertyName "user_can_merge">]
@@ -3314,7 +3314,7 @@ type TimelineComment =
         [<System.Text.Json.Serialization.JsonPropertyName "html_url">]
         HtmlUrl : string option
         [<System.Text.Json.Serialization.JsonPropertyName "id">]
-        Id : int option
+        Id : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "issue_url">]
         IssueUrl : string option
         [<System.Text.Json.Serialization.JsonPropertyName "label">]
@@ -3328,13 +3328,13 @@ type TimelineComment =
         [<System.Text.Json.Serialization.JsonPropertyName "old_milestone">]
         OldMilestone : Milestone option
         [<System.Text.Json.Serialization.JsonPropertyName "old_project_id">]
-        OldProjectId : int option
+        OldProjectId : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "old_ref">]
         OldRef : string option
         [<System.Text.Json.Serialization.JsonPropertyName "old_title">]
         OldTitle : string option
         [<System.Text.Json.Serialization.JsonPropertyName "project_id">]
-        ProjectId : int option
+        ProjectId : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "pull_request_url">]
         PullRequestUrl : string option
         [<System.Text.Json.Serialization.JsonPropertyName "ref_action">]
@@ -3350,7 +3350,7 @@ type TimelineComment =
         [<System.Text.Json.Serialization.JsonPropertyName "resolve_doer">]
         ResolveDoer : User option
         [<System.Text.Json.Serialization.JsonPropertyName "review_id">]
-        ReviewId : int option
+        ReviewId : int64 option
         [<System.Text.Json.Serialization.JsonPropertyName "tracked_time">]
         TrackedTime : TrackedTime option
         [<System.Text.Json.Serialization.JsonPropertyName "type">]
@@ -3365,7 +3365,7 @@ type TimelineComment =
 type LanguageStatistics =
     {
         [<System.Text.Json.Serialization.JsonExtensionData>]
-        AdditionalProperties : System.Collections.Generic.Dictionary<string, int>
+        AdditionalProperties : System.Collections.Generic.Dictionary<string, int64>
     }
 
 [<JsonParse true ; JsonSerialize true>]
@@ -3443,13 +3443,13 @@ type IGitea =
     [<RestEase.Get "admin/hooks/{id}">]
     [<RestEase.Header("Content-Type", "json")>]
     abstract AdminGetHook :
-        [<RestEase.Path "id">] id : int * ?ct : System.Threading.CancellationToken -> Hook System.Threading.Tasks.Task
+        [<RestEase.Path "id">] id : int64 * ?ct : System.Threading.CancellationToken -> Hook System.Threading.Tasks.Task
 
     /// Update a hook
     [<RestEase.Patch "admin/hooks/{id}">]
     [<RestEase.Header("Content-Type", "json")>]
     abstract AdminEditHook :
-        [<RestEase.Path "id">] id : int *
+        [<RestEase.Path "id">] id : int64 *
         [<RestEase.Body>] body : EditHookOption *
         ?ct : System.Threading.CancellationToken ->
             Hook System.Threading.Tasks.Task
@@ -3539,7 +3539,7 @@ type IGitea =
     [<RestEase.Header("Content-Type", "json")>]
     abstract AdminDeleteUserPublicKey :
         [<RestEase.Path "username">] username : string *
-        [<RestEase.Path "id">] id : int *
+        [<RestEase.Path "id">] id : int64 *
         ?ct : System.Threading.CancellationToken ->
             unit System.Threading.Tasks.Task
 
@@ -3565,7 +3565,7 @@ type IGitea =
     [<RestEase.Delete "amdin/hooks/{id}">]
     [<RestEase.Header("Content-Type", "json")>]
     abstract AdminDeleteHook :
-        [<RestEase.Path "id">] id : int * ?ct : System.Threading.CancellationToken -> unit System.Threading.Tasks.Task
+        [<RestEase.Path "id">] id : int64 * ?ct : System.Threading.CancellationToken -> unit System.Threading.Tasks.Task
 
     /// Render a markdown document as HTML
     [<RestEase.Post "markdown">]
@@ -3704,7 +3704,7 @@ type IGitea =
     [<RestEase.Header("Content-Type", "json")>]
     abstract OrgGetHook :
         [<RestEase.Path "org">] org : string *
-        [<RestEase.Path "id">] id : int *
+        [<RestEase.Path "id">] id : int64 *
         ?ct : System.Threading.CancellationToken ->
             Hook System.Threading.Tasks.Task
 
@@ -3713,7 +3713,7 @@ type IGitea =
     [<RestEase.Header("Content-Type", "json")>]
     abstract OrgDeleteHook :
         [<RestEase.Path "org">] org : string *
-        [<RestEase.Path "id">] id : int *
+        [<RestEase.Path "id">] id : int64 *
         ?ct : System.Threading.CancellationToken ->
             unit System.Threading.Tasks.Task
 
@@ -3722,7 +3722,7 @@ type IGitea =
     [<RestEase.Header("Content-Type", "json")>]
     abstract OrgEditHook :
         [<RestEase.Path "org">] org : string *
-        [<RestEase.Path "id">] id : int *
+        [<RestEase.Path "id">] id : int64 *
         [<RestEase.Body>] body : EditHookOption *
         ?ct : System.Threading.CancellationToken ->
             Hook System.Threading.Tasks.Task
@@ -3751,7 +3751,7 @@ type IGitea =
     [<RestEase.Header("Content-Type", "json")>]
     abstract OrgGetLabel :
         [<RestEase.Path "org">] org : string *
-        [<RestEase.Path "id">] id : int *
+        [<RestEase.Path "id">] id : int64 *
         ?ct : System.Threading.CancellationToken ->
             Label System.Threading.Tasks.Task
 
@@ -3760,7 +3760,7 @@ type IGitea =
     [<RestEase.Header("Content-Type", "json")>]
     abstract OrgDeleteLabel :
         [<RestEase.Path "org">] org : string *
-        [<RestEase.Path "id">] id : int *
+        [<RestEase.Path "id">] id : int64 *
         ?ct : System.Threading.CancellationToken ->
             unit System.Threading.Tasks.Task
 
@@ -3769,7 +3769,7 @@ type IGitea =
     [<RestEase.Header("Content-Type", "json")>]
     abstract OrgEditLabel :
         [<RestEase.Path "org">] org : string *
-        [<RestEase.Path "id">] id : int *
+        [<RestEase.Path "id">] id : int64 *
         [<RestEase.Body>] body : EditLabelOption *
         ?ct : System.Threading.CancellationToken ->
             Label System.Threading.Tasks.Task
@@ -3942,7 +3942,7 @@ type IGitea =
         [<RestEase.Query "labels">] labels : string *
         [<RestEase.Query "milestones">] milestones : string *
         [<RestEase.Query "q">] q : string *
-        [<RestEase.Query "priority_repo_id">] priority_repo_id : int *
+        [<RestEase.Query "priority_repo_id">] priority_repo_id : int64 *
         [<RestEase.Query "type">] type' : string *
         [<RestEase.Query "since">] since : string *
         [<RestEase.Query "before">] before : string *
@@ -3971,10 +3971,10 @@ type IGitea =
         [<RestEase.Query "q">] q : string *
         [<RestEase.Query "topic">] topic : bool *
         [<RestEase.Query "includeDesc">] includeDesc : bool *
-        [<RestEase.Query "uid">] uid : int *
-        [<RestEase.Query "priority_owner_id">] priority_owner_id : int *
-        [<RestEase.Query "team_id">] team_id : int *
-        [<RestEase.Query "starredBy">] starredBy : int *
+        [<RestEase.Query "uid">] uid : int64 *
+        [<RestEase.Query "priority_owner_id">] priority_owner_id : int64 *
+        [<RestEase.Query "team_id">] team_id : int64 *
+        [<RestEase.Query "starredBy">] starredBy : int64 *
         [<RestEase.Query "private">] private' : bool *
         [<RestEase.Query "is_private">] is_private : bool *
         [<RestEase.Query "template">] template : bool *
@@ -4464,7 +4464,7 @@ type IGitea =
     abstract RepoGetHook :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "id">] id : int *
+        [<RestEase.Path "id">] id : int64 *
         ?ct : System.Threading.CancellationToken ->
             Hook System.Threading.Tasks.Task
 
@@ -4474,7 +4474,7 @@ type IGitea =
     abstract RepoDeleteHook :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "id">] id : int *
+        [<RestEase.Path "id">] id : int64 *
         ?ct : System.Threading.CancellationToken ->
             unit System.Threading.Tasks.Task
 
@@ -4484,7 +4484,7 @@ type IGitea =
     abstract RepoEditHook :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "id">] id : int *
+        [<RestEase.Path "id">] id : int64 *
         [<RestEase.Body>] body : EditHookOption *
         ?ct : System.Threading.CancellationToken ->
             Hook System.Threading.Tasks.Task
@@ -4495,7 +4495,7 @@ type IGitea =
     abstract RepoTestHook :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "id">] id : int *
+        [<RestEase.Path "id">] id : int64 *
         [<RestEase.Query "ref">] ref : string *
         ?ct : System.Threading.CancellationToken ->
             unit System.Threading.Tasks.Task
@@ -4559,7 +4559,7 @@ type IGitea =
     abstract IssueDeleteComment :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "id">] id : int *
+        [<RestEase.Path "id">] id : int64 *
         ?ct : System.Threading.CancellationToken ->
             unit System.Threading.Tasks.Task
 
@@ -4569,7 +4569,7 @@ type IGitea =
     abstract IssueListIssueCommentAttachments :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "id">] id : int *
+        [<RestEase.Path "id">] id : int64 *
         ?ct : System.Threading.CancellationToken ->
             Attachment list System.Threading.Tasks.Task
 
@@ -4579,8 +4579,8 @@ type IGitea =
     abstract IssueGetIssueCommentAttachment :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "id">] id : int *
-        [<RestEase.Path "attachment_id">] attachment_id : int *
+        [<RestEase.Path "id">] id : int64 *
+        [<RestEase.Path "attachment_id">] attachment_id : int64 *
         ?ct : System.Threading.CancellationToken ->
             Attachment System.Threading.Tasks.Task
 
@@ -4590,8 +4590,8 @@ type IGitea =
     abstract IssueDeleteIssueCommentAttachment :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "id">] id : int *
-        [<RestEase.Path "attachment_id">] attachment_id : int *
+        [<RestEase.Path "id">] id : int64 *
+        [<RestEase.Path "attachment_id">] attachment_id : int64 *
         ?ct : System.Threading.CancellationToken ->
             unit System.Threading.Tasks.Task
 
@@ -4601,8 +4601,8 @@ type IGitea =
     abstract IssueEditIssueCommentAttachment :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "id">] id : int *
-        [<RestEase.Path "attachment_id">] attachment_id : int *
+        [<RestEase.Path "id">] id : int64 *
+        [<RestEase.Path "attachment_id">] attachment_id : int64 *
         [<RestEase.Body>] body : EditAttachmentOptions *
         ?ct : System.Threading.CancellationToken ->
             Attachment System.Threading.Tasks.Task
@@ -4613,7 +4613,7 @@ type IGitea =
     abstract IssueGetCommentReactions :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "id">] id : int *
+        [<RestEase.Path "id">] id : int64 *
         ?ct : System.Threading.CancellationToken ->
             Reaction list System.Threading.Tasks.Task
 
@@ -4623,7 +4623,7 @@ type IGitea =
     abstract IssueDeleteCommentReaction :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "id">] id : int *
+        [<RestEase.Path "id">] id : int64 *
         [<RestEase.Body>] content : EditReactionOption *
         ?ct : System.Threading.CancellationToken ->
             unit System.Threading.Tasks.Task
@@ -4634,7 +4634,7 @@ type IGitea =
     abstract IssueGetIssue :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
+        [<RestEase.Path "index">] index : int64 *
         ?ct : System.Threading.CancellationToken ->
             Issue System.Threading.Tasks.Task
 
@@ -4644,7 +4644,7 @@ type IGitea =
     abstract IssueDelete :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
+        [<RestEase.Path "index">] index : int64 *
         ?ct : System.Threading.CancellationToken ->
             unit System.Threading.Tasks.Task
 
@@ -4654,7 +4654,7 @@ type IGitea =
     abstract IssueEditIssue :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
+        [<RestEase.Path "index">] index : int64 *
         [<RestEase.Body>] body : EditIssueOption *
         ?ct : System.Threading.CancellationToken ->
             Issue System.Threading.Tasks.Task
@@ -4665,7 +4665,7 @@ type IGitea =
     abstract IssueListIssueAttachments :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
+        [<RestEase.Path "index">] index : int64 *
         ?ct : System.Threading.CancellationToken ->
             Attachment list System.Threading.Tasks.Task
 
@@ -4675,8 +4675,8 @@ type IGitea =
     abstract IssueGetIssueAttachment :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
-        [<RestEase.Path "attachment_id">] attachment_id : int *
+        [<RestEase.Path "index">] index : int64 *
+        [<RestEase.Path "attachment_id">] attachment_id : int64 *
         ?ct : System.Threading.CancellationToken ->
             Attachment System.Threading.Tasks.Task
 
@@ -4686,8 +4686,8 @@ type IGitea =
     abstract IssueDeleteIssueAttachment :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
-        [<RestEase.Path "attachment_id">] attachment_id : int *
+        [<RestEase.Path "index">] index : int64 *
+        [<RestEase.Path "attachment_id">] attachment_id : int64 *
         ?ct : System.Threading.CancellationToken ->
             unit System.Threading.Tasks.Task
 
@@ -4697,8 +4697,8 @@ type IGitea =
     abstract IssueEditIssueAttachment :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
-        [<RestEase.Path "attachment_id">] attachment_id : int *
+        [<RestEase.Path "index">] index : int64 *
+        [<RestEase.Path "attachment_id">] attachment_id : int64 *
         [<RestEase.Body>] body : EditAttachmentOptions *
         ?ct : System.Threading.CancellationToken ->
             Attachment System.Threading.Tasks.Task
@@ -4709,7 +4709,7 @@ type IGitea =
     abstract IssueGetComments :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
+        [<RestEase.Path "index">] index : int64 *
         [<RestEase.Query "since">] since : string *
         [<RestEase.Query "before">] before : string *
         ?ct : System.Threading.CancellationToken ->
@@ -4721,7 +4721,7 @@ type IGitea =
     abstract IssueCreateComment :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
+        [<RestEase.Path "index">] index : int64 *
         [<RestEase.Body>] body : CreateIssueCommentOption *
         ?ct : System.Threading.CancellationToken ->
             Comment System.Threading.Tasks.Task
@@ -4733,7 +4733,7 @@ type IGitea =
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
         [<RestEase.Path "index">] index : int *
-        [<RestEase.Path "id">] id : int *
+        [<RestEase.Path "id">] id : int64 *
         ?ct : System.Threading.CancellationToken ->
             unit System.Threading.Tasks.Task
 
@@ -4743,7 +4743,7 @@ type IGitea =
     abstract IssueEditIssueDeadline :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
+        [<RestEase.Path "index">] index : int64 *
         [<RestEase.Body>] body : EditDeadlineOption *
         ?ct : System.Threading.CancellationToken ->
             IssueDeadline System.Threading.Tasks.Task
@@ -4754,7 +4754,7 @@ type IGitea =
     abstract IssueGetLabels :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
+        [<RestEase.Path "index">] index : int64 *
         ?ct : System.Threading.CancellationToken ->
             Label list System.Threading.Tasks.Task
 
@@ -4764,7 +4764,7 @@ type IGitea =
     abstract IssueAddLabel :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
+        [<RestEase.Path "index">] index : int64 *
         [<RestEase.Body>] body : IssueLabelsOption *
         ?ct : System.Threading.CancellationToken ->
             Label list System.Threading.Tasks.Task
@@ -4775,7 +4775,7 @@ type IGitea =
     abstract IssueClearLabels :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
+        [<RestEase.Path "index">] index : int64 *
         ?ct : System.Threading.CancellationToken ->
             unit System.Threading.Tasks.Task
 
@@ -4785,7 +4785,7 @@ type IGitea =
     abstract IssueReplaceLabels :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
+        [<RestEase.Path "index">] index : int64 *
         [<RestEase.Body>] body : IssueLabelsOption *
         ?ct : System.Threading.CancellationToken ->
             Label list System.Threading.Tasks.Task
@@ -4796,8 +4796,8 @@ type IGitea =
     abstract IssueRemoveLabel :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
-        [<RestEase.Path "id">] id : int *
+        [<RestEase.Path "index">] index : int64 *
+        [<RestEase.Path "id">] id : int64 *
         ?ct : System.Threading.CancellationToken ->
             unit System.Threading.Tasks.Task
 
@@ -4807,7 +4807,7 @@ type IGitea =
     abstract IssueGetIssueReactions :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
+        [<RestEase.Path "index">] index : int64 *
         [<RestEase.Query "page">] page : int *
         [<RestEase.Query "limit">] limit : int *
         ?ct : System.Threading.CancellationToken ->
@@ -4819,7 +4819,7 @@ type IGitea =
     abstract IssueDeleteIssueReaction :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
+        [<RestEase.Path "index">] index : int64 *
         [<RestEase.Body>] content : EditReactionOption *
         ?ct : System.Threading.CancellationToken ->
             unit System.Threading.Tasks.Task
@@ -4830,7 +4830,7 @@ type IGitea =
     abstract IssueDeleteStopWatch :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
+        [<RestEase.Path "index">] index : int64 *
         ?ct : System.Threading.CancellationToken ->
             unit System.Threading.Tasks.Task
 
@@ -4840,7 +4840,7 @@ type IGitea =
     abstract IssueStartStopWatch :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
+        [<RestEase.Path "index">] index : int64 *
         ?ct : System.Threading.CancellationToken ->
             unit System.Threading.Tasks.Task
 
@@ -4850,7 +4850,7 @@ type IGitea =
     abstract IssueStopStopWatch :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
+        [<RestEase.Path "index">] index : int64 *
         ?ct : System.Threading.CancellationToken ->
             unit System.Threading.Tasks.Task
 
@@ -4860,7 +4860,7 @@ type IGitea =
     abstract IssueSubscriptions :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
+        [<RestEase.Path "index">] index : int64 *
         [<RestEase.Query "page">] page : int *
         [<RestEase.Query "limit">] limit : int *
         ?ct : System.Threading.CancellationToken ->
@@ -4872,7 +4872,7 @@ type IGitea =
     abstract IssueCheckSubscription :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
+        [<RestEase.Path "index">] index : int64 *
         ?ct : System.Threading.CancellationToken ->
             WatchInfo System.Threading.Tasks.Task
 
@@ -4882,7 +4882,7 @@ type IGitea =
     abstract IssueGetCommentsAndTimeline :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
+        [<RestEase.Path "index">] index : int64 *
         [<RestEase.Query "since">] since : string *
         [<RestEase.Query "page">] page : int *
         [<RestEase.Query "limit">] limit : int *
@@ -4896,7 +4896,7 @@ type IGitea =
     abstract IssueTrackedTimes :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
+        [<RestEase.Path "index">] index : int64 *
         [<RestEase.Query "user">] user : string *
         [<RestEase.Query "since">] since : string *
         [<RestEase.Query "before">] before : string *
@@ -4911,7 +4911,7 @@ type IGitea =
     abstract IssueAddTime :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
+        [<RestEase.Path "index">] index : int64 *
         [<RestEase.Body>] body : AddTimeOption *
         ?ct : System.Threading.CancellationToken ->
             TrackedTime System.Threading.Tasks.Task
@@ -4922,7 +4922,7 @@ type IGitea =
     abstract IssueResetTime :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
+        [<RestEase.Path "index">] index : int64 *
         ?ct : System.Threading.CancellationToken ->
             unit System.Threading.Tasks.Task
 
@@ -4932,8 +4932,8 @@ type IGitea =
     abstract IssueDeleteTime :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
-        [<RestEase.Path "id">] id : int *
+        [<RestEase.Path "index">] index : int64 *
+        [<RestEase.Path "id">] id : int64 *
         ?ct : System.Threading.CancellationToken ->
             unit System.Threading.Tasks.Task
 
@@ -4966,7 +4966,7 @@ type IGitea =
     abstract RepoGetKey :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "id">] id : int *
+        [<RestEase.Path "id">] id : int64 *
         ?ct : System.Threading.CancellationToken ->
             DeployKey System.Threading.Tasks.Task
 
@@ -4976,7 +4976,7 @@ type IGitea =
     abstract RepoDeleteKey :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "id">] id : int *
+        [<RestEase.Path "id">] id : int64 *
         ?ct : System.Threading.CancellationToken ->
             unit System.Threading.Tasks.Task
 
@@ -5007,7 +5007,7 @@ type IGitea =
     abstract IssueGetLabel :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "id">] id : int *
+        [<RestEase.Path "id">] id : int64 *
         ?ct : System.Threading.CancellationToken ->
             Label System.Threading.Tasks.Task
 
@@ -5017,7 +5017,7 @@ type IGitea =
     abstract IssueDeleteLabel :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "id">] id : int *
+        [<RestEase.Path "id">] id : int64 *
         ?ct : System.Threading.CancellationToken ->
             unit System.Threading.Tasks.Task
 
@@ -5027,7 +5027,7 @@ type IGitea =
     abstract IssueEditLabel :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "id">] id : int *
+        [<RestEase.Path "id">] id : int64 *
         [<RestEase.Body>] body : EditLabelOption *
         ?ct : System.Threading.CancellationToken ->
             Label System.Threading.Tasks.Task
@@ -5152,8 +5152,8 @@ type IGitea =
         [<RestEase.Path "repo">] repo : string *
         [<RestEase.Query "state">] state : string *
         [<RestEase.Query "sort">] sort : string *
-        [<RestEase.Query "milestone">] milestone : int *
-        [<RestEase.Query "labels">] labels : int list *
+        [<RestEase.Query "milestone">] milestone : int64 *
+        [<RestEase.Query "labels">] labels : int64 list *
         [<RestEase.Query "page">] page : int *
         [<RestEase.Query "limit">] limit : int *
         ?ct : System.Threading.CancellationToken ->
@@ -5175,7 +5175,7 @@ type IGitea =
     abstract RepoGetPullRequest :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
+        [<RestEase.Path "index">] index : int64 *
         ?ct : System.Threading.CancellationToken ->
             PullRequest System.Threading.Tasks.Task
 
@@ -5185,7 +5185,7 @@ type IGitea =
     abstract RepoEditPullRequest :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
+        [<RestEase.Path "index">] index : int64 *
         [<RestEase.Body>] body : EditPullRequestOption *
         ?ct : System.Threading.CancellationToken ->
             PullRequest System.Threading.Tasks.Task
@@ -5196,7 +5196,7 @@ type IGitea =
     abstract RepoDownloadPullDiffOrPatch :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
+        [<RestEase.Path "index">] index : int64 *
         [<RestEase.Path "diffType">] diffType : string *
         [<RestEase.Query "binary">] binary : bool *
         ?ct : System.Threading.CancellationToken ->
@@ -5208,7 +5208,7 @@ type IGitea =
     abstract RepoGetPullRequestCommits :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
+        [<RestEase.Path "index">] index : int64 *
         [<RestEase.Query "page">] page : int *
         [<RestEase.Query "limit">] limit : int *
         ?ct : System.Threading.CancellationToken ->
@@ -5220,7 +5220,7 @@ type IGitea =
     abstract RepoGetPullRequestFiles :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
+        [<RestEase.Path "index">] index : int64 *
         [<RestEase.Query "skip-to">] skip_to : string *
         [<RestEase.Query "whitespace">] whitespace : string *
         [<RestEase.Query "page">] page : int *
@@ -5234,7 +5234,7 @@ type IGitea =
     abstract RepoPullRequestIsMerged :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
+        [<RestEase.Path "index">] index : int64 *
         ?ct : System.Threading.CancellationToken ->
             unit System.Threading.Tasks.Task
 
@@ -5244,7 +5244,7 @@ type IGitea =
     abstract RepoMergePullRequest :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
+        [<RestEase.Path "index">] index : int64 *
         [<RestEase.Body>] body : MergePullRequestOption *
         ?ct : System.Threading.CancellationToken ->
             unit System.Threading.Tasks.Task
@@ -5255,7 +5255,7 @@ type IGitea =
     abstract RepoCancelScheduledAutoMerge :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
+        [<RestEase.Path "index">] index : int64 *
         ?ct : System.Threading.CancellationToken ->
             unit System.Threading.Tasks.Task
 
@@ -5265,7 +5265,7 @@ type IGitea =
     abstract RepoCreatePullReviewRequests :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
+        [<RestEase.Path "index">] index : int64 *
         [<RestEase.Body>] body : PullReviewRequestOptions *
         ?ct : System.Threading.CancellationToken ->
             PullReview list System.Threading.Tasks.Task
@@ -5276,7 +5276,7 @@ type IGitea =
     abstract RepoDeletePullReviewRequests :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
+        [<RestEase.Path "index">] index : int64 *
         [<RestEase.Body>] body : PullReviewRequestOptions *
         ?ct : System.Threading.CancellationToken ->
             unit System.Threading.Tasks.Task
@@ -5287,7 +5287,7 @@ type IGitea =
     abstract RepoListPullReviews :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
+        [<RestEase.Path "index">] index : int64 *
         [<RestEase.Query "page">] page : int *
         [<RestEase.Query "limit">] limit : int *
         ?ct : System.Threading.CancellationToken ->
@@ -5299,7 +5299,7 @@ type IGitea =
     abstract RepoCreatePullReview :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
+        [<RestEase.Path "index">] index : int64 *
         [<RestEase.Body>] body : CreatePullReviewOptions *
         ?ct : System.Threading.CancellationToken ->
             PullReview System.Threading.Tasks.Task
@@ -5310,8 +5310,8 @@ type IGitea =
     abstract RepoGetPullReview :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
-        [<RestEase.Path "id">] id : int *
+        [<RestEase.Path "index">] index : int64 *
+        [<RestEase.Path "id">] id : int64 *
         ?ct : System.Threading.CancellationToken ->
             PullReview System.Threading.Tasks.Task
 
@@ -5321,8 +5321,8 @@ type IGitea =
     abstract RepoSubmitPullReview :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
-        [<RestEase.Path "id">] id : int *
+        [<RestEase.Path "index">] index : int64 *
+        [<RestEase.Path "id">] id : int64 *
         [<RestEase.Body>] body : SubmitPullReviewOptions *
         ?ct : System.Threading.CancellationToken ->
             PullReview System.Threading.Tasks.Task
@@ -5333,8 +5333,8 @@ type IGitea =
     abstract RepoDeletePullReview :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
-        [<RestEase.Path "id">] id : int *
+        [<RestEase.Path "index">] index : int64 *
+        [<RestEase.Path "id">] id : int64 *
         ?ct : System.Threading.CancellationToken ->
             unit System.Threading.Tasks.Task
 
@@ -5344,8 +5344,8 @@ type IGitea =
     abstract RepoGetPullReviewComments :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
-        [<RestEase.Path "id">] id : int *
+        [<RestEase.Path "index">] index : int64 *
+        [<RestEase.Path "id">] id : int64 *
         ?ct : System.Threading.CancellationToken ->
             PullReviewComment list System.Threading.Tasks.Task
 
@@ -5355,8 +5355,8 @@ type IGitea =
     abstract RepoDismissPullReview :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
-        [<RestEase.Path "id">] id : int *
+        [<RestEase.Path "index">] index : int64 *
+        [<RestEase.Path "id">] id : int64 *
         [<RestEase.Body>] body : DismissPullReviewOptions *
         ?ct : System.Threading.CancellationToken ->
             PullReview System.Threading.Tasks.Task
@@ -5367,8 +5367,8 @@ type IGitea =
     abstract RepoUnDismissPullReview :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
-        [<RestEase.Path "id">] id : int *
+        [<RestEase.Path "index">] index : int64 *
+        [<RestEase.Path "id">] id : int64 *
         ?ct : System.Threading.CancellationToken ->
             PullReview System.Threading.Tasks.Task
 
@@ -5378,7 +5378,7 @@ type IGitea =
     abstract RepoUpdatePullRequest :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "index">] index : int *
+        [<RestEase.Path "index">] index : int64 *
         [<RestEase.Query "style">] style : string *
         ?ct : System.Threading.CancellationToken ->
             unit System.Threading.Tasks.Task
@@ -5503,7 +5503,7 @@ type IGitea =
     abstract RepoGetRelease :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "id">] id : int *
+        [<RestEase.Path "id">] id : int64 *
         ?ct : System.Threading.CancellationToken ->
             Release System.Threading.Tasks.Task
 
@@ -5513,7 +5513,7 @@ type IGitea =
     abstract RepoDeleteRelease :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "id">] id : int *
+        [<RestEase.Path "id">] id : int64 *
         ?ct : System.Threading.CancellationToken ->
             unit System.Threading.Tasks.Task
 
@@ -5523,7 +5523,7 @@ type IGitea =
     abstract RepoEditRelease :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "id">] id : int *
+        [<RestEase.Path "id">] id : int64 *
         [<RestEase.Body>] body : EditReleaseOption *
         ?ct : System.Threading.CancellationToken ->
             Release System.Threading.Tasks.Task
@@ -5534,7 +5534,7 @@ type IGitea =
     abstract RepoListReleaseAttachments :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "id">] id : int *
+        [<RestEase.Path "id">] id : int64 *
         ?ct : System.Threading.CancellationToken ->
             Attachment list System.Threading.Tasks.Task
 
@@ -5544,8 +5544,8 @@ type IGitea =
     abstract RepoGetReleaseAttachment :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "id">] id : int *
-        [<RestEase.Path "attachment_id">] attachment_id : int *
+        [<RestEase.Path "id">] id : int64 *
+        [<RestEase.Path "attachment_id">] attachment_id : int64 *
         ?ct : System.Threading.CancellationToken ->
             Attachment System.Threading.Tasks.Task
 
@@ -5555,8 +5555,8 @@ type IGitea =
     abstract RepoDeleteReleaseAttachment :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "id">] id : int *
-        [<RestEase.Path "attachment_id">] attachment_id : int *
+        [<RestEase.Path "id">] id : int64 *
+        [<RestEase.Path "attachment_id">] attachment_id : int64 *
         ?ct : System.Threading.CancellationToken ->
             unit System.Threading.Tasks.Task
 
@@ -5566,8 +5566,8 @@ type IGitea =
     abstract RepoEditReleaseAttachment :
         [<RestEase.Path "owner">] owner : string *
         [<RestEase.Path "repo">] repo : string *
-        [<RestEase.Path "id">] id : int *
-        [<RestEase.Path "attachment_id">] attachment_id : int *
+        [<RestEase.Path "id">] id : int64 *
+        [<RestEase.Path "attachment_id">] attachment_id : int64 *
         [<RestEase.Body>] body : EditAttachmentOptions *
         ?ct : System.Threading.CancellationToken ->
             Attachment System.Threading.Tasks.Task
@@ -5914,7 +5914,7 @@ type IGitea =
     [<RestEase.Get "repositories/{id}">]
     [<RestEase.Header("Content-Type", "json")>]
     abstract RepoGetByID :
-        [<RestEase.Path "id">] id : int * ?ct : System.Threading.CancellationToken ->
+        [<RestEase.Path "id">] id : int64 * ?ct : System.Threading.CancellationToken ->
             Repository System.Threading.Tasks.Task
 
     /// Get instance's global settings for api
@@ -5950,13 +5950,13 @@ type IGitea =
     [<RestEase.Get "teams/{id}">]
     [<RestEase.Header("Content-Type", "json")>]
     abstract OrgGetTeam :
-        [<RestEase.Path "id">] id : int * ?ct : System.Threading.CancellationToken -> Team System.Threading.Tasks.Task
+        [<RestEase.Path "id">] id : int64 * ?ct : System.Threading.CancellationToken -> Team System.Threading.Tasks.Task
 
     /// Delete a team
     [<RestEase.Delete "teams/{id}">]
     [<RestEase.Header("Content-Type", "json")>]
     abstract OrgDeleteTeam :
-        [<RestEase.Path "id">] id : int * ?ct : System.Threading.CancellationToken -> unit System.Threading.Tasks.Task
+        [<RestEase.Path "id">] id : int64 * ?ct : System.Threading.CancellationToken -> unit System.Threading.Tasks.Task
 
     /// Edit a team
     [<RestEase.Patch "teams/{id}">]
@@ -5971,7 +5971,7 @@ type IGitea =
     [<RestEase.Get "teams/{id}/members">]
     [<RestEase.Header("Content-Type", "json")>]
     abstract OrgListTeamMembers :
-        [<RestEase.Path "id">] id : int *
+        [<RestEase.Path "id">] id : int64 *
         [<RestEase.Query "page">] page : int *
         [<RestEase.Query "limit">] limit : int *
         ?ct : System.Threading.CancellationToken ->
@@ -5981,7 +5981,7 @@ type IGitea =
     [<RestEase.Get "teams/{id}/members/{username}">]
     [<RestEase.Header("Content-Type", "json")>]
     abstract OrgListTeamMember :
-        [<RestEase.Path "id">] id : int *
+        [<RestEase.Path "id">] id : int64 *
         [<RestEase.Path "username">] username : string *
         ?ct : System.Threading.CancellationToken ->
             User System.Threading.Tasks.Task
@@ -5990,7 +5990,7 @@ type IGitea =
     [<RestEase.Delete "teams/{id}/members/{username}">]
     [<RestEase.Header("Content-Type", "json")>]
     abstract OrgRemoveTeamMember :
-        [<RestEase.Path "id">] id : int *
+        [<RestEase.Path "id">] id : int64 *
         [<RestEase.Path "username">] username : string *
         ?ct : System.Threading.CancellationToken ->
             unit System.Threading.Tasks.Task
@@ -5999,7 +5999,7 @@ type IGitea =
     [<RestEase.Put "teams/{id}/members/{username}">]
     [<RestEase.Header("Content-Type", "json")>]
     abstract OrgAddTeamMember :
-        [<RestEase.Path "id">] id : int *
+        [<RestEase.Path "id">] id : int64 *
         [<RestEase.Path "username">] username : string *
         ?ct : System.Threading.CancellationToken ->
             unit System.Threading.Tasks.Task
@@ -6008,7 +6008,7 @@ type IGitea =
     [<RestEase.Get "teams/{id}/repos">]
     [<RestEase.Header("Content-Type", "json")>]
     abstract OrgListTeamRepos :
-        [<RestEase.Path "id">] id : int *
+        [<RestEase.Path "id">] id : int64 *
         [<RestEase.Query "page">] page : int *
         [<RestEase.Query "limit">] limit : int *
         ?ct : System.Threading.CancellationToken ->
@@ -6018,7 +6018,7 @@ type IGitea =
     [<RestEase.Get "teams/{id}/repos/{org}/{repo}">]
     [<RestEase.Header("Content-Type", "json")>]
     abstract OrgListTeamRepo :
-        [<RestEase.Path "id">] id : int *
+        [<RestEase.Path "id">] id : int64 *
         [<RestEase.Path "org">] org : string *
         [<RestEase.Path "repo">] repo : string *
         ?ct : System.Threading.CancellationToken ->
@@ -6028,7 +6028,7 @@ type IGitea =
     [<RestEase.Delete "teams/{id}/repos/{org}/{repo}">]
     [<RestEase.Header("Content-Type", "json")>]
     abstract OrgRemoveTeamRepository :
-        [<RestEase.Path "id">] id : int *
+        [<RestEase.Path "id">] id : int64 *
         [<RestEase.Path "org">] org : string *
         [<RestEase.Path "repo">] repo : string *
         ?ct : System.Threading.CancellationToken ->
@@ -6038,7 +6038,7 @@ type IGitea =
     [<RestEase.Put "teams/{id}/repos/{org}/{repo}">]
     [<RestEase.Header("Content-Type", "json")>]
     abstract OrgAddTeamRepository :
-        [<RestEase.Path "id">] id : int *
+        [<RestEase.Path "id">] id : int64 *
         [<RestEase.Path "org">] org : string *
         [<RestEase.Path "repo">] repo : string *
         ?ct : System.Threading.CancellationToken ->
@@ -6079,20 +6079,20 @@ type IGitea =
     [<RestEase.Get "user/applications/oauth2/{id}">]
     [<RestEase.Header("Content-Type", "json")>]
     abstract UserGetOAuth2Application :
-        [<RestEase.Path "id">] id : int * ?ct : System.Threading.CancellationToken ->
+        [<RestEase.Path "id">] id : int64 * ?ct : System.Threading.CancellationToken ->
             OAuth2Application System.Threading.Tasks.Task
 
     /// delete an OAuth2 Application
     [<RestEase.Delete "user/applications/oauth2/{id}">]
     [<RestEase.Header("Content-Type", "json")>]
     abstract UserDeleteOAuth2Application :
-        [<RestEase.Path "id">] id : int * ?ct : System.Threading.CancellationToken -> unit System.Threading.Tasks.Task
+        [<RestEase.Path "id">] id : int64 * ?ct : System.Threading.CancellationToken -> unit System.Threading.Tasks.Task
 
     /// update an OAuth2 Application, this includes regenerating the client secret
     [<RestEase.Patch "user/applications/oauth2/{id}">]
     [<RestEase.Header("Content-Type", "json")>]
     abstract UserUpdateOAuth2Application :
-        [<RestEase.Path "id">] id : int *
+        [<RestEase.Path "id">] id : int64 *
         [<RestEase.Body>] body : CreateOAuth2ApplicationOptions *
         ?ct : System.Threading.CancellationToken ->
             OAuth2Application System.Threading.Tasks.Task
@@ -6164,7 +6164,7 @@ type IGitea =
     [<RestEase.Delete "user/gpg_keys/{id}">]
     [<RestEase.Header("Content-Type", "json")>]
     abstract UserCurrentDeleteGPGKey :
-        [<RestEase.Path "id">] id : int * ?ct : System.Threading.CancellationToken -> unit System.Threading.Tasks.Task
+        [<RestEase.Path "id">] id : int64 * ?ct : System.Threading.CancellationToken -> unit System.Threading.Tasks.Task
 
     /// List the authenticated user's public keys
     [<RestEase.Get "user/keys">]
@@ -6187,14 +6187,14 @@ type IGitea =
     [<RestEase.Get "user/keys/{id}">]
     [<RestEase.Header("Content-Type", "json")>]
     abstract UserCurrentGetKey :
-        [<RestEase.Path "id">] id : int * ?ct : System.Threading.CancellationToken ->
+        [<RestEase.Path "id">] id : int64 * ?ct : System.Threading.CancellationToken ->
             PublicKey System.Threading.Tasks.Task
 
     /// Delete a public key
     [<RestEase.Delete "user/keys/{id}">]
     [<RestEase.Header("Content-Type", "json")>]
     abstract UserCurrentDeleteKey :
-        [<RestEase.Path "id">] id : int * ?ct : System.Threading.CancellationToken -> unit System.Threading.Tasks.Task
+        [<RestEase.Path "id">] id : int64 * ?ct : System.Threading.CancellationToken -> unit System.Threading.Tasks.Task
 
     /// List the current user's organizations
     [<RestEase.Get "user/orgs">]
@@ -6312,7 +6312,7 @@ type IGitea =
     [<RestEase.Header("Content-Type", "json")>]
     abstract UserSearch :
         [<RestEase.Query "q">] q : string *
-        [<RestEase.Query "uid">] uid : int *
+        [<RestEase.Query "uid">] uid : int64 *
         [<RestEase.Query "page">] page : int *
         [<RestEase.Query "limit">] limit : int *
         ?ct : System.Threading.CancellationToken ->

--- a/WoofWare.Myriad.Plugins.Test/TestSwagger/TestSwaggerTypeRender.fs
+++ b/WoofWare.Myriad.Plugins.Test/TestSwagger/TestSwaggerTypeRender.fs
@@ -23,7 +23,7 @@ module TestSwaggerTypeRender =
     let ``defnToType respects integer formats`` (format : string option, expected : string) : unit =
         let result =
             SwaggerClientGenerator.defnToType
-                (ref 0)
+                (fun () -> failwith "no anonymous types expected")
                 (Dictionary ())
                 (Dictionary ())
                 "definitions"

--- a/WoofWare.Myriad.Plugins.Test/TestSwagger/TestSwaggerTypeRender.fs
+++ b/WoofWare.Myriad.Plugins.Test/TestSwagger/TestSwaggerTypeRender.fs
@@ -1,0 +1,47 @@
+namespace WoofWare.Myriad.Plugins.Test
+
+open System.Collections.Generic
+open Fantomas.FCS.Syntax
+open NUnit.Framework
+open FsUnitTyped
+open WoofWare.Myriad.Plugins
+open WoofWare.Myriad.Plugins.SwaggerV2
+
+[<TestFixture>]
+module TestSwaggerTypeRender =
+
+    let private nameOfSynType (ty : SynType) : string =
+        match ty with
+        | SynType.LongIdent (SynLongIdent (idents, _, _)) -> idents |> List.map _.idText |> String.concat "."
+        | ty -> failwith $"unexpectedly got a non-LongIdent SynType: %+A{ty}"
+
+    let integerCases =
+        [ None, "int" ; Some "int32", "int" ; Some "int64", "int64" ]
+        |> List.map TestCaseData
+
+    [<TestCaseSource(nameof integerCases)>]
+    let ``defnToType respects integer formats`` (format : string option, expected : string) : unit =
+        let result =
+            SwaggerClientGenerator.defnToType
+                (ref 0)
+                (Dictionary ())
+                (Dictionary ())
+                "definitions"
+                None
+                (Definition.Integer format)
+
+        match result with
+        | None -> failwith "expected a type"
+        | Some entry -> nameOfSynType entry.Signature |> shouldEqual expected
+
+    [<TestCaseSource(nameof integerCases)>]
+    let ``renderType respects integer formats`` (format : string option, expected : string) : unit =
+        let types : Types =
+            {
+                ByHandle = Dictionary ()
+                ByDefinition = Dictionary ()
+            }
+
+        match SwaggerClientGenerator.renderType types (Definition.Integer format) with
+        | None -> failwith "expected a type"
+        | Some ty -> nameOfSynType ty |> shouldEqual expected

--- a/WoofWare.Myriad.Plugins.Test/WoofWare.Myriad.Plugins.Test.fsproj
+++ b/WoofWare.Myriad.Plugins.Test/WoofWare.Myriad.Plugins.Test.fsproj
@@ -41,6 +41,7 @@
     <Compile Include="TestArgParser\TestArgParserNegation.fs" />
     <Compile Include="TestSwagger\TestSwaggerParse.fs" />
     <Compile Include="TestSwagger\TestSuccessResponse.fs" />
+    <Compile Include="TestSwagger\TestSwaggerTypeRender.fs" />
     <Compile Include="TestSwagger\TestOpenApi3Parse.fs" />
     <EmbeddedResource Include="TestSwagger\api-with-examples.json" />
     <EmbeddedResource Include="TestSwagger\callback-example.json" />

--- a/WoofWare.Myriad.Plugins/SwaggerClientGenerator.fs
+++ b/WoofWare.Myriad.Plugins/SwaggerClientGenerator.fs
@@ -104,6 +104,7 @@ module internal SwaggerClientGenerator =
         | SwaggerV2.Definition.Unspecified -> failwith "should not hit"
         | SwaggerV2.Definition.String -> SynType.string |> Some
         | SwaggerV2.Definition.Boolean -> SynType.bool |> Some
+        | SwaggerV2.Definition.Integer (Some "int64") -> SynType.createLongIdent' [ "int64" ] |> Some
         | SwaggerV2.Definition.Integer _ -> SynType.int |> Some
         | SwaggerV2.Definition.File -> SynType.createLongIdent' [ "System" ; "IO" ; "Stream" ] |> Some
 
@@ -349,9 +350,14 @@ module internal SwaggerClientGenerator =
                     FSharpDefinition = None
                 }
                 |> Some
-            | SwaggerV2.Definition.Integer _ ->
+            | SwaggerV2.Definition.Integer format ->
+                let repr =
+                    match format with
+                    | Some "int64" -> "int64"
+                    | _ -> "int"
+
                 {
-                    Signature = SynType.createLongIdent' [ "int" ]
+                    Signature = SynType.createLongIdent' [ repr ]
                     FSharpDefinition = None
                 }
                 |> Some


### PR DESCRIPTION
Third fix split out of #540; stacked on #543.

All Swagger integer definitions rendered as F# `int` regardless of `format`, narrowing 64-bit IDs to `Int32`: overflow on the way out, rejection of otherwise-valid responses on the way in. `"format": "int64"` now renders as `int64` in both `defnToType` and `renderType`; other or absent formats remain `int`.

In the generated Gitea client, `IssueGetComments` now takes `index : int64`, `Team.Id` is `int64 option`, etc.

Tests (`TestSwaggerTypeRender.fs`) were written first and observed failing on the int64 cases; they drive both rendering paths directly over all three format cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)