### PR TITLE
Serialise BigInteger fields as JSON numbers

### DIFF
--- a/ConsumePlugin/GeneratedJson.fs
+++ b/ConsumePlugin/GeneratedJson.fs
@@ -72,6 +72,46 @@ module internal InternalTypeExtensionJsonSerializeExtension =
                 )
 
             node :> _
+namespace ConsumePlugin
+
+open System.Collections.Generic
+open System.Text.Json.Serialization
+
+/// Module containing JSON serializing extension members for the ContainsABigInt type
+[<AutoOpen>]
+module ContainsABigIntJsonSerializeExtension =
+    /// Extension methods for JSON parsing
+    type ContainsABigInt with
+
+        /// Serialize to a JSON node
+        static member toJsonNode (input : ContainsABigInt) : System.Text.Json.Nodes.JsonNode =
+            let node = System.Text.Json.Nodes.JsonObject ()
+
+            do
+                node.Add (
+                    "bigNum",
+                    (input.BigNum
+                     |> (fun field ->
+                         let value = field : bigint
+
+                         let node =
+                             System.Text.Json.Nodes.JsonNode.Parse (
+                                 value.ToString ("D", System.Globalization.CultureInfo.InvariantCulture)
+                             )
+
+                         (match node with
+                          | null ->
+                              raise (
+                                  System.ArgumentNullException (
+                                      "node",
+                                      "Invariant BigInteger text unexpectedly parsed as JSON null."
+                                  )
+                              )
+                          | node -> node)
+                     ))
+                )
+
+            node :> _
 
 namespace ConsumePlugin
 
@@ -522,26 +562,29 @@ module ToGetExtensionMethodJsonParseExtension =
             }
 namespace ConsumePlugin
 
-/// Module containing JSON parsing methods for the ContainsABigInt type
-[<RequireQualifiedAccess ; CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
-module ContainsABigInt =
-    /// Parse from a JSON node.
-    let jsonParse (node : System.Text.Json.Nodes.JsonNode) : ContainsABigInt =
-        let arg_0 =
-            match node.["bigNum"] |> Option.ofObj with
-            | None ->
-                raise (
-                    System.Collections.Generic.KeyNotFoundException (
-                        sprintf "Required key '%s' not found on JSON object" ("bigNum")
-                    )
-                )
-            | Some node ->
-                System.Numerics.BigInteger.Parse (
-                    node.ToJsonString (),
-                    System.Globalization.NumberStyles.Float,
-                    System.Globalization.CultureInfo.InvariantCulture
-                )
+/// Module containing JSON parsing extension members for the ContainsABigInt type
+[<AutoOpen>]
+module ContainsABigIntJsonParseExtension =
+    /// Extension methods for JSON parsing
+    type ContainsABigInt with
 
-        {
-            BigNum = arg_0
-        }
+        /// Parse from a JSON node.
+        static member jsonParse (node : System.Text.Json.Nodes.JsonNode) : ContainsABigInt =
+            let arg_0 =
+                match node.["bigNum"] |> Option.ofObj with
+                | None ->
+                    raise (
+                        System.Collections.Generic.KeyNotFoundException (
+                            sprintf "Required key '%s' not found on JSON object" ("bigNum")
+                        )
+                    )
+                | Some node ->
+                    System.Numerics.BigInteger.Parse (
+                        node.ToJsonString (),
+                        System.Globalization.NumberStyles.Float,
+                        System.Globalization.CultureInfo.InvariantCulture
+                    )
+
+            {
+                BigNum = arg_0
+            }

--- a/ConsumePlugin/JsonRecord.fs
+++ b/ConsumePlugin/JsonRecord.fs
@@ -83,7 +83,8 @@ type ToGetExtensionMethod =
 module ToGetExtensionMethod =
     let thisModuleWouldClash = 3
 
-[<WoofWare.Myriad.Plugins.JsonParse>]
+[<WoofWare.Myriad.Plugins.JsonParse true>]
+[<WoofWare.Myriad.Plugins.JsonSerialize true>]
 type ContainsABigInt =
     {
         BigNum : bigint

--- a/WoofWare.Myriad.Plugins.Test/TestJsonSerialize/TestJsonSerde.fs
+++ b/WoofWare.Myriad.Plugins.Test/TestJsonSerialize/TestJsonSerde.fs
@@ -148,6 +148,43 @@ module TestJsonSerde =
 
         property |> Prop.forAll (Arb.fromGen outerGen) |> Check.QuickThrowOnFailure
 
+    let private twoPow64 : bigint = 18446744073709551616I
+
+    /// Generates BigIntegers across a wide magnitude range, including values far outside Int64/UInt64.
+    let bigIntGen : Gen<bigint> =
+        gen {
+            let! isNegative = ArbMap.generate<bool> ArbMap.defaults
+            let! chunks = Gen.nonEmptyListOf (ArbMap.generate<uint64> ArbMap.defaults)
+
+            let magnitude =
+                chunks |> List.fold (fun acc chunk -> acc * twoPow64 + bigint chunk) 0I
+
+            return (if isNegative then -magnitude else magnitude)
+        }
+
+    [<Test>]
+    let ``BigInteger serialises as a JSON number and roundtrips`` () =
+        let property (n : bigint) : bool =
+            let record =
+                {
+                    BigNum = n
+                }
+
+            let serialised = (ContainsABigInt.toJsonNode record).ToJsonString ()
+
+            // A JSON number, not an object: JsonValue.Create<BigInteger> would serialise the struct's
+            // public properties as an object, which is both wrong and non-roundtrippable.
+            let expectedText =
+                n.ToString ("D", System.Globalization.CultureInfo.InvariantCulture)
+
+            serialised |> shouldEqual ("{\"bigNum\":" + expectedText + "}")
+
+            JsonNode.Parse serialised |> ContainsABigInt.jsonParse |> shouldEqual record
+
+            true
+
+        property |> Prop.forAll (Arb.fromGen bigIntGen) |> Check.QuickThrowOnFailure
+
     [<Test>]
     let ``Single example of big record`` () =
         let guid = Guid.Parse "dfe24db5-9f8d-447b-8463-4c0bcf1166d5"

--- a/WoofWare.Myriad.Plugins/JsonSerializeGenerator.fs
+++ b/WoofWare.Myriad.Plugins/JsonSerializeGenerator.fs
@@ -128,6 +128,35 @@ module internal JsonSerializeGenerator =
                 ]
             |> SynExpr.createLambda "field"
             |> fun e -> e, false
+        | BigInt ->
+            // JsonValue.Create<BigInteger> serialises BigInteger's public properties as an object.
+            // Parse its invariant decimal representation to force a JSON numeric node instead.
+            SynExpr.createIdent "value"
+            |> SynExpr.callMethodArg
+                "ToString"
+                (SynExpr.tuple
+                    [
+                        SynExpr.CreateConst "D"
+                        SynExpr.createLongIdent [ "System" ; "Globalization" ; "CultureInfo" ; "InvariantCulture" ]
+                    ])
+            |> SynExpr.paren
+            |> SynExpr.applyFunction (
+                SynExpr.createLongIdent [ "System" ; "Text" ; "Json" ; "Nodes" ; "JsonNode" ; "Parse" ]
+            )
+            |> fun parsed ->
+                assertNotNull
+                    (Ident.create "node")
+                    (SynExpr.CreateConst "Invariant BigInteger text unexpectedly parsed as JSON null.")
+                    (SynExpr.createIdent "node")
+                |> SynExpr.createLet [ SynBinding.basic [ Ident.create "node" ] [] parsed ]
+            |> SynExpr.createLet
+                [
+                    SynExpr.createIdent "field"
+                    |> SynExpr.typeAnnotate fieldType
+                    |> SynBinding.basic [ Ident.create "value" ] []
+                ]
+            |> SynExpr.createLambda "field"
+            |> fun expr -> expr, true
         | DateTimeOffset ->
             // fun field -> field.ToString("o") |> JsonValue.Create<string>
             let create =


### PR DESCRIPTION
## What

The JSON serialize generator had no dedicated `BigInteger` case, so a `bigint` field fell through to the catch-all and emitted `bigint.toJsonNode` — code that doesn't compile. In practice this meant `[<JsonSerialize>]` types could not contain a `bigint`.

This adds a `BigInt` case to `serializeNodeNonNullable` that forces a JSON *numeric* node: it takes the value's invariant decimal representation (`ToString("D", InvariantCulture)`) and `JsonNode.Parse`s it. This mirrors the existing parse path (`BigInteger.Parse(..., NumberStyles.Float, InvariantCulture)`), so serialize/parse roundtrip. (Note: `JsonValue.Create<BigInteger>` would instead serialise the struct's public properties as a JSON object — wrong and non-roundtrippable.)

## Test

`ContainsABigInt` now carries both `[<JsonParse true>]` and `[<JsonSerialize true>]` so it can roundtrip. A new property-based test generates BigIntegers across a wide magnitude range (including values well outside `Int64`/`UInt64`) and asserts that:

- the serialised form is a bare JSON number (`{"bigNum":<decimal>}`), not an object; and
- parsing it back yields the original value.

I verified the test genuinely captures the change: on `main` (without the generator fix), regenerating `ConsumePlugin` fails to compile with `The type 'BigInteger' does not define the field, constructor or member 'toJsonNode'`. With the fix, all 866 tests pass.

Extracted from the `openapi-3` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)