### PR TITLE
Serialise nullable-valued JsonExtensionData dictionaries

### DIFF
--- a/ConsumePlugin/GeneratedSerde.fs
+++ b/ConsumePlugin/GeneratedSerde.fs
@@ -799,6 +799,49 @@ module OuterCollectRemainingJsonSerializeExtension =
                 node.Add ("remaining", (input.Remaining |> CollectRemaining.toJsonNode))
 
             node :> _
+namespace ConsumePlugin
+
+open System
+open System.Collections.Generic
+open System.Text.Json.Serialization
+
+/// Module containing JSON serializing methods for the CollectRemainingNullable type
+[<RequireQualifiedAccess ; CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+module CollectRemainingNullable =
+    /// Serialize to a JSON node
+    let toJsonNode (input : CollectRemainingNullable) : System.Text.Json.Nodes.JsonNode =
+        let node = System.Text.Json.Nodes.JsonObject ()
+
+        do
+            for KeyValue (key, value) in input.Rest do
+                node.Add (
+                    key,
+                    (fun field ->
+                        match field with
+                        | None -> None
+                        | Some field ->
+                            (field
+                             |> (fun field ->
+                                 let field = System.Text.Json.Nodes.JsonValue.Create<int> field
+
+                                 (match field with
+                                  | null ->
+                                      raise (
+                                          System.ArgumentNullException (
+                                              "field",
+                                              "Expected type int32 to be non-null, but received a null value when serialising"
+                                          )
+                                      )
+                                  | field -> field)
+                             ))
+                            :> System.Text.Json.Nodes.JsonNode
+                            |> Some
+                    )
+                        value
+                    |> Option.toObj
+                )
+
+        node :> _
 
 namespace ConsumePlugin
 

--- a/ConsumePlugin/SerializationAndDeserialization.fs
+++ b/ConsumePlugin/SerializationAndDeserialization.fs
@@ -92,3 +92,10 @@ type OuterCollectRemaining =
         Others : Dictionary<string, int>
         Remaining : CollectRemaining
     }
+
+[<WoofWare.Myriad.Plugins.JsonSerialize>]
+type CollectRemainingNullable =
+    {
+        [<JsonExtensionData>]
+        Rest : Dictionary<string, int option>
+    }

--- a/WoofWare.Myriad.Plugins.Test/TestJsonSerialize/TestJsonSerde.fs
+++ b/WoofWare.Myriad.Plugins.Test/TestJsonSerialize/TestJsonSerde.fs
@@ -446,6 +446,18 @@ module TestJsonSerde =
         actual |> shouldEqual expected
 
     [<Test>]
+    let ``Nullable-valued extension data writes None as JSON null`` () =
+        let toWrite =
+            {
+                Rest = [ "present", Some 3 ; "absent", None ] |> dict
+            }
+
+        // A None value must become a JSON null; without Option.toObj the Option<JsonNode>
+        // couldn't even be handed to JsonObject.Add.
+        CollectRemainingNullable.toJsonNode(toWrite).ToJsonString ()
+        |> shouldEqual """{"present":3,"absent":null}"""
+
+    [<Test>]
     let ``Can collect extension data, nested`` () =
         let str =
             """{

--- a/WoofWare.Myriad.Plugins/JsonSerializeGenerator.fs
+++ b/WoofWare.Myriad.Plugins/JsonSerializeGenerator.fs
@@ -429,19 +429,22 @@ module internal JsonSerializeGenerator =
                     | DictionaryType (String, v) -> v
                     | _ -> failwith "Expected JsonExtensionData to be a Dictionary<string, something>"
 
-                let serialise =
+                let isNullable, serialise =
                     match JsonNodeWithNullability.Identify valType with
-                    | CannotBeNull -> fst (serializeNodeNonNullable valType)
-                    | Nullable -> fst (serializeNodeNullable valType)
+                    | CannotBeNull -> false, fst (serializeNodeNonNullable valType)
+                    | Nullable -> true, fst (serializeNodeNullable valType)
+
+                let serialised = SynExpr.applyFunction serialise (SynExpr.createIdent "value")
+
+                let serialised =
+                    if isNullable then
+                        serialised
+                        |> SynExpr.pipeThroughFunction (SynExpr.createLongIdent [ "Option" ; "toObj" ])
+                    else
+                        serialised
 
                 SynExpr.createIdent "node"
-                |> SynExpr.callMethodArg
-                    "Add"
-                    (SynExpr.tuple
-                        [
-                            SynExpr.createIdent "key"
-                            SynExpr.applyFunction serialise (SynExpr.createIdent "value")
-                        ])
+                |> SynExpr.callMethodArg "Add" (SynExpr.tuple [ SynExpr.createIdent "key" ; serialised ])
                 |> SynExpr.createForEach
                     (SynPat.identWithArgs
                         [ Ident.create "KeyValue" ]


### PR DESCRIPTION
## What

When a `[<JsonExtensionData>]` dictionary's value type is nullable (an `option`), the per-value serialiser returns an `Option<JsonNode>`. That was passed straight to `JsonObject.Add`, which expects a `JsonNode` — so a type like `Dictionary<string, int option>` as extension data **failed to compile** (`The type 'JsonNode option' is not compatible with the type 'JsonNode'`).

This pipes the nullable case through `Option.toObj`, so `None` becomes a JSON `null` and `Some` is unwrapped to its node. The non-nullable case is untouched.

## Behaviour preservation

For non-nullable extension-data values the generated AST is unchanged (the new `serialised` binding is generator-side only). Regenerating `ConsumePlugin` produces a **purely additive** diff to `GeneratedSerde.fs` (+43, −0): the existing `CollectRemaining`/`OuterCollectRemaining` serialisers are byte-identical, and only the new type appears.

## Test

Added `CollectRemainingNullable` (a record whose only field is an `int option`-valued extension-data dictionary) and a test asserting `{ Rest = [ "present", Some 3 ; "absent", None ] }` serialises to `{"present":3,"absent":null}`. On `main` this type doesn't compile; with the fix, all 867 tests pass.

The `int option` value type keeps this change independent of the JsonNode-serialisation work.

Extracted from the `openapi-3` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)