### PR TITLE
Serialise HTTP request bodies with a direct JSON-text form

### DIFF
--- a/ConsumePlugin/GeneratedRestClient.fs
+++ b/ConsumePlugin/GeneratedRestClient.fs
@@ -843,6 +843,84 @@ module PureGymApi =
                 }
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
 
+            member _.CreateUserSerialisedJsonNodeBody
+                (user : System.Text.Json.Nodes.JsonNode, ct : CancellationToken option)
+                =
+                async {
+                    let! ct = Async.CancellationToken
+
+                    let uri =
+                        System.Uri (
+                            (match client.BaseAddress with
+                             | null -> System.Uri "https://whatnot.com/"
+                             | v -> v),
+                            System.Uri ("users/new", System.UriKind.Relative)
+                        )
+
+                    use httpMessage =
+                        new System.Net.Http.HttpRequestMessage (
+                            Method = System.Net.Http.HttpMethod.Post,
+                            RequestUri = uri
+                        )
+
+                    let queryParams =
+                        new System.Net.Http.StringContent (
+                            user |> (fun node -> (node : System.Text.Json.Nodes.JsonNode).ToJsonString ())
+                        )
+
+                    do
+                        queryParams.Headers.ContentType <-
+                            System.Net.Http.Headers.MediaTypeHeaderValue.Parse ("application/json; charset=utf-8")
+
+                    do httpMessage.Content <- queryParams
+                    let! response = client.SendAsync (httpMessage, ct) |> Async.AwaitTask
+                    let response = response.EnsureSuccessStatusCode ()
+                    use response = response
+                    let! responseString = response.Content.ReadAsStringAsync ct |> Async.AwaitTask
+                    return responseString
+                }
+                |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
+
+            member _.CreateUserSerialisedBigIntBody (user : bigint, ct : CancellationToken option) =
+                async {
+                    let! ct = Async.CancellationToken
+
+                    let uri =
+                        System.Uri (
+                            (match client.BaseAddress with
+                             | null -> System.Uri "https://whatnot.com/"
+                             | v -> v),
+                            System.Uri ("users/new", System.UriKind.Relative)
+                        )
+
+                    use httpMessage =
+                        new System.Net.Http.HttpRequestMessage (
+                            Method = System.Net.Http.HttpMethod.Post,
+                            RequestUri = uri
+                        )
+
+                    let queryParams =
+                        new System.Net.Http.StringContent (
+                            user
+                            |> (fun field ->
+                                let value = field : bigint
+                                value.ToString ("D", System.Globalization.CultureInfo.InvariantCulture)
+                            )
+                        )
+
+                    do
+                        queryParams.Headers.ContentType <-
+                            System.Net.Http.Headers.MediaTypeHeaderValue.Parse ("application/json; charset=utf-8")
+
+                    do httpMessage.Content <- queryParams
+                    let! response = client.SendAsync (httpMessage, ct) |> Async.AwaitTask
+                    let response = response.EnsureSuccessStatusCode ()
+                    use response = response
+                    let! responseString = response.Content.ReadAsStringAsync ct |> Async.AwaitTask
+                    return responseString
+                }
+                |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
+
             member _.CreateUserHttpContent (user : System.Net.Http.HttpContent, ct : CancellationToken option) =
                 async {
                     let! ct = Async.CancellationToken

--- a/ConsumePlugin/RestApiExample.fs
+++ b/ConsumePlugin/RestApiExample.fs
@@ -71,6 +71,13 @@ type IPureGymApi =
     abstract CreateUserSerialisedIntBody : [<Body>] user : int * ?ct : CancellationToken -> Task<string>
 
     [<Post "users/new">]
+    abstract CreateUserSerialisedJsonNodeBody :
+        [<Body>] user : System.Text.Json.Nodes.JsonNode * ?ct : CancellationToken -> Task<string>
+
+    [<Post "users/new">]
+    abstract CreateUserSerialisedBigIntBody : [<Body>] user : bigint * ?ct : CancellationToken -> Task<string>
+
+    [<Post "users/new">]
     abstract CreateUserHttpContent :
         [<Body>] user : System.Net.Http.HttpContent * ?ct : CancellationToken -> Task<string>
 

--- a/WoofWare.Myriad.Plugins.Test/TestHttpClient/TestBodyParam.fs
+++ b/WoofWare.Myriad.Plugins.Test/TestHttpClient/TestBodyParam.fs
@@ -185,6 +185,54 @@ module TestBodyParam =
         }
 
     [<Test>]
+    let ``Body param of serialised JsonNode`` () =
+        task {
+            let proc (message : HttpRequestMessage) : HttpResponseMessage Async =
+                async {
+                    message.Method |> shouldEqual HttpMethod.Post
+                    let! content = message.Content.ReadAsStringAsync () |> Async.AwaitTask
+                    let content = new StringContent ("Done! " + content)
+                    let resp = new HttpResponseMessage (HttpStatusCode.OK)
+                    resp.Content <- content
+                    return resp
+                }
+
+            use client = HttpClientMock.make (Uri "https://example.com") proc
+            let api = PureGymApi.make client
+
+            let body = System.Text.Json.Nodes.JsonNode.Parse """{"a":1,"b":["x",true]}"""
+
+            let! result = api.CreateUserSerialisedJsonNodeBody body
+
+            // The node is serialised directly to its JSON text; no intermediate node is constructed.
+            result |> shouldEqual """Done! {"a":1,"b":["x",true]}"""
+        }
+
+    [<Test>]
+    let ``Body param of serialised bigint`` () =
+        task {
+            let proc (message : HttpRequestMessage) : HttpResponseMessage Async =
+                async {
+                    message.Method |> shouldEqual HttpMethod.Post
+                    let! content = message.Content.ReadAsStringAsync () |> Async.AwaitTask
+                    let content = new StringContent ("Done! " + content)
+                    let resp = new HttpResponseMessage (HttpStatusCode.OK)
+                    resp.Content <- content
+                    return resp
+                }
+
+            use client = HttpClientMock.make (Uri "https://example.com") proc
+            let api = PureGymApi.make client
+
+            // A value far outside Int64/UInt64, to show it is serialised as a bare JSON number without loss.
+            let body = System.Numerics.BigInteger.Parse "123456789012345678901234567890"
+
+            let! result = api.CreateUserSerialisedBigIntBody body
+
+            result |> shouldEqual "Done! 123456789012345678901234567890"
+        }
+
+    [<Test>]
     let ``Body param of primitive: Uri`` () =
         task {
             let proc (message : HttpRequestMessage) : HttpResponseMessage Async =

--- a/WoofWare.Myriad.Plugins/HttpClientGenerator.fs
+++ b/WoofWare.Myriad.Plugins/HttpClientGenerator.fs
@@ -644,42 +644,46 @@ module internal HttpClientGenerator =
                         | CannotBeNull -> false
                         | Nullable -> true
 
+                    let serialiseToString (body : SynExpr) =
+                        match JsonSerializeGenerator.trySerializeNodeToJsonString ty with
+                        | Some serialise -> body |> SynExpr.pipeThroughFunction serialise
+                        | None ->
+                            body
+                            |> SynExpr.pipeThroughFunction (
+                                fst (
+                                    (if isNullable then
+                                         JsonSerializeGenerator.serializeNodeNullable
+                                     else
+                                         JsonSerializeGenerator.serializeNodeNonNullable)
+                                        ty
+                                )
+                            )
+                            |> SynExpr.pipeThroughFunction (
+                                SynExpr.createLambda
+                                    "node"
+                                    (if isNullable then
+                                         SynExpr.createMatch
+                                             (SynExpr.createIdent "node")
+                                             [
+                                                 SynMatchClause.create
+                                                     (SynPat.named "None")
+                                                     (SynExpr.CreateConst "null")
+                                                 SynMatchClause.create
+                                                     (SynPat.nameWithArgs "Some" [ SynPat.named "node" ])
+                                                     (SynExpr.applyFunction
+                                                         (SynExpr.createLongIdent [ "node" ; "ToJsonString" ])
+                                                         (SynExpr.CreateConst ()))
+                                             ]
+                                     else
+                                         (SynExpr.applyFunction
+                                             (SynExpr.createLongIdent [ "node" ; "ToJsonString" ])
+                                             (SynExpr.CreateConst ())))
+                            )
+
                     [
                         Let (
                             "queryParams",
-                            createStringContent (
-                                SynExpr.createIdent' bodyParamName
-                                |> SynExpr.pipeThroughFunction (
-                                    fst (
-                                        (if isNullable then
-                                             JsonSerializeGenerator.serializeNodeNullable
-                                         else
-                                             JsonSerializeGenerator.serializeNodeNonNullable)
-                                            ty
-                                    )
-                                )
-                                |> SynExpr.pipeThroughFunction (
-                                    SynExpr.createLambda
-                                        "node"
-                                        (if isNullable then
-                                             SynExpr.createMatch
-                                                 (SynExpr.createIdent "node")
-                                                 [
-                                                     SynMatchClause.create
-                                                         (SynPat.named "None")
-                                                         (SynExpr.CreateConst "null")
-                                                     SynMatchClause.create
-                                                         (SynPat.nameWithArgs "Some" [ SynPat.named "node" ])
-                                                         (SynExpr.applyFunction
-                                                             (SynExpr.createLongIdent [ "node" ; "ToJsonString" ])
-                                                             (SynExpr.CreateConst ()))
-                                                 ]
-                                         else
-                                             (SynExpr.applyFunction
-                                                 (SynExpr.createLongIdent [ "node" ; "ToJsonString" ])
-                                                 (SynExpr.CreateConst ())))
-                                )
-                            )
+                            createStringContent (SynExpr.createIdent' bodyParamName |> serialiseToString)
                         )
                         // `contentTypeHeader` is always Some here: it defaults to
                         // application/json for a serialised body.

--- a/WoofWare.Myriad.Plugins/JsonSerializeGenerator.fs
+++ b/WoofWare.Myriad.Plugins/JsonSerializeGenerator.fs
@@ -303,6 +303,59 @@ module internal JsonSerializeGenerator =
 
             SynExpr.createLongIdent' (typeName @ [ Ident.create "toJsonNode" ]), true
 
+    let private trySerializeNonNullableNodeToJsonString (fieldType : SynType) : SynExpr option =
+        match fieldType with
+        | BigInt ->
+            SynExpr.createIdent "value"
+            |> SynExpr.callMethodArg
+                "ToString"
+                (SynExpr.tuple
+                    [
+                        SynExpr.CreateConst "D"
+                        SynExpr.createLongIdent [ "System" ; "Globalization" ; "CultureInfo" ; "InvariantCulture" ]
+                    ])
+            |> SynExpr.createLet
+                [
+                    SynExpr.createIdent "field"
+                    |> SynExpr.typeAnnotate fieldType
+                    |> SynBinding.basic [ Ident.create "value" ] []
+                ]
+            |> SynExpr.createLambda "field"
+            |> Some
+        | JsonNode ->
+            SynExpr.createIdent "node"
+            |> SynExpr.typeAnnotate (SynType.createLongIdent' [ "System" ; "Text" ; "Json" ; "Nodes" ; "JsonNode" ])
+            |> SynExpr.paren
+            |> SynExpr.callMethod "ToJsonString"
+            |> SynExpr.createLambda "node"
+            |> Some
+        | _ -> None
+
+    /// Avoid constructing an intermediate JsonNode when an HTTP request body already has a direct JSON-text form.
+    let trySerializeNodeToJsonString (fieldType : SynType) : SynExpr option =
+        match fieldType with
+        | OptionType ty ->
+            trySerializeNonNullableNodeToJsonString ty
+            |> Option.map (fun serialize ->
+                [
+                    SynMatchClause.create (SynPat.named "None") (SynExpr.CreateConst "null")
+                    SynExpr.createIdent "field"
+                    |> SynExpr.applyFunction serialize
+                    |> SynMatchClause.create (SynPat.nameWithArgs "Some" [ SynPat.named "field" ])
+                ]
+                |> SynExpr.createMatch (SynExpr.createIdent "field")
+                |> SynExpr.createLambda "field"
+            )
+        | NullableType ty ->
+            trySerializeNonNullableNodeToJsonString ty
+            |> Option.map (fun serialize ->
+                SynExpr.createLongIdent [ "field" ; "Value" ]
+                |> SynExpr.applyFunction serialize
+                |> SynExpr.ifThenElse (SynExpr.createLongIdent [ "field" ; "HasValue" ]) (SynExpr.CreateConst "null")
+                |> SynExpr.createLambda "field"
+            )
+        | _ -> trySerializeNonNullableNodeToJsonString fieldType
+
     /// propertyName is probably a string literal, but it could be a [<Literal>] variable
     /// `node.Add ({propertyName}, {toJsonNode})`
     let createSerializeRhsRecord (propertyName : SynExpr) (fieldId : Ident) (fieldType : SynType) : SynExpr =


### PR DESCRIPTION
## What

Some request-body types already have a direct JSON-text representation, so building an intermediate `JsonNode` just to call `ToJsonString ()` on it is wasteful:

- a `JsonNode` body can emit its own text directly (`(node : JsonNode).ToJsonString ()`);
- a `BigInteger` body's invariant decimal (`value.ToString ("D", InvariantCulture)`) is itself valid JSON.

This adds `JsonSerializeGenerator.trySerializeNodeToJsonString`, which returns a serialiser straight to a JSON string for those types (and their `Option`/`Nullable` wrappers), or `None` otherwise. The HttpClient generator's serialised-body path now tries it first and falls back to the previous *serialize-to-node-then-`ToJsonString`* logic for everything else.

## Behaviour preservation

The fallback branch is the previous logic moved verbatim into a local `serialiseToString`. Regenerating `ConsumePlugin` produces a **purely additive** diff to `GeneratedRestClient.fs` (+78, −0): existing `Member`/`int`/`Uri` bodies (which hit `None`) generate byte-identical code; only the two new endpoints appear.

## Test

Adds `JsonNode` and `BigInteger` request-body endpoints to the example API and tests that drive them through `HttpClientMock`, asserting the body is serialised directly (a compact JSON object for the node; a bare, un-truncated number well outside `Int64`/`UInt64` for the bigint). Full suite: 868 passing.

Extracted from the `openapi-3` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)