### PR TITLE
Encode option-typed query parameters

### DIFF
--- a/ConsumePlugin/GeneratedRestClient.fs
+++ b/ConsumePlugin/GeneratedRestClient.fs
@@ -2362,6 +2362,119 @@ open RestEase
 
 /// Module for constructing a REST client.
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix) ; RequireQualifiedAccess>]
+module ApiWithOptionalQuery =
+    /// Create a REST client.
+    let make (client : System.Net.Http.HttpClient) : IApiWithOptionalQuery =
+        { new IApiWithOptionalQuery with
+            member _.GetWithMixedQuery
+                (page : int option, limit : int, search : string option, ct : CancellationToken option)
+                =
+                async {
+                    let! ct = Async.CancellationToken
+
+                    let queryString =
+                        [
+                            page
+                            |> Option.map (fun queryParam ->
+                                "page=" + ((queryParam.ToString ()) |> System.Uri.EscapeDataString)
+                            )
+                            |> Option.toList
+
+                            [ "limit=" + ((limit.ToString ()) |> System.Uri.EscapeDataString) ]
+                            search
+                            |> Option.map (fun queryParam ->
+                                "search=" + ((queryParam.ToString ()) |> System.Uri.EscapeDataString)
+                            )
+                            |> Option.toList
+                        ]
+                        |> List.concat
+                        |> String.concat "&"
+
+                    let uri =
+                        System.Uri (
+                            (match client.BaseAddress with
+                             | null -> System.Uri "https://whatnot.com/"
+                             | v -> v),
+                            System.Uri (
+                                ("endpoint"
+                                 + (if queryString = "" then
+                                        ""
+                                    else
+                                        ((if "endpoint".IndexOf (char 63) >= 0 then "&" else "?") + queryString))),
+                                System.UriKind.Relative
+                            )
+                        )
+
+                    use httpMessage =
+                        new System.Net.Http.HttpRequestMessage (
+                            Method = System.Net.Http.HttpMethod.Get,
+                            RequestUri = uri
+                        )
+
+                    let! response = client.SendAsync (httpMessage, ct) |> Async.AwaitTask
+                    let response = response.EnsureSuccessStatusCode ()
+                    use response = response
+                    let! responseString = response.Content.ReadAsStringAsync ct |> Async.AwaitTask
+                    return responseString
+                }
+                |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
+
+            member _.GetWithAllOptionalQuery (since : DateOnly option, ct : CancellationToken option) =
+                async {
+                    let! ct = Async.CancellationToken
+
+                    let queryString =
+                        [
+                            since
+                            |> Option.map (fun queryParam ->
+                                "since=" + ((queryParam.ToString "yyyy-MM-dd") |> System.Uri.EscapeDataString)
+                            )
+                            |> Option.toList
+                        ]
+                        |> List.concat
+                        |> String.concat "&"
+
+                    let uri =
+                        System.Uri (
+                            (match client.BaseAddress with
+                             | null -> System.Uri "https://whatnot.com/"
+                             | v -> v),
+                            System.Uri (
+                                ("endpoint"
+                                 + (if queryString = "" then
+                                        ""
+                                    else
+                                        ((if "endpoint".IndexOf (char 63) >= 0 then "&" else "?") + queryString))),
+                                System.UriKind.Relative
+                            )
+                        )
+
+                    use httpMessage =
+                        new System.Net.Http.HttpRequestMessage (
+                            Method = System.Net.Http.HttpMethod.Get,
+                            RequestUri = uri
+                        )
+
+                    let! response = client.SendAsync (httpMessage, ct) |> Async.AwaitTask
+                    let response = response.EnsureSuccessStatusCode ()
+                    use response = response
+                    let! responseString = response.Content.ReadAsStringAsync ct |> Async.AwaitTask
+                    return responseString
+                }
+                |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
+        }
+namespace PureGym
+
+open System
+open System.Threading
+open System.Threading.Tasks
+open System.IO
+open System.Net
+open System.Net.Http
+open RestEase
+
+/// Module for constructing a REST client.
+[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix) ; RequireQualifiedAccess>]
 module ClientWithStringBody =
     /// Create a REST client.
     let make (client : System.Net.Http.HttpClient) : IClientWithStringBody =

--- a/ConsumePlugin/GeneratedRestClient.fs
+++ b/ConsumePlugin/GeneratedRestClient.fs
@@ -2462,6 +2462,105 @@ module ApiWithOptionalQuery =
                     return responseString
                 }
                 |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
+
+            member _.GetWithOptionalListQuery (tags : string list option, limit : int, ct : CancellationToken option) =
+                async {
+                    let! ct = Async.CancellationToken
+
+                    let queryString =
+                        [
+                            tags
+                            |> Option.map (fun queryParam ->
+                                queryParam
+                                |> List.map (fun queryParam ->
+                                    "tag=" + ((queryParam.ToString ()) |> System.Uri.EscapeDataString)
+                                )
+                            )
+                            |> Option.toList
+                            |> List.concat
+                            [ "limit=" + ((limit.ToString ()) |> System.Uri.EscapeDataString) ]
+                        ]
+                        |> List.concat
+                        |> String.concat "&"
+
+                    let uri =
+                        System.Uri (
+                            (match client.BaseAddress with
+                             | null -> System.Uri "https://whatnot.com/"
+                             | v -> v),
+                            System.Uri (
+                                ("endpoint"
+                                 + (if queryString = "" then
+                                        ""
+                                    else
+                                        ((if "endpoint".IndexOf (char 63) >= 0 then "&" else "?") + queryString))),
+                                System.UriKind.Relative
+                            )
+                        )
+
+                    use httpMessage =
+                        new System.Net.Http.HttpRequestMessage (
+                            Method = System.Net.Http.HttpMethod.Get,
+                            RequestUri = uri
+                        )
+
+                    let! response = client.SendAsync (httpMessage, ct) |> Async.AwaitTask
+                    let response = response.EnsureSuccessStatusCode ()
+                    use response = response
+                    let! responseString = response.Content.ReadAsStringAsync ct |> Async.AwaitTask
+                    return responseString
+                }
+                |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
+
+            member _.GetWithOptionalArrayQuery (ids : int array option, limit : int, ct : CancellationToken option) =
+                async {
+                    let! ct = Async.CancellationToken
+
+                    let queryString =
+                        [
+                            ids
+                            |> Option.map (fun queryParam ->
+                                queryParam
+                                |> Seq.map (fun queryParam ->
+                                    "id=" + ((queryParam.ToString ()) |> System.Uri.EscapeDataString)
+                                )
+                                |> List.ofSeq
+                            )
+                            |> Option.toList
+                            |> List.concat
+                            [ "limit=" + ((limit.ToString ()) |> System.Uri.EscapeDataString) ]
+                        ]
+                        |> List.concat
+                        |> String.concat "&"
+
+                    let uri =
+                        System.Uri (
+                            (match client.BaseAddress with
+                             | null -> System.Uri "https://whatnot.com/"
+                             | v -> v),
+                            System.Uri (
+                                ("endpoint"
+                                 + (if queryString = "" then
+                                        ""
+                                    else
+                                        ((if "endpoint".IndexOf (char 63) >= 0 then "&" else "?") + queryString))),
+                                System.UriKind.Relative
+                            )
+                        )
+
+                    use httpMessage =
+                        new System.Net.Http.HttpRequestMessage (
+                            Method = System.Net.Http.HttpMethod.Get,
+                            RequestUri = uri
+                        )
+
+                    let! response = client.SendAsync (httpMessage, ct) |> Async.AwaitTask
+                    let response = response.EnsureSuccessStatusCode ()
+                    use response = response
+                    let! responseString = response.Content.ReadAsStringAsync ct |> Async.AwaitTask
+                    return responseString
+                }
+                |> (fun a -> Async.StartAsTask (a, ?cancellationToken = ct))
         }
 namespace PureGym
 

--- a/ConsumePlugin/RestApiExample.fs
+++ b/ConsumePlugin/RestApiExample.fs
@@ -279,6 +279,17 @@ type IApiWithOptionalQuery =
     abstract GetWithAllOptionalQuery :
         [<Query "since">] since : DateOnly option * ?ct : CancellationToken -> Task<string>
 
+    // An optional collection-typed query parameter contributes one key=value pair per element
+    // when Some, and none at all when None.
+    [<Get "endpoint">]
+    abstract GetWithOptionalListQuery :
+        [<Query "tag">] tags : string list option * [<Query "limit">] limit : int * ?ct : CancellationToken ->
+            Task<string>
+
+    [<Get "endpoint">]
+    abstract GetWithOptionalArrayQuery :
+        [<Query "id">] ids : int array option * [<Query "limit">] limit : int * ?ct : CancellationToken -> Task<string>
+
 [<WoofWare.Myriad.Plugins.HttpClient>]
 type IClientWithStringBody =
     // As a POST request of a bare string body, we don't override the Content-Type.

--- a/ConsumePlugin/RestApiExample.fs
+++ b/ConsumePlugin/RestApiExample.fs
@@ -264,6 +264,22 @@ type IApiShadowingGeneratedNames =
             Task<string>
 
 [<WoofWare.Myriad.Plugins.HttpClient>]
+[<BaseAddress "https://whatnot.com">]
+type IApiWithOptionalQuery =
+    // Optional query parameters are omitted from the URL when None.
+    [<Get "endpoint">]
+    abstract GetWithMixedQuery :
+        [<Query "page">] page : int option *
+        [<Query "limit">] limit : int *
+        [<Query "search">] search : string option *
+        ?ct : CancellationToken ->
+            Task<string>
+
+    [<Get "endpoint">]
+    abstract GetWithAllOptionalQuery :
+        [<Query "since">] since : DateOnly option * ?ct : CancellationToken -> Task<string>
+
+[<WoofWare.Myriad.Plugins.HttpClient>]
 type IClientWithStringBody =
     // As a POST request of a bare string body, we don't override the Content-Type.
     [<Post "endpoint/{param}">]

--- a/WoofWare.Myriad.Plugins.Test/TestHttpClient/TestOptionalQueryParam.fs
+++ b/WoofWare.Myriad.Plugins.Test/TestHttpClient/TestOptionalQueryParam.fs
@@ -65,3 +65,40 @@ module TestOptionalQueryParam =
         let api = ApiWithOptionalQuery.make client
 
         api.GetWithAllOptionalQuery(None).Result |> shouldEqual "response"
+
+    [<Test>]
+    let ``Optional list param present contributes one pair per element`` () =
+        use client = makeClient "https://example.com/endpoint?tag=a&tag=b&limit=10"
+        let api = ApiWithOptionalQuery.make client
+
+        api.GetWithOptionalListQuery(Some [ "a" ; "b" ], 10).Result
+        |> shouldEqual "response"
+
+    [<Test>]
+    let ``Optional list param empty contributes nothing`` () =
+        use client = makeClient "https://example.com/endpoint?limit=10"
+        let api = ApiWithOptionalQuery.make client
+
+        api.GetWithOptionalListQuery(Some [], 10).Result |> shouldEqual "response"
+
+    [<Test>]
+    let ``Optional list param missing contributes nothing`` () =
+        use client = makeClient "https://example.com/endpoint?limit=10"
+        let api = ApiWithOptionalQuery.make client
+
+        api.GetWithOptionalListQuery(None, 10).Result |> shouldEqual "response"
+
+    [<Test>]
+    let ``Optional array param present contributes one pair per element`` () =
+        use client = makeClient "https://example.com/endpoint?id=1&id=2&limit=10"
+        let api = ApiWithOptionalQuery.make client
+
+        api.GetWithOptionalArrayQuery(Some [| 1 ; 2 |], 10).Result
+        |> shouldEqual "response"
+
+    [<Test>]
+    let ``Optional array param missing contributes nothing`` () =
+        use client = makeClient "https://example.com/endpoint?limit=10"
+        let api = ApiWithOptionalQuery.make client
+
+        api.GetWithOptionalArrayQuery(None, 10).Result |> shouldEqual "response"

--- a/WoofWare.Myriad.Plugins.Test/TestHttpClient/TestOptionalQueryParam.fs
+++ b/WoofWare.Myriad.Plugins.Test/TestHttpClient/TestOptionalQueryParam.fs
@@ -1,0 +1,67 @@
+namespace WoofWare.Myriad.Plugins.Test
+
+open System
+open System.Net
+open System.Net.Http
+open NUnit.Framework
+open PureGym
+open FsUnitTyped
+
+[<TestFixture>]
+module TestOptionalQueryParam =
+
+    let private makeClient (expectedUri : string) : HttpClientMock =
+        let proc (message : HttpRequestMessage) : HttpResponseMessage Async =
+            async {
+                message.Method |> shouldEqual HttpMethod.Get
+                message.RequestUri.AbsoluteUri |> shouldEqual expectedUri
+
+                let resp = new HttpResponseMessage (HttpStatusCode.OK)
+                resp.Content <- new StringContent ("response")
+                return resp
+            }
+
+        HttpClientMock.make (Uri "https://example.com") proc
+
+    [<Test>]
+    let ``All params present`` () =
+        use client = makeClient "https://example.com/endpoint?page=3&limit=10&search=hello"
+        let api = ApiWithOptionalQuery.make client
+
+        api.GetWithMixedQuery(Some 3, 10, Some "hello").Result |> shouldEqual "response"
+
+    [<Test>]
+    let ``First param missing`` () =
+        use client = makeClient "https://example.com/endpoint?limit=10&search=hello"
+        let api = ApiWithOptionalQuery.make client
+
+        api.GetWithMixedQuery(None, 10, Some "hello").Result |> shouldEqual "response"
+
+    [<Test>]
+    let ``Last param missing`` () =
+        use client = makeClient "https://example.com/endpoint?page=3&limit=10"
+        let api = ApiWithOptionalQuery.make client
+
+        api.GetWithMixedQuery(Some 3, 10, None).Result |> shouldEqual "response"
+
+    [<Test>]
+    let ``Optional params are escaped`` () =
+        use client = makeClient "https://example.com/endpoint?limit=10&search=a%20b"
+        let api = ApiWithOptionalQuery.make client
+
+        api.GetWithMixedQuery(None, 10, Some "a b").Result |> shouldEqual "response"
+
+    [<Test>]
+    let ``Sole optional param present`` () =
+        use client = makeClient "https://example.com/endpoint?since=2024-01-15"
+        let api = ApiWithOptionalQuery.make client
+
+        api.GetWithAllOptionalQuery(Some (DateOnly (2024, 1, 15))).Result
+        |> shouldEqual "response"
+
+    [<Test>]
+    let ``Sole optional param missing leaves the URL bare`` () =
+        use client = makeClient "https://example.com/endpoint"
+        let api = ApiWithOptionalQuery.make client
+
+        api.GetWithAllOptionalQuery(None).Result |> shouldEqual "response"

--- a/WoofWare.Myriad.Plugins.Test/WoofWare.Myriad.Plugins.Test.fsproj
+++ b/WoofWare.Myriad.Plugins.Test/WoofWare.Myriad.Plugins.Test.fsproj
@@ -27,6 +27,7 @@
     <Compile Include="TestHttpClient\TestVaultClient.fs" />
     <Compile Include="TestHttpClient\TestVariableHeader.fs" />
     <Compile Include="TestHttpClient\TestListQueryParam.fs" />
+    <Compile Include="TestHttpClient\TestOptionalQueryParam.fs" />
     <Compile Include="TestHttpClient\TestGeneratedNameCollision.fs" />
     <Compile Include="TestHttpClient\TestFreshName.fs" />
     <Compile Include="TestHttpClient\TestContentTypeCharset.fs" />

--- a/WoofWare.Myriad.Plugins/HttpClientGenerator.fs
+++ b/WoofWare.Myriad.Plugins/HttpClientGenerator.fs
@@ -311,7 +311,8 @@ module internal HttpClientGenerator =
             |> freshName "queryString"
 
         // A list- or array-typed query parameter contributes one key=value pair per
-        // element ("multi" collection format, RestEase's convention), so the query
+        // element ("multi" collection format, RestEase's convention), and an option-typed
+        // one contributes zero or one pair (omitted entirely when None), so the query
         // string is a runtime computation: we emit a `queryString` binding and then
         // splice it (with a separator, if it's nonempty) onto the URL.
         let requestUriTrailer, queryStringBindings =
@@ -368,6 +369,16 @@ module internal HttpClientGenerator =
                                         (keyEqualsValue eltType (SynExpr.createIdent "queryParam")))
                             )
                             |> SynExpr.pipeThroughFunction (SynExpr.createLongIdent [ "List" ; "ofSeq" ])
+                        | OptionType innerType ->
+                            SynExpr.createIdent' paramValueId
+                            |> SynExpr.pipeThroughFunction (
+                                SynExpr.applyFunction
+                                    (SynExpr.createLongIdent [ "Option" ; "map" ])
+                                    (SynExpr.createLambda
+                                        "queryParam"
+                                        (keyEqualsValue innerType (SynExpr.createIdent "queryParam")))
+                            )
+                            |> SynExpr.pipeThroughFunction (SynExpr.createLongIdent [ "Option" ; "toList" ])
                         | ty ->
                             keyEqualsValue ty (SynExpr.createIdent' paramValueId)
                             |> List.singleton

--- a/WoofWare.Myriad.Plugins/HttpClientGenerator.fs
+++ b/WoofWare.Myriad.Plugins/HttpClientGenerator.fs
@@ -349,40 +349,62 @@ module internal HttpClientGenerator =
                             |> SynExpr.paren
                             |> SynExpr.plus (SynExpr.CreateConst (paramKey + "="))
 
-                        match paramValue.Type with
-                        | ListType eltType ->
-                            SynExpr.createIdent' paramValueId
-                            |> SynExpr.pipeThroughFunction (
-                                SynExpr.applyFunction
-                                    (SynExpr.createLongIdent [ "List" ; "map" ])
-                                    (SynExpr.createLambda
-                                        "queryParam"
-                                        (keyEqualsValue eltType (SynExpr.createIdent "queryParam")))
-                            )
-                        | ArrayType eltType ->
-                            SynExpr.createIdent' paramValueId
-                            |> SynExpr.pipeThroughFunction (
-                                SynExpr.applyFunction
-                                    (SynExpr.createLongIdent [ "Seq" ; "map" ])
-                                    (SynExpr.createLambda
-                                        "queryParam"
-                                        (keyEqualsValue eltType (SynExpr.createIdent "queryParam")))
-                            )
-                            |> SynExpr.pipeThroughFunction (SynExpr.createLongIdent [ "List" ; "ofSeq" ])
-                        | OptionType innerType ->
-                            SynExpr.createIdent' paramValueId
-                            |> SynExpr.pipeThroughFunction (
-                                SynExpr.applyFunction
-                                    (SynExpr.createLongIdent [ "Option" ; "map" ])
-                                    (SynExpr.createLambda
-                                        "queryParam"
-                                        (keyEqualsValue innerType (SynExpr.createIdent "queryParam")))
-                            )
-                            |> SynExpr.pipeThroughFunction (SynExpr.createLongIdent [ "Option" ; "toList" ])
-                        | ty ->
-                            keyEqualsValue ty (SynExpr.createIdent' paramValueId)
-                            |> List.singleton
-                            |> SynExpr.listLiteral
+                        // A type is "many-valued" if it contributes a variable number of key=value
+                        // pairs, so that mapping over it yields a `string list list` we must flatten.
+                        let isManyValued (ty : SynType) =
+                            match ty with
+                            | ListType _
+                            | ArrayType _
+                            | OptionType _ -> true
+                            | _ -> false
+
+                        // The `string list` of key=value pairs contributed by a value of type `ty`.
+                        // A collection contributes one pair per element and an option contributes the
+                        // pairs of its contents (none at all when None); these compose, so e.g.
+                        // `string list option` sends `Some [ "a" ; "b" ]` to [ "tag=a" ; "tag=b" ].
+                        let rec expand (ty : SynType) (value : SynExpr) : SynExpr =
+                            match ty with
+                            | ListType eltType ->
+                                value
+                                |> SynExpr.pipeThroughFunction (
+                                    mapElements [ "List" ; "map" ] [ "List" ; "collect" ] eltType
+                                )
+                            | ArrayType eltType ->
+                                value
+                                |> SynExpr.pipeThroughFunction (
+                                    mapElements [ "Seq" ; "map" ] [ "Seq" ; "collect" ] eltType
+                                )
+                                |> SynExpr.pipeThroughFunction (SynExpr.createLongIdent [ "List" ; "ofSeq" ])
+                            | OptionType innerType ->
+                                let mapped =
+                                    value
+                                    |> SynExpr.pipeThroughFunction (
+                                        mapElements [ "Option" ; "map" ] [ "Option" ; "map" ] innerType
+                                    )
+                                    |> SynExpr.pipeThroughFunction (SynExpr.createLongIdent [ "Option" ; "toList" ])
+
+                                if isManyValued innerType then
+                                    // `Option.map` over a many-valued inner type gives a `string list option`.
+                                    mapped
+                                    |> SynExpr.pipeThroughFunction (SynExpr.createLongIdent [ "List" ; "concat" ])
+                                else
+                                    mapped
+                            | ty -> keyEqualsValue ty value |> List.singleton |> SynExpr.listLiteral
+
+                        /// Map `mapFn`/`collectFn` (as appropriate for whether the element type is
+                        /// itself many-valued) over the elements of a collection.
+                        and mapElements (mapFn : string list) (collectFn : string list) (eltType : SynType) : SynExpr =
+                            let elt = SynExpr.createIdent "queryParam"
+
+                            let fn, body =
+                                if isManyValued eltType then
+                                    collectFn, expand eltType elt
+                                else
+                                    mapFn, keyEqualsValue eltType elt
+
+                            SynExpr.applyFunction (SynExpr.createLongIdent fn) (SynExpr.createLambda "queryParam" body)
+
+                        expand paramValue.Type (SynExpr.createIdent' paramValueId)
                     )
 
                 let queryString =


### PR DESCRIPTION
The HTTP client generator has no case for an option-typed `[<Query>]` parameter: it falls through to the scalar path and emits `param.ToString()`. For `Some 3` that produces `page=Some%283%29`, and for `None` it throws a `NullReferenceException` (F#'s `None` is null at runtime).

An option-typed query parameter now contributes zero or one `key=value` pair, via `Option.map`/`Option.toList`, so `None` is omitted from the URL and an all-`None` query leaves the URL bare. The `DateOnly`-style format specifiers still apply inside the `map`.

Tests were written first and observed failing with exactly the `page=Some%283%29` symptom above. `TestOptionalQueryParam.fs` covers mixed present/missing, escaping, sole-param-present, and sole-param-missing (bare URL) through a hand-written interface.

**No existing generated client changes.** Query strings composed only of required parameters are byte-identical to before — the Gitea and PureGym outputs don't move. The only generated diff is the new `IApiWithOptionalQuery` example.

### Relationship to #546

This is the client-side half of #546, split out. That PR bundled two independent changes in two different files:

- `SwaggerClientGenerator.fs` — made Swagger 2 query parameters option-typed unless explicitly `required: true`. This is what produced the ~1700-line Gitea diff, and it is **not** included here; #546 stays closed.
- `HttpClientGenerator.fs` — this change. A pure capability addition, inert unless a parameter is already option-typed.

Nothing in the repo currently generates an optional query parameter, so this is latent today. It is a prerequisite for the OpenAPI 3 generator, whose spec-compliant handling of `required: false` parameters (e.g. petstore's `limit`) produces option-typed parameters that would otherwise be encoded as `limit=Some%283%29`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)