### PR TITLE
ArgParser: reject default attributes on non-Choice fields at generation time

### DIFF
--- a/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
+++ b/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
@@ -914,6 +914,33 @@ module internal ArgParserGenerator =
                         | [] -> List.singleton (SynExpr.CreateConst (argify ident))
                         | l -> List.ofSeq l
 
+                // A default-value attribute is only meaningful on a `Choice<'a, 'a>` field: a
+                // successful parse reports whether the value was user-supplied (Choice1Of2) or
+                // defaulted (Choice2Of2). The Choice-parsing path is the sole place these
+                // attributes are read, so on any other field they would be silently dropped,
+                // leaving the field required. Reject them here rather than emitting a parser in
+                // which the attribute has no effect.
+                let hasDefaultAttr =
+                    attrs
+                    |> List.exists (fun attr ->
+                        match (List.last attr.TypeName.LongIdent).idText with
+                        | "ArgumentDefaultFunction"
+                        | "ArgumentDefaultFunctionAttribute"
+                        | "ArgumentDefaultEnvironmentVariable"
+                        | "ArgumentDefaultEnvironmentVariableAttribute" -> true
+                        | _ -> false
+                    )
+
+                if hasDefaultAttr then
+                    match positionalArgAttr, fieldType with
+                    | Some _, _ ->
+                        failwith
+                            $"Field '%s{ident.idText}' is positional, so it cannot carry a default-value attribute ([<ArgumentDefaultFunction>] or [<ArgumentDefaultEnvironmentVariable>]): positional args are collected, not defaulted."
+                    | None, ChoiceType _ -> ()
+                    | None, _ ->
+                        failwith
+                            $"Field '%s{ident.idText}' has a default-value attribute ([<ArgumentDefaultFunction>] or [<ArgumentDefaultEnvironmentVariable>]), but its type is not Choice<'a, 'a>. Defaults are surfaced through Choice<'a, 'a> so a successful parse can report whether a value was user-supplied (Choice1Of2) or defaulted (Choice2Of2); a bare field cannot express this. Change the field's type to Choice<'a, 'a>, or remove the attribute."
+
                 let ambientRecordMatch =
                     match localTypeName fieldType with
                     | Some target -> ambientRecords |> List.tryFind (fun r -> r.Name.idText = target)
@@ -945,12 +972,9 @@ module internal ArgParserGenerator =
 
                 match positionalArgAttr with
                 | Some includeFlagLike ->
-                    let getChoice (spec : ArgumentDefaultSpec option) : unit =
-                        match spec with
-                        | Some _ ->
-                            failwith
-                                "Positional Choice args cannot have default values. Remove [<ArgumentDefault*>] from the positional arg."
-                        | None -> ()
+                    // Positional fields carrying a default attribute are rejected above, so the
+                    // Choice-parsing path only ever reaches this callback with `None`.
+                    let getChoice (_ : ArgumentDefaultSpec option) : unit = ()
 
                     let parser, accumulation, parseTy =
                         createParseFunction<unit> getChoice flagDus finalRecord.Name ident attrs fieldType

--- a/WoofWare.Myriad.Plugins/Test/TestArgParserRejection.fs
+++ b/WoofWare.Myriad.Plugins/Test/TestArgParserRejection.fs
@@ -851,3 +851,111 @@ type DuArgs =
 
         // One namespace for the embedded runtime module, one for the generated parser module.
         List.length modules |> shouldEqual 2
+
+    // ------------------------------------------------------------------------------------------
+    // Default-value attributes. `[<ArgumentDefaultFunction>]` and
+    // `[<ArgumentDefaultEnvironmentVariable>]` are only meaningful on a `Choice<'a, 'a>` field: a
+    // successful parse reports whether the value was user-supplied (Choice1Of2) or defaulted
+    // (Choice2Of2). On a bare (non-Choice) field the default cannot be surfaced, so honouring it
+    // silently would defeat the point; the generator used to accept the attribute and drop it,
+    // leaving the field required. It must be rejected at generation time instead.
+
+    [<Test>]
+    let ``ArgumentDefaultFunction on a bare flag DU field is rejected`` () =
+        // The motivating repro from the issue: DryRun is a flag DU, not Choice<DryRunMode, DryRunMode>.
+        """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+type DryRunMode =
+    | [<ArgumentFlag false>] Wet
+    | [<ArgumentFlag true>] Dry
+
+[<ArgParser>]
+type BareFlagDefault =
+    {
+        [<ArgumentDefaultFunction>]
+        DryRun : DryRunMode
+    }
+"""
+        |> shouldRejectWith
+            "Field 'DryRun' has a default-value attribute ([<ArgumentDefaultFunction>] or [<ArgumentDefaultEnvironmentVariable>]), but its type is not Choice<'a, 'a>. Defaults are surfaced through Choice<'a, 'a> so a successful parse can report whether a value was user-supplied (Choice1Of2) or defaulted (Choice2Of2); a bare field cannot express this. Change the field's type to Choice<'a, 'a>, or remove the attribute."
+
+    [<Test>]
+    let ``ArgumentDefaultEnvironmentVariable on a bare scalar field is rejected`` () =
+        // The sibling default attribute shares the gap.
+        """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+[<ArgParser>]
+type BareScalarDefault =
+    {
+        [<ArgumentDefaultEnvironmentVariable "MY_ENV_VAR">]
+        Count : int
+    }
+"""
+        |> shouldRejectWith
+            "Field 'Count' has a default-value attribute ([<ArgumentDefaultFunction>] or [<ArgumentDefaultEnvironmentVariable>]), but its type is not Choice<'a, 'a>. Defaults are surfaced through Choice<'a, 'a> so a successful parse can report whether a value was user-supplied (Choice1Of2) or defaulted (Choice2Of2); a bare field cannot express this. Change the field's type to Choice<'a, 'a>, or remove the attribute."
+
+    [<Test>]
+    let ``A default attribute on a record-typed field is rejected`` () =
+        // Record- and union-typed fields never reach the Choice-parsing path, so the attribute
+        // was dropped silently there too.
+        """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+type ChildRecord =
+    {
+        Thing : int
+    }
+
+[<ArgParser>]
+type ParentRecord =
+    {
+        [<ArgumentDefaultFunction>]
+        Child : ChildRecord
+    }
+"""
+        |> shouldRejectWith
+            "Field 'Child' has a default-value attribute ([<ArgumentDefaultFunction>] or [<ArgumentDefaultEnvironmentVariable>]), but its type is not Choice<'a, 'a>. Defaults are surfaced through Choice<'a, 'a> so a successful parse can report whether a value was user-supplied (Choice1Of2) or defaulted (Choice2Of2); a bare field cannot express this. Change the field's type to Choice<'a, 'a>, or remove the attribute."
+
+    [<Test>]
+    let ``A default attribute on a positional field is rejected`` () =
+        """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+[<ArgParser>]
+type PositionalDefault =
+    {
+        [<PositionalArgs>]
+        [<ArgumentDefaultFunction>]
+        Rest : string list
+    }
+"""
+        |> shouldRejectWith
+            "Field 'Rest' is positional, so it cannot carry a default-value attribute ([<ArgumentDefaultFunction>] or [<ArgumentDefaultEnvironmentVariable>]): positional args are collected, not defaulted."
+
+    [<Test>]
+    let ``A default attribute on a Choice field generates successfully`` () =
+        // The valid form: the generator must still accept it.
+        let modules =
+            generateFromSource
+                """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+[<ArgParser>]
+type WithDefault =
+    {
+        [<ArgumentDefaultFunction>]
+        Count : Choice<int, int>
+    }
+
+    static member DefaultCount () = 4
+"""
+
+        // One namespace for the embedded runtime module, one for the generated parser module.
+        List.length modules |> shouldEqual 2


### PR DESCRIPTION
Fixes #571.

## Problem

`[<ArgumentDefaultFunction>]` and `[<ArgumentDefaultEnvironmentVariable>]` are only ever read inside the `ChoiceType` branch of `createParseFunction`. On any non-`Choice` field the generator accepted them, generated code without complaint, and **silently dropped the default** — the field stayed required at parse time. This is a fail-fast gap: an attribute that cannot be honoured should be rejected at generation time.

Defaults are intentionally surfaced through `Choice<'a, 'a>` so a successful parse can distinguish a user-supplied value (`Choice1Of2`) from a parser-filled default (`Choice2Of2`). A bare field cannot express "was this defaulted?", so honouring the default is impossible — but the generator didn't say so.

## Fix

A syntactic guard in `toParseSpec`'s per-field fold, before the record/union/positional dispatch. If a field carries a default attribute:

- **positional** → rejected (positional args are collected, not defaulted);
- **non-positional, type is `Choice<_,_>`** → accepted, unchanged (an unequal `Choice<int,string>` still hits the pre-existing "prove types equal" error);
- **non-positional, any other type** (scalar, flag DU, record, union) → rejected with a message pointing at the `Choice<'a,'a>` convention.

The now-unreachable positional default-rejection arm inside the positional `getChoice` callback is removed (the guard front-runs it).

## Tests

Five new tests in `TestArgParserRejection.fs`, written first and observed failing before the guard:

1. the issue's exact repro (bare flag DU + `ArgumentDefaultFunction`);
2. sibling attribute on a bare scalar (`ArgumentDefaultEnvironmentVariable`);
3. default on a record-typed field;
4. default on a positional field;
5. positive control — a `Choice<int,int>` field with a default still generates.

## Verification

- New rejection fixture: 38/38 pass (4 were failing before the guard).
- `ConsumePlugin` builds clean — every real `Choice`-typed default field still generates.
- Broader arg-parser consumer suite: 222/222 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)