### PR TITLE
Arg parser: a bare `--` no longer discards pending parser state

### DIFF
--- a/ConsumePlugin/GeneratedArgParserNegationTests.fs
+++ b/ConsumePlugin/GeneratedArgParserNegationTests.fs
@@ -144,7 +144,19 @@ module BoolNegationArgParse =
                                 "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
                                 key
                             |> ArgParser_errors.Add
-                | "--" :: rest -> parser_LeftoverArgs.AddRange (rest |> Seq.map (fun x -> x))
+                | "--" :: rest ->
+                    match state with
+                    | ParseState_BoolNegation.AwaitingKey -> ()
+                    | ParseState_BoolNegation.AwaitingValue key ->
+                        if setFlagValue key then
+                            ()
+                        else
+                            sprintf
+                                "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
+                                key
+                            |> ArgParser_errors.Add
+
+                    parser_LeftoverArgs.AddRange (rest |> Seq.map (fun x -> x))
                 | arg :: args ->
                     match state with
                     | ParseState_BoolNegation.AwaitingKey ->
@@ -363,7 +375,19 @@ module FlagNegationArgParse =
                                 "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
                                 key
                             |> ArgParser_errors.Add
-                | "--" :: rest -> parser_LeftoverArgs.AddRange (rest |> Seq.map (fun x -> x))
+                | "--" :: rest ->
+                    match state with
+                    | ParseState_FlagNegation.AwaitingKey -> ()
+                    | ParseState_FlagNegation.AwaitingValue key ->
+                        if setFlagValue key then
+                            ()
+                        else
+                            sprintf
+                                "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
+                                key
+                            |> ArgParser_errors.Add
+
+                    parser_LeftoverArgs.AddRange (rest |> Seq.map (fun x -> x))
                 | arg :: args ->
                     match state with
                     | ParseState_FlagNegation.AwaitingKey ->
@@ -626,7 +650,19 @@ module MultipleFormsNegationArgParse =
                                 "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
                                 key
                             |> ArgParser_errors.Add
-                | "--" :: rest -> parser_LeftoverArgs.AddRange (rest |> Seq.map (fun x -> x))
+                | "--" :: rest ->
+                    match state with
+                    | ParseState_MultipleFormsNegation.AwaitingKey -> ()
+                    | ParseState_MultipleFormsNegation.AwaitingValue key ->
+                        if setFlagValue key then
+                            ()
+                        else
+                            sprintf
+                                "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
+                                key
+                            |> ArgParser_errors.Add
+
+                    parser_LeftoverArgs.AddRange (rest |> Seq.map (fun x -> x))
                 | arg :: args ->
                     match state with
                     | ParseState_MultipleFormsNegation.AwaitingKey ->
@@ -933,7 +969,19 @@ module CombinedFeaturesArgParse =
                                 "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
                                 key
                             |> ArgParser_errors.Add
-                | "--" :: rest -> parser_LeftoverArgs.AddRange (rest |> Seq.map (fun x -> x))
+                | "--" :: rest ->
+                    match state with
+                    | ParseState_CombinedFeatures.AwaitingKey -> ()
+                    | ParseState_CombinedFeatures.AwaitingValue key ->
+                        if setFlagValue key then
+                            ()
+                        else
+                            sprintf
+                                "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
+                                key
+                            |> ArgParser_errors.Add
+
+                    parser_LeftoverArgs.AddRange (rest |> Seq.map (fun x -> x))
                 | arg :: args ->
                     match state with
                     | ParseState_CombinedFeatures.AwaitingKey ->

--- a/ConsumePlugin/GeneratedArgs.fs
+++ b/ConsumePlugin/GeneratedArgs.fs
@@ -131,7 +131,19 @@ module BasicNoPositionals =
                             "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
                             key
                         |> ArgParser_errors.Add
-            | "--" :: rest -> parser_LeftoverArgs.AddRange (rest |> Seq.map (fun x -> x))
+            | "--" :: rest ->
+                match state with
+                | ParseState_BasicNoPositionals.AwaitingKey -> ()
+                | ParseState_BasicNoPositionals.AwaitingValue key ->
+                    if setFlagValue key then
+                        ()
+                    else
+                        sprintf
+                            "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
+                            key
+                        |> ArgParser_errors.Add
+
+                parser_LeftoverArgs.AddRange (rest |> Seq.map (fun x -> x))
             | arg :: args ->
                 match state with
                 | ParseState_BasicNoPositionals.AwaitingKey ->
@@ -350,7 +362,19 @@ module Basic =
                             "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
                             key
                         |> ArgParser_errors.Add
-            | "--" :: rest -> arg_3.AddRange (rest |> Seq.map (fun x -> x))
+            | "--" :: rest ->
+                match state with
+                | ParseState_Basic.AwaitingKey -> ()
+                | ParseState_Basic.AwaitingValue key ->
+                    if setFlagValue key then
+                        ()
+                    else
+                        sprintf
+                            "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
+                            key
+                        |> ArgParser_errors.Add
+
+                arg_3.AddRange (rest |> Seq.map (fun x -> x))
             | arg :: args ->
                 match state with
                 | ParseState_Basic.AwaitingKey ->
@@ -553,7 +577,19 @@ module BasicWithIntPositionals =
                             "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
                             key
                         |> ArgParser_errors.Add
-            | "--" :: rest -> arg_3.AddRange (rest |> Seq.map (fun x -> System.Int32.Parse x))
+            | "--" :: rest ->
+                match state with
+                | ParseState_BasicWithIntPositionals.AwaitingKey -> ()
+                | ParseState_BasicWithIntPositionals.AwaitingValue key ->
+                    if setFlagValue key then
+                        ()
+                    else
+                        sprintf
+                            "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
+                            key
+                        |> ArgParser_errors.Add
+
+                arg_3.AddRange (rest |> Seq.map (fun x -> System.Int32.Parse x))
             | arg :: args ->
                 match state with
                 | ParseState_BasicWithIntPositionals.AwaitingKey ->
@@ -934,7 +970,19 @@ module LoadsOfTypes =
                             "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
                             key
                         |> ArgParser_errors.Add
-            | "--" :: rest -> arg_7.AddRange (rest |> Seq.map (fun x -> System.Int32.Parse x))
+            | "--" :: rest ->
+                match state with
+                | ParseState_LoadsOfTypes.AwaitingKey -> ()
+                | ParseState_LoadsOfTypes.AwaitingValue key ->
+                    if setFlagValue key then
+                        ()
+                    else
+                        sprintf
+                            "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
+                            key
+                        |> ArgParser_errors.Add
+
+                arg_7.AddRange (rest |> Seq.map (fun x -> System.Int32.Parse x))
             | arg :: args ->
                 match state with
                 | ParseState_LoadsOfTypes.AwaitingKey ->
@@ -1362,7 +1410,19 @@ module LoadsOfTypesNoPositionals =
                             "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
                             key
                         |> ArgParser_errors.Add
-            | "--" :: rest -> parser_LeftoverArgs.AddRange (rest |> Seq.map (fun x -> x))
+            | "--" :: rest ->
+                match state with
+                | ParseState_LoadsOfTypesNoPositionals.AwaitingKey -> ()
+                | ParseState_LoadsOfTypesNoPositionals.AwaitingValue key ->
+                    if setFlagValue key then
+                        ()
+                    else
+                        sprintf
+                            "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
+                            key
+                        |> ArgParser_errors.Add
+
+                parser_LeftoverArgs.AddRange (rest |> Seq.map (fun x -> x))
             | arg :: args ->
                 match state with
                 | ParseState_LoadsOfTypesNoPositionals.AwaitingKey ->
@@ -1681,7 +1741,19 @@ module DatesAndTimesArgParse =
                                 "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
                                 key
                             |> ArgParser_errors.Add
-                | "--" :: rest -> parser_LeftoverArgs.AddRange (rest |> Seq.map (fun x -> x))
+                | "--" :: rest ->
+                    match state with
+                    | ParseState_DatesAndTimes.AwaitingKey -> ()
+                    | ParseState_DatesAndTimes.AwaitingValue key ->
+                        if setFlagValue key then
+                            ()
+                        else
+                            sprintf
+                                "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
+                                key
+                            |> ArgParser_errors.Add
+
+                    parser_LeftoverArgs.AddRange (rest |> Seq.map (fun x -> x))
                 | arg :: args ->
                     match state with
                     | ParseState_DatesAndTimes.AwaitingKey ->
@@ -1917,7 +1989,19 @@ module ParentRecordArgParse =
                                 "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
                                 key
                             |> ArgParser_errors.Add
-                | "--" :: rest -> parser_LeftoverArgs.AddRange (rest |> Seq.map (fun x -> x))
+                | "--" :: rest ->
+                    match state with
+                    | ParseState_ParentRecord.AwaitingKey -> ()
+                    | ParseState_ParentRecord.AwaitingValue key ->
+                        if setFlagValue key then
+                            ()
+                        else
+                            sprintf
+                                "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
+                                key
+                            |> ArgParser_errors.Add
+
+                    parser_LeftoverArgs.AddRange (rest |> Seq.map (fun x -> x))
                 | arg :: args ->
                     match state with
                     | ParseState_ParentRecord.AwaitingKey ->
@@ -2133,7 +2217,19 @@ module ParentRecordChildPosArgParse =
                                 "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
                                 key
                             |> ArgParser_errors.Add
-                | "--" :: rest -> arg_1.AddRange (rest |> Seq.map (fun x -> System.Uri x))
+                | "--" :: rest ->
+                    match state with
+                    | ParseState_ParentRecordChildPos.AwaitingKey -> ()
+                    | ParseState_ParentRecordChildPos.AwaitingValue key ->
+                        if setFlagValue key then
+                            ()
+                        else
+                            sprintf
+                                "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
+                                key
+                            |> ArgParser_errors.Add
+
+                    arg_1.AddRange (rest |> Seq.map (fun x -> System.Uri x))
                 | arg :: args ->
                     match state with
                     | ParseState_ParentRecordChildPos.AwaitingKey ->
@@ -2316,7 +2412,19 @@ module ParentRecordSelfPosArgParse =
                                 "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
                                 key
                             |> ArgParser_errors.Add
-                | "--" :: rest -> arg_2.AddRange (rest |> Seq.map (fun x -> System.Boolean.Parse x))
+                | "--" :: rest ->
+                    match state with
+                    | ParseState_ParentRecordSelfPos.AwaitingKey -> ()
+                    | ParseState_ParentRecordSelfPos.AwaitingValue key ->
+                        if setFlagValue key then
+                            ()
+                        else
+                            sprintf
+                                "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
+                                key
+                            |> ArgParser_errors.Add
+
+                    arg_2.AddRange (rest |> Seq.map (fun x -> System.Boolean.Parse x))
                 | arg :: args ->
                     match state with
                     | ParseState_ParentRecordSelfPos.AwaitingKey ->
@@ -2457,7 +2565,19 @@ module ChoicePositionalsArgParse =
                                 "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
                                 key
                             |> ArgParser_errors.Add
-                | "--" :: rest -> arg_0.AddRange (rest |> Seq.map (fun x -> x) |> Seq.map Choice2Of2)
+                | "--" :: rest ->
+                    match state with
+                    | ParseState_ChoicePositionals.AwaitingKey -> ()
+                    | ParseState_ChoicePositionals.AwaitingValue key ->
+                        if setFlagValue key then
+                            ()
+                        else
+                            sprintf
+                                "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
+                                key
+                            |> ArgParser_errors.Add
+
+                    arg_0.AddRange (rest |> Seq.map (fun x -> x) |> Seq.map Choice2Of2)
                 | arg :: args ->
                     match state with
                     | ParseState_ChoicePositionals.AwaitingKey ->
@@ -2606,7 +2726,19 @@ module ContainsBoolEnvVarArgParse =
                                 "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
                                 key
                             |> ArgParser_errors.Add
-                | "--" :: rest -> parser_LeftoverArgs.AddRange (rest |> Seq.map (fun x -> x))
+                | "--" :: rest ->
+                    match state with
+                    | ParseState_ContainsBoolEnvVar.AwaitingKey -> ()
+                    | ParseState_ContainsBoolEnvVar.AwaitingValue key ->
+                        if setFlagValue key then
+                            ()
+                        else
+                            sprintf
+                                "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
+                                key
+                            |> ArgParser_errors.Add
+
+                    parser_LeftoverArgs.AddRange (rest |> Seq.map (fun x -> x))
                 | arg :: args ->
                     match state with
                     | ParseState_ContainsBoolEnvVar.AwaitingKey ->
@@ -2792,7 +2924,19 @@ module WithFlagDuArgParse =
                                 "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
                                 key
                             |> ArgParser_errors.Add
-                | "--" :: rest -> parser_LeftoverArgs.AddRange (rest |> Seq.map (fun x -> x))
+                | "--" :: rest ->
+                    match state with
+                    | ParseState_WithFlagDu.AwaitingKey -> ()
+                    | ParseState_WithFlagDu.AwaitingValue key ->
+                        if setFlagValue key then
+                            ()
+                        else
+                            sprintf
+                                "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
+                                key
+                            |> ArgParser_errors.Add
+
+                    parser_LeftoverArgs.AddRange (rest |> Seq.map (fun x -> x))
                 | arg :: args ->
                     match state with
                     | ParseState_WithFlagDu.AwaitingKey ->
@@ -2975,7 +3119,19 @@ module ContainsFlagEnvVarArgParse =
                                 "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
                                 key
                             |> ArgParser_errors.Add
-                | "--" :: rest -> parser_LeftoverArgs.AddRange (rest |> Seq.map (fun x -> x))
+                | "--" :: rest ->
+                    match state with
+                    | ParseState_ContainsFlagEnvVar.AwaitingKey -> ()
+                    | ParseState_ContainsFlagEnvVar.AwaitingValue key ->
+                        if setFlagValue key then
+                            ()
+                        else
+                            sprintf
+                                "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
+                                key
+                            |> ArgParser_errors.Add
+
+                    parser_LeftoverArgs.AddRange (rest |> Seq.map (fun x -> x))
                 | arg :: args ->
                     match state with
                     | ParseState_ContainsFlagEnvVar.AwaitingKey ->
@@ -3187,7 +3343,19 @@ module ContainsFlagDefaultValueArgParse =
                                 "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
                                 key
                             |> ArgParser_errors.Add
-                | "--" :: rest -> parser_LeftoverArgs.AddRange (rest |> Seq.map (fun x -> x))
+                | "--" :: rest ->
+                    match state with
+                    | ParseState_ContainsFlagDefaultValue.AwaitingKey -> ()
+                    | ParseState_ContainsFlagDefaultValue.AwaitingValue key ->
+                        if setFlagValue key then
+                            ()
+                        else
+                            sprintf
+                                "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
+                                key
+                            |> ArgParser_errors.Add
+
+                    parser_LeftoverArgs.AddRange (rest |> Seq.map (fun x -> x))
                 | arg :: args ->
                     match state with
                     | ParseState_ContainsFlagDefaultValue.AwaitingKey ->
@@ -3434,7 +3602,19 @@ module ManyLongFormsArgParse =
                                 "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
                                 key
                             |> ArgParser_errors.Add
-                | "--" :: rest -> parser_LeftoverArgs.AddRange (rest |> Seq.map (fun x -> x))
+                | "--" :: rest ->
+                    match state with
+                    | ParseState_ManyLongForms.AwaitingKey -> ()
+                    | ParseState_ManyLongForms.AwaitingValue key ->
+                        if setFlagValue key then
+                            ()
+                        else
+                            sprintf
+                                "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
+                                key
+                            |> ArgParser_errors.Add
+
+                    parser_LeftoverArgs.AddRange (rest |> Seq.map (fun x -> x))
                 | arg :: args ->
                     match state with
                     | ParseState_ManyLongForms.AwaitingKey ->
@@ -3614,7 +3794,19 @@ module FlagsIntoPositionalArgsArgParse =
                                 "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
                                 key
                             |> ArgParser_errors.Add
-                | "--" :: rest -> arg_1.AddRange (rest |> Seq.map (fun x -> x))
+                | "--" :: rest ->
+                    match state with
+                    | ParseState_FlagsIntoPositionalArgs.AwaitingKey -> ()
+                    | ParseState_FlagsIntoPositionalArgs.AwaitingValue key ->
+                        if setFlagValue key then
+                            ()
+                        else
+                            sprintf
+                                "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
+                                key
+                            |> ArgParser_errors.Add
+
+                    arg_1.AddRange (rest |> Seq.map (fun x -> x))
                 | arg :: args ->
                     match state with
                     | ParseState_FlagsIntoPositionalArgs.AwaitingKey ->
@@ -3778,7 +3970,19 @@ module FlagsIntoPositionalArgsChoiceArgParse =
                                 "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
                                 key
                             |> ArgParser_errors.Add
-                | "--" :: rest -> arg_1.AddRange (rest |> Seq.map (fun x -> x) |> Seq.map Choice2Of2)
+                | "--" :: rest ->
+                    match state with
+                    | ParseState_FlagsIntoPositionalArgsChoice.AwaitingKey -> ()
+                    | ParseState_FlagsIntoPositionalArgsChoice.AwaitingValue key ->
+                        if setFlagValue key then
+                            ()
+                        else
+                            sprintf
+                                "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
+                                key
+                            |> ArgParser_errors.Add
+
+                    arg_1.AddRange (rest |> Seq.map (fun x -> x) |> Seq.map Choice2Of2)
                 | arg :: args ->
                     match state with
                     | ParseState_FlagsIntoPositionalArgsChoice.AwaitingKey ->
@@ -3942,7 +4146,19 @@ module FlagsIntoPositionalArgsIntArgParse =
                                 "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
                                 key
                             |> ArgParser_errors.Add
-                | "--" :: rest -> arg_1.AddRange (rest |> Seq.map (fun x -> System.Int32.Parse x))
+                | "--" :: rest ->
+                    match state with
+                    | ParseState_FlagsIntoPositionalArgsInt.AwaitingKey -> ()
+                    | ParseState_FlagsIntoPositionalArgsInt.AwaitingValue key ->
+                        if setFlagValue key then
+                            ()
+                        else
+                            sprintf
+                                "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
+                                key
+                            |> ArgParser_errors.Add
+
+                    arg_1.AddRange (rest |> Seq.map (fun x -> System.Int32.Parse x))
                 | arg :: args ->
                     match state with
                     | ParseState_FlagsIntoPositionalArgsInt.AwaitingKey ->
@@ -4106,7 +4322,19 @@ module FlagsIntoPositionalArgsIntChoiceArgParse =
                                 "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
                                 key
                             |> ArgParser_errors.Add
-                | "--" :: rest -> arg_1.AddRange (rest |> Seq.map (fun x -> System.Int32.Parse x) |> Seq.map Choice2Of2)
+                | "--" :: rest ->
+                    match state with
+                    | ParseState_FlagsIntoPositionalArgsIntChoice.AwaitingKey -> ()
+                    | ParseState_FlagsIntoPositionalArgsIntChoice.AwaitingValue key ->
+                        if setFlagValue key then
+                            ()
+                        else
+                            sprintf
+                                "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
+                                key
+                            |> ArgParser_errors.Add
+
+                    arg_1.AddRange (rest |> Seq.map (fun x -> System.Int32.Parse x) |> Seq.map Choice2Of2)
                 | arg :: args ->
                     match state with
                     | ParseState_FlagsIntoPositionalArgsIntChoice.AwaitingKey ->
@@ -4270,7 +4498,19 @@ module FlagsIntoPositionalArgs'ArgParse =
                                 "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
                                 key
                             |> ArgParser_errors.Add
-                | "--" :: rest -> arg_1.AddRange (rest |> Seq.map (fun x -> x))
+                | "--" :: rest ->
+                    match state with
+                    | ParseState_FlagsIntoPositionalArgs'.AwaitingKey -> ()
+                    | ParseState_FlagsIntoPositionalArgs'.AwaitingValue key ->
+                        if setFlagValue key then
+                            ()
+                        else
+                            sprintf
+                                "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
+                                key
+                            |> ArgParser_errors.Add
+
+                    arg_1.AddRange (rest |> Seq.map (fun x -> x))
                 | arg :: args ->
                     match state with
                     | ParseState_FlagsIntoPositionalArgs'.AwaitingKey ->
@@ -4473,7 +4713,19 @@ module WithTypeHelp =
                             "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
                             key
                         |> ArgParser_errors.Add
-            | "--" :: rest -> parser_LeftoverArgs.AddRange (rest |> Seq.map (fun x -> x))
+            | "--" :: rest ->
+                match state with
+                | ParseState_WithTypeHelp.AwaitingKey -> ()
+                | ParseState_WithTypeHelp.AwaitingValue key ->
+                    if setFlagValue key then
+                        ()
+                    else
+                        sprintf
+                            "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
+                            key
+                        |> ArgParser_errors.Add
+
+                parser_LeftoverArgs.AddRange (rest |> Seq.map (fun x -> x))
             | arg :: args ->
                 match state with
                 | ParseState_WithTypeHelp.AwaitingKey ->
@@ -4690,7 +4942,19 @@ You can use this to provide detailed documentation for your argument parser."
                             "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
                             key
                         |> ArgParser_errors.Add
-            | "--" :: rest -> parser_LeftoverArgs.AddRange (rest |> Seq.map (fun x -> x))
+            | "--" :: rest ->
+                match state with
+                | ParseState_WithMultilineTypeHelp.AwaitingKey -> ()
+                | ParseState_WithMultilineTypeHelp.AwaitingValue key ->
+                    if setFlagValue key then
+                        ()
+                    else
+                        sprintf
+                            "Trailing argument %s had no value. Use a double-dash to separate positional args from key-value args."
+                            key
+                        |> ArgParser_errors.Add
+
+                parser_LeftoverArgs.AddRange (rest |> Seq.map (fun x -> x))
             | arg :: args ->
                 match state with
                 | ParseState_WithMultilineTypeHelp.AwaitingKey ->

--- a/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParser.fs
+++ b/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParser.fs
@@ -466,6 +466,44 @@ Required argument '--exact' received no value"""
                 BoolVar = Choice1Of2 true
             }
 
+    [<Test>]
+    let ``Trailing double-dash does not discard pending arity-0 flag`` () =
+        // Regression test: a bare `--` was being handled before the parser examined its pending state,
+        // so the pending `--bool-var` flag was silently discarded and the env-var default won.
+        // The `--bool-var` should be treated as an arity-0 flag exactly as if input had ended.
+        ContainsBoolEnvVar.parse' (fun _ -> Some "false") [ "--bool-var" ; "--" ]
+        |> shouldEqual
+            {
+                BoolVar = Choice1Of2 true
+            }
+
+    [<Test>]
+    let ``A bare trailing double-dash is equivalent to end of input`` () =
+        // A `--` with nothing after it introduces no positional args, so appending one to a
+        // dash-free argument list must not change the parse outcome, whatever pending state we're in.
+        let getEnvVar (_ : string) = Some "false"
+
+        let outcome (args : string list) =
+            try
+                Ok (ContainsBoolEnvVar.parse' getEnvVar args)
+            with e ->
+                Error e.Message
+
+        let tokenOf (i : int) =
+            match ((i % 5) + 5) % 5 with
+            | 0 -> "--bool-var"
+            | 1 -> "true"
+            | 2 -> "false"
+            | 3 -> "--bool-var=true"
+            | _ -> "--bool-var=false"
+
+        let property (choices : int list) =
+            // None of these tokens is itself "--", so appending a trailing "--" adds no positional args.
+            let tokens = choices |> List.map tokenOf
+            outcome tokens = outcome (tokens @ [ "--" ])
+
+        Check.QuickThrowOnFailure property
+
     [<TestCaseSource(nameof boolCases)>]
     let ``Flag DUs can be parsed from env var`` (envValue : string, boolValue : bool) =
         let getEnvVar (s : string) =
@@ -639,6 +677,25 @@ Required argument '--exact' received no value"""
                 A = "--b=false"
                 GrabEverything = [ "--c" ; "hi" ; "--help" ]
             }
+
+    [<Test>]
+    let ``Trailing double-dash does not silently drop a pending unknown key`` () =
+        // Regression test: previously `--unknown --` silently dropped `--unknown` because the `--`
+        // was handled before the parser examined its pending `AwaitingValue` state. A pending key
+        // with no value is now resolved exactly as if input had ended: it's not an arity-0 flag, so
+        // this is the "trailing argument had no value" error rather than a silent success.
+        let getEnvVar (_ : string) = failwith "do not call"
+
+        let exc =
+            Assert.Throws<exn> (fun () ->
+                FlagsIntoPositionalArgs.parse' getEnvVar [ "--a=present" ; "--unknown" ; "--" ]
+                |> ignore<FlagsIntoPositionalArgs>
+            )
+
+        exc.Message
+        |> shouldEqual
+            """Errors during parse!
+Trailing argument --unknown had no value. Use a double-dash to separate positional args from key-value args."""
 
     [<Test>]
     let ``Can collect non-help args into positional args with Choice`` () =

--- a/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
+++ b/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
@@ -1512,50 +1512,56 @@ module internal ArgParserGenerator =
                 )
                 |> SynExpr.applyTo (SynExpr.createIdent "key")
 
+            // Resolve any pending parser state when no (further) value is available for the current key.
+            // This fires both at end-of-input and immediately before a `--` separator: in either case the
+            // key we're `AwaitingValue` for got no value, so it must be an arity-0 flag or it's an error.
+            let resolvePendingState =
+                SynExpr.createMatch
+                    (SynExpr.createIdent "state")
+                    [
+                        SynMatchClause.create
+                            (SynPat.identWithArgs [ parseState ; Ident.create "AwaitingKey" ] (SynArgPats.create []))
+                            (SynExpr.CreateConst ())
+                        SynMatchClause.create
+                            (SynPat.identWithArgs
+                                [ parseState ; Ident.create "AwaitingValue" ]
+                                (SynArgPats.createNamed [ "key" ]))
+                            (SynExpr.ifThenElse
+                                (SynExpr.applyFunction (SynExpr.createIdent "setFlagValue") (SynExpr.createIdent "key"))
+                                (trailingArgMessage
+                                 |> SynExpr.pipeThroughFunction (SynExpr.dotGet "Add" (SynExpr.createIdent' errorAcc)))
+                                (SynExpr.CreateConst ()))
+                    ]
+
+            // `parser_LeftoverArgs.AddRange (rest |> Seq.map ...)`: everything after a `--` is positional.
+            let addRestToLeftovers =
+                SynExpr.callMethodArg
+                    "AddRange"
+                    (SynExpr.paren (
+                        SynExpr.createIdent "rest"
+                        |> SynExpr.pipeThroughFunction (
+                            SynExpr.applyFunction (SynExpr.createLongIdent [ "Seq" ; "map" ]) leftoverArgParser
+                        )
+                        |> fun p ->
+                            match leftoverArgAcc with
+                            | ChoicePositional.Normal _ -> p
+                            | ChoicePositional.Choice _ ->
+                                p
+                                |> SynExpr.pipeThroughFunction (
+                                    SynExpr.applyFunction
+                                        (SynExpr.createLongIdent [ "Seq" ; "map" ])
+                                        (SynExpr.createIdent "Choice2Of2")
+                                )
+                    ))
+                    (SynExpr.createIdent' leftoverArgs)
+
             [
-                SynMatchClause.create
-                    SynPat.emptyList
-                    (SynExpr.createMatch
-                        (SynExpr.createIdent "state")
-                        [
-                            SynMatchClause.create
-                                (SynPat.identWithArgs [ parseState ; Ident.create "AwaitingKey" ] (SynArgPats.create []))
-                                (SynExpr.CreateConst ())
-                            SynMatchClause.create
-                                (SynPat.identWithArgs
-                                    [ parseState ; Ident.create "AwaitingValue" ]
-                                    (SynArgPats.createNamed [ "key" ]))
-                                (SynExpr.ifThenElse
-                                    (SynExpr.applyFunction
-                                        (SynExpr.createIdent "setFlagValue")
-                                        (SynExpr.createIdent "key"))
-                                    (trailingArgMessage
-                                     |> SynExpr.pipeThroughFunction (
-                                         SynExpr.dotGet "Add" (SynExpr.createIdent' errorAcc)
-                                     ))
-                                    (SynExpr.CreateConst ()))
-                        ])
+                SynMatchClause.create SynPat.emptyList resolvePendingState
                 SynMatchClause.create
                     (SynPat.listCons (SynPat.createConst (SynConst.Create "--")) (SynPat.named "rest"))
-                    (SynExpr.callMethodArg
-                        "AddRange"
-                        (SynExpr.paren (
-                            SynExpr.createIdent "rest"
-                            |> SynExpr.pipeThroughFunction (
-                                SynExpr.applyFunction (SynExpr.createLongIdent [ "Seq" ; "map" ]) leftoverArgParser
-                            )
-                            |> fun p ->
-                                match leftoverArgAcc with
-                                | ChoicePositional.Normal _ -> p
-                                | ChoicePositional.Choice _ ->
-                                    p
-                                    |> SynExpr.pipeThroughFunction (
-                                        SynExpr.applyFunction
-                                            (SynExpr.createLongIdent [ "Seq" ; "map" ])
-                                            (SynExpr.createIdent "Choice2Of2")
-                                    )
-                        ))
-                        (SynExpr.createIdent' leftoverArgs))
+                    // Resolve the pending key first (a `--` must not silently discard it), *then* treat the
+                    // remainder as positional args.
+                    (SynExpr.sequential [ resolvePendingState ; addRestToLeftovers ])
                 SynMatchClause.create (SynPat.listCons (SynPat.named "arg") (SynPat.named "args")) argBody
             ]
             |> SynExpr.createMatch (SynExpr.createIdent "args")


### PR DESCRIPTION
## Problem

The generated parser's `--` separator clause pattern-matched the token list before examining the `AwaitingKey`/`AwaitingValue` state, so a key still awaiting its value was silently discarded when a `--` followed:

- `--bool-var --` (where `BoolVar` has an env-var default) returned the env default instead of treating `--bool-var` as an arity-0 flag set to `true`.
- Under `[<PositionalArgs true>]`, `--unknown --` silently dropped `--unknown` and parsed successfully.

## Fix

On encountering `--`, resolve the pending state exactly as at end-of-input, *then* treat the remainder as positional: a bool-like key is set as an arity-0 flag; any other pending key becomes the existing "Trailing argument ... had no value" error.

Note the deliberate behaviour change: `--unknown --` under `PositionalArgs true` now fails with "trailing argument had no value" (consistent with `--unknown` at end-of-input) instead of silently succeeding.

## Tests

- Regression test: `--bool-var --` with an env default now yields `Choice1Of2 true`.
- Regression test: pending unknown key before `--` errors instead of vanishing.
- FsCheck property: appending a trailing `--` to a token list containing no `--` never changes the parse outcome.

This is the first of a stack of PRs working towards the arg-parser rewrite (type-erased core + DU/sum support).

🤖 Generated with [Claude Code](https://claude.com/claude-code)