### PR TITLE
Harden ambient type-reference resolution in the ArgParser generator

### DIFF
--- a/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
+++ b/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
@@ -424,16 +424,19 @@ module internal ArgParserGenerator =
 
         result.ToString().TrimStart '-'
 
-    let private identifyAsFlag (flagDus : FlagDu list) (ty : SynType) : FlagDu option =
-        match ty with
-        | SynType.LongIdent (SynLongIdent.SynLongIdent (ident, _, _)) ->
-            flagDus
-            |> List.tryPick (fun du ->
-                let duName = du.Name.idText
-                let ident = List.last(ident).idText
-                if duName = ident then Some du else None
-            )
+    /// A type defined alongside the tagged type is referred to by its bare name, so only a
+    /// single-segment reference (possibly parenthesized) may resolve to a local type. Matching
+    /// anything less than the complete reference would let e.g. a local union named `Uri`
+    /// capture a field of the foreign type `System.Uri`.
+    let private localTypeName (ty : SynType) : string option =
+        match SynType.stripOptionalParen ty with
+        | SynType.LongIdent (SynLongIdent.SynLongIdent ([ ident ], _, _)) -> Some ident.idText
         | _ -> None
+
+    let private identifyAsFlag (flagDus : FlagDu list) (ty : SynType) : FlagDu option =
+        match localTypeName ty with
+        | Some name -> flagDus |> List.tryFind (fun du -> du.Name.idText = name)
+        | None -> None
 
     /// Builds a function or lambda of one string argument, which returns a `ty` (as modified by the `Accumulation`;
     /// for example, maybe it returns a `ty option` or a `ty list`).
@@ -631,13 +634,30 @@ module internal ArgParserGenerator =
 
                 parser, Accumulation.Required, ty
 
+    /// An argument schema must be a finite tree: a record which refers to itself, even
+    /// indirectly, would expand forever. `ancestors` is the chain of type names currently being
+    /// lowered, innermost first; re-entry into any of them is a cycle, which we reject rather
+    /// than dying with a stack overflow. (Names are the bare idText, matching the by-name lookup
+    /// which resolves ambient type references.)
+    let private pushSchemaType (ancestors : string list) (name : Ident) : string list =
+        if ancestors |> List.contains name.idText then
+            let path = name.idText :: ancestors |> List.rev |> String.concat " -> "
+
+            failwith
+                $"The [<ArgParser>] schema is recursive: %s{path}. Argument records and unions may not contain themselves, even indirectly."
+
+        name.idText :: ancestors
+
     let rec private toParseSpec
+        (ancestors : string list)
         (counter : int)
         (flagDus : FlagDu list)
         (ambientRecords : RecordType list)
         (finalRecord : RecordType)
         : ParseTreeCrate * int
         =
+        let ancestors = pushSchemaType ancestors finalRecord.Name
+
         finalRecord.Fields
         |> List.iter (fun (SynField.SynField (isStatic = isStatic)) ->
             if isStatic then
@@ -714,16 +734,14 @@ module internal ArgParserGenerator =
                         | l -> List.ofSeq l
 
                 let ambientRecordMatch =
-                    match fieldType with
-                    | SynType.LongIdent (SynLongIdent.SynLongIdent (id, _, _)) ->
-                        let target = List.last(id).idText
-                        ambientRecords |> List.tryFind (fun r -> r.Name.idText = target)
-                    | _ -> None
+                    match localTypeName fieldType with
+                    | Some target -> ambientRecords |> List.tryFind (fun r -> r.Name.idText = target)
+                    | None -> None
 
                 match ambientRecordMatch with
                 | Some ambient ->
                     // This field has a type we need to obtain from parsing another record.
-                    let spec, counter = toParseSpec counter flagDus ambientRecords ambient
+                    let spec, counter = toParseSpec ancestors counter flagDus ambientRecords ambient
                     counter, (ident, spec) :: acc
                 | None ->
 
@@ -998,7 +1016,7 @@ module internal ArgParserGenerator =
         (recordType : RecordType)
         : SynExpr
         =
-        let spec, _ = toParseSpec 0 flagDus ambientRecords recordType
+        let spec, _ = toParseSpec [] 0 flagDus ambientRecords recordType
         // For each argument (positional and non-positional), create an accumulator for it.
         let nonPos, pos =
             { new ParseTreeEval<_> with

--- a/WoofWare.Myriad.Plugins/Test/TestArgParserRejection.fs
+++ b/WoofWare.Myriad.Plugins/Test/TestArgParserRejection.fs
@@ -354,3 +354,138 @@ type NoConflict =
 
         // One namespace for the embedded runtime module, one for the generated parser module.
         List.length modules |> shouldEqual 2
+
+    // ------------------------------------------------------------------------------------------
+    // Qualified type references. A type defined alongside the tagged type is referred to by its
+    // bare name; resolving ambient references by *last segment* instead of by the complete
+    // reference would let a local type capture a qualified reference to a foreign type (e.g.
+    // `System.Uri` alongside a local type named `Uri`), silently generating code which does not
+    // compile.
+
+    let private renderOrFail (modules : SynModuleOrNamespace list) : string =
+        match Ast.render modules with
+        | Some rendered -> rendered
+        | None -> failwith "expected the generated modules to render"
+
+    [<Test>]
+    let ``A qualified reference is not captured by a local record with the same last segment`` () =
+        // `Address : System.Uri` names the BCL type, parsed by the built-in Uri leaf parser. If
+        // the local record `Uri` captured it, the generated parser would recurse into that record
+        // and construct `{ Foo = ... }` where a `System.Uri` is required.
+        let rendered =
+            generateFromSource
+                """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+type Uri =
+    {
+        Foo : int
+    }
+
+[<ArgParser>]
+type TopLevel =
+    {
+        Address : System.Uri
+    }
+"""
+            |> renderOrFail
+
+        rendered.Contains "Foo" |> shouldEqual false
+        rendered.Contains "System.Uri" |> shouldEqual true
+
+    [<Test>]
+    let ``A qualified reference is not captured by a local flag DU with the same last segment`` () =
+        // `External.Enabled` is some foreign type the generator cannot parse; treating it as the
+        // local flag DU `Enabled` would emit `Enabled.On`/`Enabled.Off` into an
+        // `External.Enabled` field. Rejection is the correct outcome.
+        let exc =
+            Assert.Throws<exn> (fun () ->
+                generateFromSource
+                    """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+type Enabled =
+    | [<ArgumentFlag true>] On
+    | [<ArgumentFlag false>] Off
+
+[<ArgParser>]
+type FlagClash =
+    {
+        Mode : External.Enabled
+    }
+"""
+                |> ignore<SynModuleOrNamespace list>
+            )
+
+        exc.Message.Contains "Could not decide how to parse" |> shouldEqual true
+
+    [<Test>]
+    let ``Parenthesized ambient record references are accepted wherever bare ones are`` () =
+        // FCS represents `Child : (ChildRecord)` as SynType.Paren; the by-name lookup for a
+        // record-typed field must see through it.
+        let modules =
+            generateFromSource
+                """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+type ChildRecord =
+    {
+        Thing : int
+    }
+
+[<ArgParser>]
+type ParentRecord =
+    {
+        Child : (ChildRecord)
+        AndAnother : bool
+    }
+"""
+
+        List.length modules |> shouldEqual 2
+
+    // ------------------------------------------------------------------------------------------
+    // Recursive schemas. An argument schema must be a finite tree: a record which refers to
+    // itself, even indirectly, would expand forever. Without an explicit check the generator
+    // recurses until the process dies with a stack overflow instead of producing a comprehensible
+    // error.
+
+    [<Test>]
+    let ``A record which contains itself is rejected`` () =
+        """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+[<ArgParser>]
+type SelfRef =
+    {
+        Value : int
+        Nested : SelfRef
+    }
+"""
+        |> shouldRejectWith
+            "The [<ArgParser>] schema is recursive: SelfRef -> SelfRef. Argument records and unions may not contain themselves, even indirectly."
+
+    [<Test>]
+    let ``Mutually recursive records are rejected`` () =
+        """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+type Inner =
+    {
+        A : int
+        Outer : OuterRef
+    }
+
+[<ArgParser>]
+type OuterRef =
+    {
+        B : int
+        Inner : Inner
+    }
+"""
+        |> shouldRejectWith
+            "The [<ArgParser>] schema is recursive: OuterRef -> Inner -> OuterRef. Argument records and unions may not contain themselves, even indirectly."


### PR DESCRIPTION
Two independent ArgParser generation bugs, extracted from the discriminated-union branch because they exist on `main` today and are unrelated to DU support.

## Bugs fixed

**1. Ambient references resolved by last segment.** Ambient record and flag-DU references were matched by the *last segment* of the reference, so a qualified reference to a foreign type whose last segment matched a local type — e.g. `System.Uri` alongside a local record or flag DU named `Uri` — was silently captured by the local type, generating code that does not compile. Local types are only ever referred to by bare name, so resolution now requires the complete (single-segment) reference via a new `localTypeName` helper. Seeing through `SynType.Paren` at the same time makes a parenthesized reference like `Child : (ChildRecord)` resolve where before it did not.

**2. Stack overflow on recursive schemas.** `toParseSpec` descended into ambient records by name with no memory of what it was already expanding, so a record which refers to itself (directly or mutually) recursed until the Myriad subprocess died with a stack overflow. The chain of types currently being lowered is now threaded through the recursion, failing with the cycle path on re-entry.

## Tests

Five regression tests drive the full generator over in-memory source:

- qualified reference not captured by a local record of the same last segment
- qualified reference not captured by a local flag DU of the same last segment
- parenthesized ambient record reference accepted
- self-referential record rejected
- mutually recursive records rejected

Each was confirmed to fail without the corresponding generator fix (the recursion cases crash the host with a stack overflow; the rest fail cleanly).

## No collateral

The regenerated `ConsumePlugin` ArgParser outputs are byte-identical after formatting, so the change is inert for every existing input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)