### PR TITLE
ArgParser: permit a Reject-mode positional sink beside a union

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Notable changes are recorded here.
 
+# WoofWare.Myriad.Plugins 10.2.3
+
+The `ArgParserGenerator` now permits a `[<PositionalArgs>]` field at the top level alongside (though not within) a discriminated-union arg, as long as the positional sink rejects unrecognised flag-like tokens (the default; `[<PositionalArgs true>]` remains banned beside a union, because that would make it very confusing when you typo a DU-case-selecting flag).
+
 # WoofWare.Myriad.Plugins 10.2.1
 
 The `ArgParserGenerator` now ships with (limited) discriminated-union support: you can specify mutually exclusive sets of args and the parser will select the correct set.

--- a/ConsumePlugin/DuArgs.fs
+++ b/ConsumePlugin/DuArgs.fs
@@ -65,3 +65,43 @@ type PlainArgs =
 type DuWithDefaultArgs =
     | Defaulted of DefaultedArgs
     | Plain of PlainArgs
+
+/// A union beside a positional sink (default, i.e. Reject-mode): named arguments select the
+/// union case, and every bare token is routed to the sink whichever case wins. An unrecognised
+/// `--key`-shaped token remains fatal. The sink converts, so selection must not depend on the
+/// tokens' parseability as int.
+[<ArgParser>]
+type ModeAndPositionals =
+    {
+        Mode : Mode
+
+        [<PositionalArgs>]
+        Rest : int list
+    }
+
+type FetchArgs =
+    {
+        Url : string
+    }
+
+type PushArgs =
+    {
+        Remote : string
+        Force : bool
+    }
+
+/// No case is satisfiable with no arguments, so bare positional tokens alone must fail with
+/// "no case selected" rather than picking a fallback.
+type Command =
+    | Fetch of FetchArgs
+    | Push of PushArgs
+
+/// The literal [<PositionalArgs false>] spelling of a Reject-mode sink beside a union.
+[<ArgParser>]
+type CommandAndPositionals =
+    {
+        Command : Command
+
+        [<PositionalArgs false>]
+        Paths : string list
+    }

--- a/ConsumePlugin/GeneratedDuArgs.fs
+++ b/ConsumePlugin/GeneratedDuArgs.fs
@@ -1594,3 +1594,417 @@ module DuWithDefaultArgs =
 
     let parse (args : string list) : DuWithDefaultArgs =
         parse' (System.Environment.GetEnvironmentVariable >> Option.ofObj) args
+namespace ConsumePlugin
+
+open WoofWare.Myriad.Plugins
+
+/// Methods to parse arguments for the type ModeAndPositionals
+[<RequireQualifiedAccess ; CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+module ModeAndPositionals =
+    let parse' (getEnvironmentVariable : string -> string option) (args : string list) : ModeAndPositionals =
+        let helpText () =
+            [
+                "exactly one of the following sets of arguments:"
+                "Auto:"
+                (sprintf "  %s  bool%s%s" (sprintf "--%s" "quiet") " (optional)" "")
+                "Manual:"
+                (sprintf "  %s  int32%s%s" (sprintf "--%s" "level") "" "")
+                (sprintf "%s  int32%s%s" (sprintf "--%s" "rest") " (positional args) (can be repeated)" "")
+            ]
+            |> String.concat "\n"
+
+        let arg_3 : int ResizeArray = ResizeArray ()
+        let mutable arg_1 : bool option = None
+        let mutable arg_2 : int option = None
+
+        let parser_schema : ArgParserRuntime_DuArgs.ErasedSchema =
+            {
+                Leaves =
+                    [
+                        {
+                            Id = 0
+                            Forms = [ "quiet" ]
+                            AcceptsNegation = false
+                            Arity = ArgParserRuntime_DuArgs.ErasedArity.BoolLike
+                            Repeatable = false
+                            Requirement = ArgParserRuntime_DuArgs.ErasedRequirement.Optional
+                            TypeDescription = ""
+                            Help = None
+                        }
+                        {
+                            Id = 1
+                            Forms = [ "level" ]
+                            AcceptsNegation = false
+                            Arity = ArgParserRuntime_DuArgs.ErasedArity.One
+                            Repeatable = false
+                            Requirement = ArgParserRuntime_DuArgs.ErasedRequirement.Required
+                            TypeDescription = ""
+                            Help = None
+                        }
+                    ]
+                Tree =
+                    (ArgParserRuntime_DuArgs.ErasedTree.Product (
+                        [
+                            ArgParserRuntime_DuArgs.ErasedTree.Sum (
+                                (0,
+                                 [
+                                     ("Auto",
+                                      ArgParserRuntime_DuArgs.ErasedTree.Product (
+                                          [ ArgParserRuntime_DuArgs.ErasedTree.Leaf 0 ]
+                                      ))
+                                     ("Manual",
+                                      ArgParserRuntime_DuArgs.ErasedTree.Product (
+                                          [ ArgParserRuntime_DuArgs.ErasedTree.Leaf 1 ]
+                                      ))
+                                 ])
+                            )
+                        ]
+                    ))
+                Positional =
+                    ({
+                        ArgParserRuntime_DuArgs.ErasedPositional.Id = 2
+                        ArgParserRuntime_DuArgs.ErasedPositional.Forms = [ "rest" ]
+                        ArgParserRuntime_DuArgs.ErasedPositional.FlagLike =
+                            ArgParserRuntime_DuArgs.ErasedFlagLikeBehaviour.Reject
+                        ArgParserRuntime_DuArgs.ErasedPositional.TypeDescription = ""
+                        ArgParserRuntime_DuArgs.ErasedPositional.Help = None
+                    })
+                    |> Some
+            }
+
+        let parser_storeOccurrence (occurrence : ArgParserRuntime_DuArgs.ErasedOccurrence) : string option =
+            match occurrence.LeafId with
+            | 0 ->
+                match arg_1 with
+                | Some _ -> None
+                | None ->
+                    match occurrence.Value with
+                    | Some value ->
+                        try
+                            let parsedBool = System.Boolean.Parse value
+                            let parsedBool = if occurrence.Negated then not parsedBool else parsedBool
+                            arg_1 <- Some (parsedBool)
+                            None
+                        with _ as exc ->
+                            (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                    | None ->
+                        arg_1 <- Some ((if occurrence.Negated then false else true))
+                        None
+            | 1 ->
+                match arg_2 with
+                | Some _ -> None
+                | None ->
+                    match occurrence.Value with
+                    | Some value ->
+                        try
+                            arg_2 <- Some (value |> (fun x -> System.Int32.Parse x))
+                            None
+                        with _ as exc ->
+                            (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                    | None ->
+                        failwith
+                            "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
+            | _ -> failwith "WoofWare.Myriad internal error in generated parser: unknown argument id"
+
+        let parser_storePositional (value : string) (afterSeparator : bool) : string option =
+            try
+                arg_3.Add (value |> (fun x -> System.Int32.Parse x))
+                None
+            with _ as exc ->
+                (sprintf "%s (at arg %s)" exc.Message value) |> Some
+
+        let parser_renderStored (leafId : int) : string =
+            match leafId with
+            | 0 ->
+                match arg_1 with
+                | Some x -> x.ToString ()
+                | None -> "<no value>"
+            | 1 ->
+                match arg_2 with
+                | Some x -> x.ToString ()
+                | None -> "<no value>"
+            | _ -> "<no value>"
+
+        let parser_applyDefault (leafId : int) : string option =
+            match leafId with
+            | _ -> failwith "WoofWare.Myriad internal error in generated parser: unknown defaulted argument id"
+
+        let parser_callbacks : ArgParserRuntime_DuArgs.TypedCallbacks =
+            {
+                StoreOccurrence = parser_storeOccurrence
+                StorePositional = parser_storePositional
+                HelpText = helpText
+                RenderStored = parser_renderStored
+                ApplyDefault = parser_applyDefault
+            }
+
+        match
+            ArgParserRuntime_DuArgs.runParse
+                (ArgParserRuntime_DuArgs.WellFormedSchema.checkOrFail parser_schema)
+                parser_callbacks
+                args
+        with
+        | ArgParserRuntime_DuArgs.ParseOutcome.Success parser_selection ->
+            {
+                Mode =
+                    match Map.tryFind 0 parser_selection.Choices with
+                    | Some 0 ->
+                        Mode.Auto (
+                            {
+                                Quiet = arg_1
+                            }
+                        )
+                    | Some 1 ->
+                        Mode.Manual (
+                            {
+                                Level =
+                                    (match arg_2 with
+                                     | Some x -> x
+                                     | None ->
+                                         failwith
+                                             "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
+                            }
+                        )
+                    | _ ->
+                        failwith
+                            "WoofWare.Myriad internal error in generated parser: no case selected despite a successful parse"
+                Rest = (arg_3 |> Seq.toList)
+            }
+        | ArgParserRuntime_DuArgs.ParseOutcome.HelpRequested -> helpText () |> failwithf "Help text requested.\n%s"
+        | ArgParserRuntime_DuArgs.ParseOutcome.Fatal message -> failwith message
+        | ArgParserRuntime_DuArgs.ParseOutcome.Errors errors ->
+            errors |> String.concat "\n" |> failwithf "Errors during parse!\n%s"
+
+    let parse (args : string list) : ModeAndPositionals =
+        parse' (System.Environment.GetEnvironmentVariable >> Option.ofObj) args
+namespace ConsumePlugin
+
+open WoofWare.Myriad.Plugins
+
+/// Methods to parse arguments for the type CommandAndPositionals
+[<RequireQualifiedAccess ; CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+module CommandAndPositionals =
+    let parse' (getEnvironmentVariable : string -> string option) (args : string list) : CommandAndPositionals =
+        let helpText () =
+            [
+                "exactly one of the following sets of arguments:"
+                "Fetch:"
+                (sprintf "  %s  string%s%s" (sprintf "--%s" "url") "" "")
+                "Push:"
+                (sprintf "  %s  string%s%s" (sprintf "--%s" "remote") "" "")
+                (sprintf "  %s  bool%s%s" (sprintf "--%s" "force") "" "")
+                (sprintf "%s  string%s%s" (sprintf "--%s" "paths") " (positional args) (can be repeated)" "")
+            ]
+            |> String.concat "\n"
+
+        let arg_4 : string ResizeArray = ResizeArray ()
+        let mutable arg_1 : string option = None
+        let mutable arg_2 : string option = None
+        let mutable arg_3 : bool option = None
+
+        let parser_schema : ArgParserRuntime_DuArgs.ErasedSchema =
+            {
+                Leaves =
+                    [
+                        {
+                            Id = 0
+                            Forms = [ "url" ]
+                            AcceptsNegation = false
+                            Arity = ArgParserRuntime_DuArgs.ErasedArity.One
+                            Repeatable = false
+                            Requirement = ArgParserRuntime_DuArgs.ErasedRequirement.Required
+                            TypeDescription = ""
+                            Help = None
+                        }
+
+                        {
+                            Id = 1
+                            Forms = [ "remote" ]
+                            AcceptsNegation = false
+                            Arity = ArgParserRuntime_DuArgs.ErasedArity.One
+                            Repeatable = false
+                            Requirement = ArgParserRuntime_DuArgs.ErasedRequirement.Required
+                            TypeDescription = ""
+                            Help = None
+                        }
+                        {
+                            Id = 2
+                            Forms = [ "force" ]
+                            AcceptsNegation = false
+                            Arity = ArgParserRuntime_DuArgs.ErasedArity.BoolLike
+                            Repeatable = false
+                            Requirement = ArgParserRuntime_DuArgs.ErasedRequirement.Required
+                            TypeDescription = ""
+                            Help = None
+                        }
+                    ]
+                Tree =
+                    (ArgParserRuntime_DuArgs.ErasedTree.Product (
+                        [
+                            ArgParserRuntime_DuArgs.ErasedTree.Sum (
+                                (0,
+                                 [
+                                     ("Fetch",
+                                      ArgParserRuntime_DuArgs.ErasedTree.Product (
+                                          [ ArgParserRuntime_DuArgs.ErasedTree.Leaf 0 ]
+                                      ))
+                                     ("Push",
+                                      ArgParserRuntime_DuArgs.ErasedTree.Product (
+                                          [
+                                              ArgParserRuntime_DuArgs.ErasedTree.Leaf 1
+                                              ArgParserRuntime_DuArgs.ErasedTree.Leaf 2
+                                          ]
+                                      ))
+                                 ])
+                            )
+                        ]
+                    ))
+                Positional =
+                    ({
+                        ArgParserRuntime_DuArgs.ErasedPositional.Id = 3
+                        ArgParserRuntime_DuArgs.ErasedPositional.Forms = [ "paths" ]
+                        ArgParserRuntime_DuArgs.ErasedPositional.FlagLike =
+                            (if false then
+                                 ArgParserRuntime_DuArgs.ErasedFlagLikeBehaviour.Collect
+                             else
+                                 ArgParserRuntime_DuArgs.ErasedFlagLikeBehaviour.Reject)
+                        ArgParserRuntime_DuArgs.ErasedPositional.TypeDescription = ""
+                        ArgParserRuntime_DuArgs.ErasedPositional.Help = None
+                    })
+                    |> Some
+            }
+
+        let parser_storeOccurrence (occurrence : ArgParserRuntime_DuArgs.ErasedOccurrence) : string option =
+            match occurrence.LeafId with
+            | 0 ->
+                match arg_1 with
+                | Some _ -> None
+                | None ->
+                    match occurrence.Value with
+                    | Some value ->
+                        try
+                            arg_1 <- Some (value |> (fun x -> x))
+                            None
+                        with _ as exc ->
+                            (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                    | None ->
+                        failwith
+                            "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
+            | 1 ->
+                match arg_2 with
+                | Some _ -> None
+                | None ->
+                    match occurrence.Value with
+                    | Some value ->
+                        try
+                            arg_2 <- Some (value |> (fun x -> x))
+                            None
+                        with _ as exc ->
+                            (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                    | None ->
+                        failwith
+                            "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
+            | 2 ->
+                match arg_3 with
+                | Some _ -> None
+                | None ->
+                    match occurrence.Value with
+                    | Some value ->
+                        try
+                            let parsedBool = System.Boolean.Parse value
+                            let parsedBool = if occurrence.Negated then not parsedBool else parsedBool
+                            arg_3 <- Some (parsedBool)
+                            None
+                        with _ as exc ->
+                            (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                    | None ->
+                        arg_3 <- Some ((if occurrence.Negated then false else true))
+                        None
+            | _ -> failwith "WoofWare.Myriad internal error in generated parser: unknown argument id"
+
+        let parser_storePositional (value : string) (afterSeparator : bool) : string option =
+            try
+                arg_4.Add (value |> (fun x -> x))
+                None
+            with _ as exc ->
+                (sprintf "%s (at arg %s)" exc.Message value) |> Some
+
+        let parser_renderStored (leafId : int) : string =
+            match leafId with
+            | 0 ->
+                match arg_1 with
+                | Some x -> x.ToString ()
+                | None -> "<no value>"
+            | 1 ->
+                match arg_2 with
+                | Some x -> x.ToString ()
+                | None -> "<no value>"
+            | 2 ->
+                match arg_3 with
+                | Some x -> x.ToString ()
+                | None -> "<no value>"
+            | _ -> "<no value>"
+
+        let parser_applyDefault (leafId : int) : string option =
+            match leafId with
+            | _ -> failwith "WoofWare.Myriad internal error in generated parser: unknown defaulted argument id"
+
+        let parser_callbacks : ArgParserRuntime_DuArgs.TypedCallbacks =
+            {
+                StoreOccurrence = parser_storeOccurrence
+                StorePositional = parser_storePositional
+                HelpText = helpText
+                RenderStored = parser_renderStored
+                ApplyDefault = parser_applyDefault
+            }
+
+        match
+            ArgParserRuntime_DuArgs.runParse
+                (ArgParserRuntime_DuArgs.WellFormedSchema.checkOrFail parser_schema)
+                parser_callbacks
+                args
+        with
+        | ArgParserRuntime_DuArgs.ParseOutcome.Success parser_selection ->
+            {
+                Command =
+                    match Map.tryFind 0 parser_selection.Choices with
+                    | Some 0 ->
+                        Command.Fetch (
+                            {
+                                Url =
+                                    (match arg_1 with
+                                     | Some x -> x
+                                     | None ->
+                                         failwith
+                                             "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
+                            }
+                        )
+                    | Some 1 ->
+                        Command.Push (
+                            {
+                                Force =
+                                    (match arg_3 with
+                                     | Some x -> x
+                                     | None ->
+                                         failwith
+                                             "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
+                                Remote =
+                                    (match arg_2 with
+                                     | Some x -> x
+                                     | None ->
+                                         failwith
+                                             "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
+                            }
+                        )
+                    | _ ->
+                        failwith
+                            "WoofWare.Myriad internal error in generated parser: no case selected despite a successful parse"
+                Paths = (arg_4 |> Seq.toList)
+            }
+        | ArgParserRuntime_DuArgs.ParseOutcome.HelpRequested -> helpText () |> failwithf "Help text requested.\n%s"
+        | ArgParserRuntime_DuArgs.ParseOutcome.Fatal message -> failwith message
+        | ArgParserRuntime_DuArgs.ParseOutcome.Errors errors ->
+            errors |> String.concat "\n" |> failwithf "Errors during parse!\n%s"
+
+    let parse (args : string list) : CommandAndPositionals =
+        parse' (System.Environment.GetEnvironmentVariable >> Option.ofObj) args

--- a/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParserDuPositional.fs
+++ b/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParserDuPositional.fs
@@ -1,0 +1,184 @@
+namespace WoofWare.Myriad.Plugins.Test
+
+open NUnit.Framework
+open FsUnitTyped
+open FsCheck
+open ConsumePlugin
+
+/// A discriminated-union argument schema beside a Reject-mode positional sink: named arguments
+/// select the union case, and bare tokens are collected by the sink whichever case wins.
+[<TestFixture>]
+module TestArgParserDuPositional =
+
+    let noEnv (_ : string) : string option = None
+
+    [<Test>]
+    let ``Positionals are collected while named arguments select the case`` () =
+        ModeAndPositionals.parse' noEnv [ "1" ; "--level=3" ; "2" ; "3" ]
+        |> shouldEqual
+            {
+                Mode =
+                    Manual
+                        {
+                            Level = 3
+                        }
+                Rest = [ 1 ; 2 ; 3 ]
+            }
+
+    [<Test>]
+    let ``Positionals after the separator are collected too`` () =
+        ModeAndPositionals.parse' noEnv [ "--quiet=true" ; "1" ; "--" ; "2" ; "3" ]
+        |> shouldEqual
+            {
+                Mode =
+                    Auto
+                        {
+                            Quiet = Some true
+                        }
+                Rest = [ 1 ; 2 ; 3 ]
+            }
+
+    [<Test>]
+    let ``Bare positional tokens do not stop the empty-satisfiable case being the fallback`` () =
+        ModeAndPositionals.parse' noEnv [ "4" ; "5" ]
+        |> shouldEqual
+            {
+                Mode =
+                    Auto
+                        {
+                            Quiet = None
+                        }
+                Rest = [ 4 ; 5 ]
+            }
+
+    [<Test>]
+    let ``The sink's own key routes values to the sink without touching selection`` () =
+        ModeAndPositionals.parse' noEnv [ "--rest=1" ; "--level=2" ; "--rest" ; "3" ]
+        |> shouldEqual
+            {
+                Mode =
+                    Manual
+                        {
+                            Level = 2
+                        }
+                Rest = [ 1 ; 3 ]
+            }
+
+    [<Test>]
+    let ``An unrecognised flag-like token is still fatal`` () =
+        // Reject mode: a typo of a case-selecting argument must be reported, not collected.
+        let exc =
+            Assert.Throws<exn> (fun () ->
+                ModeAndPositionals.parse' noEnv [ "--lvel=3" ; "2" ]
+                |> ignore<ModeAndPositionals>
+            )
+
+        exc.Message
+        |> shouldEqual "Unable to process argument --lvel=3 as key --lvel and value 3"
+
+    [<Test>]
+    let ``Bare positional tokens alone do not select a case`` () =
+        // The tokens are strings, so no conversion can fail: the only error is the missing
+        // selection. (Positional tokens are structurally neutral: they never choose a case.)
+        let exc =
+            Assert.Throws<exn> (fun () ->
+                CommandAndPositionals.parse' noEnv [ "src" ; "docs" ]
+                |> ignore<CommandAndPositionals>
+            )
+
+        exc.Message
+        |> shouldEqual
+            """Errors during parse!
+No arguments were supplied to select one of: Fetch, Push"""
+
+    [<Test>]
+    let ``A literal Reject-mode sink behaves like the default one`` () =
+        CommandAndPositionals.parse' noEnv [ "src" ; "--url=http://example.com" ; "docs" ]
+        |> shouldEqual
+            {
+                Command =
+                    Fetch
+                        {
+                            Url = "http://example.com"
+                        }
+                Paths = [ "src" ; "docs" ]
+            }
+
+    [<Test>]
+    let ``A conversion failure in the sink does not change which case is selected`` () =
+        // "nope" is not an int, but the selected case must still be Manual: the conversion
+        // error is reported without falling back to another alternative.
+        let exc =
+            Assert.Throws<exn> (fun () ->
+                ModeAndPositionals.parse' noEnv [ "--level=3" ; "nope" ]
+                |> ignore<ModeAndPositionals>
+            )
+
+        exc.Message.Contains "nope" |> shouldEqual true
+
+        exc.Message.Contains "Arguments select more than one alternative"
+        |> shouldEqual false
+
+        exc.Message.Contains "No arguments were supplied" |> shouldEqual false
+
+    [<Test>]
+    let ``Help text groups the union's alternatives and lists the sink last`` () =
+        let exc =
+            Assert.Throws<exn> (fun () -> ModeAndPositionals.parse' noEnv [ "--help" ] |> ignore<ModeAndPositionals>)
+
+        exc.Message
+        |> shouldEqual
+            """Help text requested.
+exactly one of the following sets of arguments:
+Auto:
+  --quiet  bool (optional)
+Manual:
+  --level  int32
+--rest  int32 (positional args) (can be repeated)"""
+
+    [<Test>]
+    let ``Adding positional tokens never changes which case is selected`` () =
+        // Insertion points are safe by construction: every named argument uses the --key=value
+        // form, so no bare token can be consumed as a pending key's value.
+        let mutable nonemptyCount = 0
+
+        let property (useManual : bool) (pos0 : int list) (pos1 : int list) (pos2 : int list) (sep : bool) : unit =
+            if not (List.isEmpty (pos0 @ pos1 @ pos2)) then
+                nonemptyCount <- nonemptyCount + 1
+
+            let named, expectedMode =
+                if useManual then
+                    [ "--level=3" ],
+                    Manual
+                        {
+                            Level = 3
+                        }
+                else
+                    [ "--quiet=false" ],
+                    Auto
+                        {
+                            Quiet = Some false
+                        }
+
+            let args =
+                [
+                    yield! pos0 |> List.map string<int>
+                    yield! named
+                    yield! pos1 |> List.map string<int>
+                    if sep then
+                        yield "--"
+                    yield! pos2 |> List.map string<int>
+                ]
+
+            ModeAndPositionals.parse' noEnv args
+            |> shouldEqual
+                {
+                    Mode = expectedMode
+                    Rest = pos0 @ pos1 @ pos2
+                }
+
+        Check.QuickThrowOnFailure property
+
+        // The property is vacuous over empty positional lists; make sure the generator
+        // actually exercised nonempty ones.
+        nonemptyCount |> shouldBeGreaterThan 30

--- a/WoofWare.Myriad.Plugins.Test/WoofWare.Myriad.Plugins.Test.fsproj
+++ b/WoofWare.Myriad.Plugins.Test/WoofWare.Myriad.Plugins.Test.fsproj
@@ -46,6 +46,7 @@
     <Compile Include="TestArgParser\TestArgParserNegation.fs" />
     <Compile Include="TestArgParser\TestArgParserEdgeCases.fs" />
     <Compile Include="TestArgParser\TestArgParserDu.fs" />
+    <Compile Include="TestArgParser\TestArgParserDuPositional.fs" />
     <Compile Include="TestArgParser\TestArgParserRuntime.fs" />
     <Compile Include="TestSwagger\TestSwaggerParse.fs" />
     <Compile Include="TestSwagger\TestSuccessResponse.fs" />

--- a/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
+++ b/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
@@ -1231,8 +1231,8 @@ module internal ArgParserGenerator =
         // Walk the tree so that a union's alternatives are *grouped* in the help, not flattened
         // into one undifferentiated list: the user must be able to see which arguments go
         // together. Non-positional lines appear in declaration order; the positional-args line,
-        // if any, comes last, as it always has. (Positionals cannot coexist with unions, so the
-        // two features never interleave.)
+        // if any, comes last, as it always has (a sink beside a union is shared by every
+        // alternative, so it stays outside the case groups).
         let rec fieldHelpNonPos (depth : int) (tree : ParseTree<HasNoPositional>) : SynExpr list =
             match tree with
             | ParseTree.NonPositionalLeaf (pf, _) -> [ toPrintable depth describeNonPositional pf ]
@@ -1344,9 +1344,33 @@ module internal ArgParserGenerator =
             }
             |> spec.Apply
 
-        if Option.isSome pos && hasSum then
-            failwith
-                "Positional args cannot be combined with a discriminated-union arg: the parser could not tell which alternative an unrecognised arg belongs to."
+        // A positional sink may sit beside a union only when the scanner's treatment of an
+        // unrecognised `--key`-shaped token is provably Reject (fatal). A Collect-mode sink
+        // treats such a token as a positional arg, so a typo of a case-selecting argument would
+        // be silently collected — with a union in play, silently changing which alternative is
+        // chosen. Bare positional tokens are sound beside a union: they are routed to the sink
+        // and never influence case selection.
+        match pos with
+        | Some pf when hasSum ->
+            let includeFlagLike =
+                match pf.Accumulation with
+                | ChoicePositional.Normal fl
+                | ChoicePositional.Choice fl -> fl
+
+            match includeFlagLike with
+            // The default [<PositionalArgs>] is Reject.
+            | None -> ()
+            | Some expr ->
+                match SynExpr.stripOptionalParen expr with
+                | SynExpr.Const (SynConst.Bool false, _) -> ()
+                | SynExpr.Const (SynConst.Bool true, _) ->
+                    failwith
+                        "Positional args which collect unrecognised flag-like tokens ([<PositionalArgs true>]) cannot be combined with a discriminated-union arg: a mistyped case-selecting argument would be collected as a positional arg instead of being reported."
+                | _ ->
+                    // E.g. a [<Literal>] constant, which the untyped AST does not resolve.
+                    failwith
+                        "Positional args combined with a discriminated-union arg must provably reject unrecognised flag-like tokens: use [<PositionalArgs>] or a literal [<PositionalArgs false>]."
+        | _ -> ()
 
         let bindings =
             nonPos

--- a/WoofWare.Myriad.Plugins/Test/TestArgParserRejection.fs
+++ b/WoofWare.Myriad.Plugins/Test/TestArgParserRejection.fs
@@ -468,12 +468,11 @@ type PositionalInsideUnion =
         |> shouldRejectWith
             "Positional args are not permitted inside cases of the [<ArgParser>] union PositionalOrNot: the parser could not tell which alternative a positional arg belongs to."
 
-    [<Test>]
-    let ``Positional args are rejected alongside a union`` () =
-        // Conservative in v1: a Reject-mode sink beside a union is in principle sound (bare
-        // tokens cannot influence case selection), but a Collect-mode sink silently swallows
-        // typo'd case-selecting keys, so for now the combination is banned wholesale.
-        """namespace TestMe
+    /// A record holding a union-typed field and a positional sink, with the sink's
+    /// [<PositionalArgs>] attribute rendered from the given text.
+    let private modeAndPositionalsSource (positionalAttr : string) : string =
+        sprintf
+            """namespace TestMe
 
 open WoofWare.Myriad.Plugins
 
@@ -496,12 +495,72 @@ type WithModeAndPositionals =
     {
         Mode : Mode
 
-        [<PositionalArgs>]
+        [<%s>]
+        Rest : string list
+    }
+"""
+            positionalAttr
+
+    [<Test>]
+    let ``A Reject-mode positional sink is permitted alongside a union`` () =
+        // Sound because bare tokens cannot influence case selection, and in Reject mode an
+        // unrecognised `--key`-shaped token is still fatal rather than swallowed. Both the
+        // default form and the explicit literal must be accepted.
+        for attr in [ "PositionalArgs" ; "PositionalArgs false" ] do
+            // One namespace for the embedded runtime module, one for the generated parser module.
+            generateFromSource (modeAndPositionalsSource attr)
+            |> List.length
+            |> shouldEqual 2
+
+    [<Test>]
+    let ``A Collect-mode positional sink is rejected alongside a union`` () =
+        // A Collect-mode sink treats an unrecognised `--key` as a positional arg, so a typo of a
+        // case-selecting argument would be silently collected instead of reported — and with a
+        // union in play, that can silently change which alternative is chosen.
+        modeAndPositionalsSource "PositionalArgs true"
+        |> shouldRejectWith
+            "Positional args which collect unrecognised flag-like tokens ([<PositionalArgs true>]) cannot be combined with a discriminated-union arg: a mistyped case-selecting argument would be collected as a positional arg instead of being reported."
+
+    [<Test>]
+    let ``A positional sink whose flag-like setting cannot be proved Reject is rejected alongside a union`` () =
+        // The attribute argument is a [<Literal>] constant, which the untyped AST does not
+        // resolve: the generator cannot prove it is `false`, so it must be conservative.
+        """namespace TestMe
+
+[<AutoOpen>]
+module Constants =
+    [<Literal>]
+    let GrabEverything = false
+
+namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+type AutoMode =
+    {
+        Quiet : bool option
+    }
+
+type ManualMode =
+    {
+        Level : int
+    }
+
+type Mode =
+    | Auto of AutoMode
+    | Manual of ManualMode
+
+[<ArgParser>]
+type WithModeAndPositionals =
+    {
+        Mode : Mode
+
+        [<PositionalArgs(GrabEverything)>]
         Rest : string list
     }
 """
         |> shouldRejectWith
-            "Positional args cannot be combined with a discriminated-union arg: the parser could not tell which alternative an unrecognised arg belongs to."
+            "Positional args combined with a discriminated-union arg must provably reject unrecognised flag-like tokens: use [<PositionalArgs>] or a literal [<PositionalArgs false>]."
 
     [<Test>]
     let ``A union case must carry a record defined alongside the union`` () =


### PR DESCRIPTION
Stage 1 of the positional-args-with-unions stack (1/8).

The `ArgParserGenerator` previously rejected any `[<PositionalArgs>]` field appearing alongside a discriminated-union-typed field. This stage narrows that rejection: a **Reject-mode** positional sink (the default `[<PositionalArgs>]`, or a literal `[<PositionalArgs false>]`) is now permitted beside a union. What remains banned is a sink that *collects* unrecognised flag-like tokens (`[<PositionalArgs true>]`), because a mistyped case-selecting argument would silently become a positional arg instead of an error; a non-literal attribute argument is also rejected since the generator can't prove which mode it means.

Semantics with the existing runtime (no runtime changes needed at this stage): named arguments select the union case; every bare token routes to the single shared sink whichever case wins; unrecognised `--key`-shaped tokens remain fatal; case selection is structural and never depends on whether a token converts at the sink's element type.

Includes new ConsumePlugin fixtures (`ModeAndPositionals`, `CommandAndPositionals`), integration tests for both, and a noninterference property: inserting positional tokens at safe points never changes which case is selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
