### PR TITLE
Add exhaustive reference semantics for positional leaves (test-only)

### DIFF
--- a/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParserPositionalReference.fs
+++ b/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParserPositionalReference.fs
@@ -1,0 +1,861 @@
+namespace WoofWare.Myriad.Plugins.Test
+
+open System
+open NUnit.Framework
+open FsUnitTyped
+open FsCheck
+open FsCheck.FSharp
+
+/// The exhaustive reference semantics for argument schemas extended with positional leaves.
+///
+/// This model is the *definition* against which the production resolver will be checked. A
+/// schema tree may contain positional-stream consumers ("sinks") as leaves; a complete
+/// interpretation of the tree (one case chosen for every reachable Sum) contains at most one
+/// of them (argv holds a single positional stream, and two unbounded list consumers would
+/// admit no canonical partition of it); and a scanned positional token carries the set of
+/// sinks it could belong to, remaining unresolved until structural case selection has
+/// finished. Acceptance is deliberately conversion-free: whether a token parses as the
+/// sink's element type can never influence which interpretation is chosen.
+module TestArgParserPositionalReference =
+
+    [<RequireQualifiedAccess>]
+    type RefRequirement =
+        | Required
+        | Optional
+
+    /// A named argument, erased to exactly what acceptance needs. (The runtime's HasDefault
+    /// behaves like Optional for acceptance purposes: an absent defaulted argument does not
+    /// fail the parse.)
+    type RefNamedLeaf =
+        {
+            Id : int
+            Requirement : RefRequirement
+        }
+
+    /// A positional-stream consumer. Forms are the `--key` spellings which address this sink
+    /// specifically; two sinks in mutually exclusive cases may share a form.
+    type RefPositionalLeaf =
+        {
+            Id : int
+            Forms : string list
+        }
+
+    /// The core algebra: named leaves, positional leaves, products and exclusive sums.
+    [<RequireQualifiedAccess>]
+    type RefTree =
+        | Named of RefNamedLeaf
+        | Positional of RefPositionalLeaf
+        | Product of RefTree list
+        | Sum of sumId : int * cases : (string * RefTree) list
+
+    /// One complete interpretation of a tree: a case chosen for every reachable Sum.
+    type Interpretation =
+        {
+            Choices : Map<int, int>
+            Named : Set<int>
+            RequiredNamed : Set<int>
+            /// The active positional leaves. The linearity rule says a well-formed tree
+            /// admits at most one per interpretation; expansion records them all so that the
+            /// rule itself is testable.
+            Positionals : Set<int>
+        }
+
+    /// How a positional token was spelled on the command line, which determines its
+    /// candidate sinks.
+    [<RequireQualifiedAccess>]
+    type RefSpelling =
+        /// A bare token (including everything after `--`): any sink could consume it.
+        | Bare
+        /// `--form=value` / `--form value`: only the sinks claiming this form could.
+        | Keyed of form : string
+
+    /// A structural input: which named leaves were observed, and the positional events in
+    /// order. (Order does not affect acceptance; it is the candidate sets that matter.)
+    type RefInput =
+        {
+            ObservedNamed : Set<int>
+            PositionalEvents : RefSpelling list
+        }
+
+    [<RequireQualifiedAccess>]
+    type RefOutcome =
+        | Unique of Interpretation
+        | NoInterpretation
+        | Ambiguous of Interpretation list
+
+    // ----------------------------------------------------------------------------------------
+    // The model itself.
+
+    /// The compositional positional-capacity calculation: the maximum number of positional
+    /// leaves any complete interpretation can contain.
+    let rec maxPositionals (tree : RefTree) : int =
+        match tree with
+        | RefTree.Named _ -> 0
+        | RefTree.Positional _ -> 1
+        | RefTree.Product children -> children |> List.sumBy maxPositionals
+        | RefTree.Sum (_, cases) ->
+            match cases with
+            | [] -> 0
+            | cases -> cases |> List.map (fun (_, case) -> maxPositionals case) |> List.max
+
+    /// All positional leaves in the tree, wherever they sit.
+    let rec positionalLeaves (tree : RefTree) : RefPositionalLeaf list =
+        match tree with
+        | RefTree.Named _ -> []
+        | RefTree.Positional p -> [ p ]
+        | RefTree.Product children -> children |> List.collect positionalLeaves
+        | RefTree.Sum (_, cases) -> cases |> List.collect (fun (_, case) -> positionalLeaves case)
+
+    let private emptyInterpretation : Interpretation =
+        {
+            Choices = Map.empty
+            Named = Set.empty
+            RequiredNamed = Set.empty
+            Positionals = Set.empty
+        }
+
+    let private combine (a : Interpretation) (b : Interpretation) : Interpretation =
+        {
+            Choices = (a.Choices, b.Choices) ||> Map.fold (fun m k v -> Map.add k v m)
+            Named = Set.union a.Named b.Named
+            RequiredNamed = Set.union a.RequiredNamed b.RequiredNamed
+            Positionals = Set.union a.Positionals b.Positionals
+        }
+
+    /// Expand a tree into every complete interpretation.
+    let rec interpretations (tree : RefTree) : Interpretation list =
+        match tree with
+        | RefTree.Named leaf ->
+            [
+                { emptyInterpretation with
+                    Named = Set.singleton leaf.Id
+                    RequiredNamed =
+                        match leaf.Requirement with
+                        | RefRequirement.Required -> Set.singleton leaf.Id
+                        | RefRequirement.Optional -> Set.empty
+                }
+            ]
+        | RefTree.Positional p ->
+            [
+                { emptyInterpretation with
+                    Positionals = Set.singleton p.Id
+                }
+            ]
+        | RefTree.Product children ->
+            ([ emptyInterpretation ], children)
+            ||> List.fold (fun accs child ->
+                let childInterps = interpretations child
+                accs |> List.collect (fun acc -> childInterps |> List.map (combine acc))
+            )
+        | RefTree.Sum (sumId, cases) ->
+            cases
+            |> List.indexed
+            |> List.collect (fun (index, (_, case)) ->
+                interpretations case
+                |> List.map (fun interp ->
+                    { interp with
+                        Choices = Map.add sumId index interp.Choices
+                    }
+                )
+            )
+
+    /// The candidate sinks for one positional event, given the tree's sinks. Keyed forms
+    /// match under the scanner's own equality (OrdinalIgnoreCase): `--REST=x` addresses a
+    /// sink declared as `rest`.
+    let candidates (sinks : RefPositionalLeaf list) (spelling : RefSpelling) : Set<int> =
+        match spelling with
+        | RefSpelling.Bare -> sinks |> List.map (fun p -> p.Id) |> Set.ofList
+        | RefSpelling.Keyed form ->
+            sinks
+            |> List.filter (fun p ->
+                p.Forms
+                |> List.exists (fun f -> String.Equals (f, form, StringComparison.OrdinalIgnoreCase))
+            )
+            |> List.map (fun p -> p.Id)
+            |> Set.ofList
+
+    /// The acceptance predicate: does this interpretation structurally accept this input?
+    ///
+    /// - every observed named leaf belongs to the interpretation;
+    /// - every required named leaf of the interpretation was observed;
+    /// - if any positional events exist, the interpretation has a positional leaf and it is
+    ///   a candidate of every event.
+    ///
+    /// Conversion is deliberately absent: whether values parse never features.
+    let accepts (sinks : RefPositionalLeaf list) (interp : Interpretation) (input : RefInput) : bool =
+        Set.isSubset input.ObservedNamed interp.Named
+        && Set.isSubset interp.RequiredNamed input.ObservedNamed
+        && (List.isEmpty input.PositionalEvents
+            || (
+                match Set.toList interp.Positionals with
+                | [ p ] ->
+                    input.PositionalEvents
+                    |> List.forall (fun spelling -> Set.contains p (candidates sinks spelling))
+                | [] -> false
+                | _ -> failwith "linearity violated: an interpretation held two positional leaves"
+            ))
+
+    /// The reference semantics: the parse is structurally successful exactly when one
+    /// interpretation accepts.
+    let exhaustiveSelect (tree : RefTree) (input : RefInput) : RefOutcome =
+        let sinks = positionalLeaves tree
+
+        match interpretations tree |> List.filter (fun interp -> accepts sinks interp input) with
+        | [ interp ] -> RefOutcome.Unique interp
+        | [] -> RefOutcome.NoInterpretation
+        | several -> RefOutcome.Ambiguous several
+
+    /// Can this subtree be satisfied with no *named* observations? (Positional leaves need
+    /// nothing: an empty stream is fine.) This is the per-sum condition the generator
+    /// enforces so that an empty command line, and by the lemma below any bare-only input,
+    /// selects at most one case.
+    let rec emptySatisfiable (tree : RefTree) : bool =
+        match tree with
+        | RefTree.Named leaf ->
+            match leaf.Requirement with
+            | RefRequirement.Required -> false
+            | RefRequirement.Optional -> true
+        | RefTree.Positional _ -> true
+        | RefTree.Product children -> children |> List.forall emptySatisfiable
+        | RefTree.Sum (_, cases) -> cases |> List.exists (fun (_, case) -> emptySatisfiable case)
+
+    /// Does every Sum node have at most one empty-satisfiable case?
+    let rec sumsAreUnambiguous (tree : RefTree) : bool =
+        match tree with
+        | RefTree.Named _
+        | RefTree.Positional _ -> true
+        | RefTree.Product children -> children |> List.forall sumsAreUnambiguous
+        | RefTree.Sum (_, cases) ->
+            (cases |> List.forall (fun (_, case) -> sumsAreUnambiguous case))
+            && (cases |> List.filter (fun (_, case) -> emptySatisfiable case) |> List.length)
+               <= 1
+
+    // ----------------------------------------------------------------------------------------
+    // Generators. Trees are generated valid by construction (positional budget 0 or 1,
+    // threaded so that a Product gives its budget to one child and a Sum to every case), and
+    // the capacity property below cross-checks the construction against the compositional
+    // calculation.
+
+    let private formPool = [ "rest" ; "files" ; "extra" ]
+
+    let private genForms : Gen<string list> =
+        gen {
+            let! count = Gen.frequency [ (4, Gen.constant 1) ; (1, Gen.constant 2) ]
+            let! forms = Gen.elements formPool |> Gen.listOfLength count
+            return List.distinct forms
+        }
+
+    /// A tree over exactly the given named-leaf ids, with a positional leaf permitted (not
+    /// required) exactly when `budget` is true. Positional ids are placeholders, renumbered
+    /// by genTree.
+    let rec private genTreeOver (sumBias : int) (budget : bool) (ids : int list) : Gen<RefTree> =
+        match ids, budget with
+        | [], false -> Gen.constant (RefTree.Product [])
+        | [], true ->
+            gen {
+                let! forms = genForms
+                let! makeSink = Gen.frequency [ (3, Gen.constant true) ; (1, Gen.constant false) ]
+
+                if makeSink then
+                    return
+                        RefTree.Positional
+                            {
+                                Id = 0
+                                Forms = forms
+                            }
+                else
+                    return RefTree.Product []
+            }
+        | [ id ], budget ->
+            gen {
+                let! requirement = Gen.elements [ RefRequirement.Required ; RefRequirement.Optional ]
+
+                let named =
+                    RefTree.Named
+                        {
+                            Id = id
+                            Requirement = requirement
+                        }
+
+                if budget then
+                    let! sink = genTreeOver sumBias true []
+
+                    match sink with
+                    | RefTree.Product [] -> return named
+                    | sink -> return RefTree.Product [ named ; sink ]
+                else
+                    return named
+            }
+        | ids, budget ->
+            gen {
+                let n = List.length ids
+                let! groupCount = Gen.choose (2, min 4 n)
+
+                let rec chooseCuts (existing : Set<int>) : Gen<Set<int>> =
+                    if Set.count existing = groupCount - 1 then
+                        Gen.constant existing
+                    else
+                        gen {
+                            let! cut = Gen.choose (1, n - 1)
+                            return! chooseCuts (Set.add cut existing)
+                        }
+
+                let! cuts = chooseCuts Set.empty
+                let boundaries = [ 0 ] @ Set.toList cuts @ [ n ]
+
+                let groups =
+                    List.pairwise boundaries
+                    |> List.map (fun (start, finish) -> ids |> List.skip start |> List.take (finish - start))
+
+                let! isSum = Gen.frequency [ (sumBias, Gen.constant true) ; (100 - sumBias, Gen.constant false) ]
+
+                if isSum then
+                    // Every case of a sum inherits the whole budget: at most one case is live.
+                    let! children = groups |> List.map (genTreeOver sumBias budget) |> Gen.sequenceToList
+                    let cases = children |> List.mapi (fun i child -> sprintf "Case%i" i, child)
+                    return RefTree.Sum (0, cases)
+                else
+                    // A product's budget goes to exactly one child.
+                    let! luckyChild = Gen.choose (0, List.length groups - 1)
+
+                    let! children =
+                        groups
+                        |> List.mapi (fun i group -> genTreeOver sumBias (budget && i = luckyChild) group)
+                        |> Gen.sequenceToList
+
+                    return RefTree.Product children
+            }
+
+    /// Give every Sum a distinct id and every positional leaf a distinct id (ids at 1000+ so
+    /// they never collide with named ids).
+    let private renumber (tree : RefTree) : RefTree =
+        let mutable nextSum = 0
+        let mutable nextPos = 1000
+
+        let rec go (tree : RefTree) : RefTree =
+            match tree with
+            | RefTree.Named _ -> tree
+            | RefTree.Positional p ->
+                let id = nextPos
+                nextPos <- nextPos + 1
+
+                RefTree.Positional
+                    { p with
+                        Id = id
+                    }
+            | RefTree.Product children -> RefTree.Product (children |> List.map go)
+            | RefTree.Sum (_, cases) ->
+                let id = nextSum
+                nextSum <- nextSum + 1
+                RefTree.Sum (id, cases |> List.map (fun (name, case) -> name, go case))
+
+        go tree
+
+    /// Like renumber, but leaves positional ids alone: for trees whose sinks were placed by
+    /// hand. The numbering is DFS order, so two trees sharing a sub-structure prefix agree
+    /// on the ids of the sums within it.
+    let private renumberSumsOnly (tree : RefTree) : RefTree =
+        let mutable next = 0
+
+        let rec go (tree : RefTree) : RefTree =
+            match tree with
+            | RefTree.Named _
+            | RefTree.Positional _ -> tree
+            | RefTree.Product children -> RefTree.Product (children |> List.map go)
+            | RefTree.Sum (_, cases) ->
+                let id = next
+                next <- next + 1
+                RefTree.Sum (id, cases |> List.map (fun (name, case) -> name, go case))
+
+        go tree
+
+    let genTree (sumBias : int) : Gen<RefTree> =
+        gen {
+            let! namedCount = Gen.choose (1, 8)
+            let! budget = Gen.frequency [ (3, Gen.constant true) ; (1, Gen.constant false) ]
+            let! tree = genTreeOver sumBias budget (List.init namedCount id)
+            return renumber tree
+        }
+
+    /// An input biased towards nearly-valid: walk the tree choosing one case per sum, keep
+    /// that alternative's required named leaves (dropping each with a small probability),
+    /// add its optional leaves with some probability, add noise leaves from outside, and
+    /// spell positional events either bare or keyed (keyed forms biased towards the chosen
+    /// alternative's sink where it has one).
+    let genInput (dropPct : int) (optionalPct : int) (noisePct : int) (tree : RefTree) : Gen<RefInput> =
+        gen {
+            let sinks = positionalLeaves tree
+
+            let rec pickAlternative (tree : RefTree) : Gen<Interpretation> =
+                match tree with
+                | RefTree.Named leaf -> Gen.constant (List.exactlyOne (interpretations (RefTree.Named leaf)))
+                | RefTree.Positional p -> Gen.constant (List.exactlyOne (interpretations (RefTree.Positional p)))
+                | RefTree.Product children ->
+                    gen {
+                        let! parts = children |> List.map pickAlternative |> Gen.sequenceToList
+                        return List.fold combine emptyInterpretation parts
+                    }
+                | RefTree.Sum (sumId, cases) ->
+                    gen {
+                        let! index = Gen.choose (0, List.length cases - 1)
+                        let! interp = pickAlternative (snd (List.item index cases))
+
+                        return
+                            { interp with
+                                Choices = Map.add sumId index interp.Choices
+                            }
+                    }
+
+            let! alternative = pickAlternative tree
+
+            let! kept =
+                alternative.Named
+                |> Set.toList
+                |> List.map (fun id ->
+                    gen {
+                        let! roll = Gen.choose (1, 100)
+
+                        let keep =
+                            if Set.contains id alternative.RequiredNamed then
+                                roll > dropPct
+                            else
+                                roll <= optionalPct
+
+                        return (if keep then Some id else None)
+                    }
+                )
+                |> Gen.sequenceToList
+
+            let allNamedIds =
+                let rec go (tree : RefTree) : int list =
+                    match tree with
+                    | RefTree.Named leaf -> [ leaf.Id ]
+                    | RefTree.Positional _ -> []
+                    | RefTree.Product children -> children |> List.collect go
+                    | RefTree.Sum (_, cases) -> cases |> List.collect (fun (_, case) -> go case)
+
+                go tree
+
+            let! noise =
+                allNamedIds
+                |> List.map (fun id ->
+                    gen {
+                        if Set.contains id alternative.Named then
+                            return None
+                        else
+                            let! roll = Gen.choose (1, 100)
+                            return (if roll <= noisePct then Some id else None)
+                    }
+                )
+                |> Gen.sequenceToList
+
+            let! eventCount = Gen.frequency [ (2, Gen.constant 0) ; (3, Gen.choose (1, 4)) ]
+
+            let ownForms =
+                alternative.Positionals
+                |> Set.toList
+                |> List.collect (fun p -> (sinks |> List.find (fun s -> s.Id = p)).Forms)
+
+            let! events =
+                gen {
+                    let! spellKeyed = Gen.frequency [ (1, Gen.constant true) ; (2, Gen.constant false) ]
+
+                    if spellKeyed then
+                        let! form =
+                            match ownForms with
+                            | [] -> Gen.elements formPool
+                            | ownForms -> Gen.frequency [ (3, Gen.elements ownForms) ; (1, Gen.elements formPool) ]
+
+                        // The scanner matches keys case-insensitively; the model must too.
+                        let! upper = Gen.frequency [ (1, Gen.constant true) ; (3, Gen.constant false) ]
+                        return RefSpelling.Keyed (if upper then form.ToUpperInvariant () else form)
+                    else
+                        return RefSpelling.Bare
+                }
+                |> Gen.listOfLength eventCount
+
+            return
+                {
+                    ObservedNamed = Set.ofList (List.choose id kept @ List.choose id noise)
+                    PositionalEvents = events
+                }
+        }
+
+    // ----------------------------------------------------------------------------------------
+    // Properties: the algebra.
+
+    [<Test>]
+    let ``Compositional positional capacity agrees with exhaustive expansion`` () =
+        // On generated (budget ≤ 1) trees the agreement pins the linearity rule; gluing two
+        // generated trees into a product also exercises capacities above one, where the
+        // compositional sum must still agree with the expansion.
+        let mutable overCapacityCount = 0
+
+        let cases =
+            gen {
+                let! sumBias = Gen.elements [ 20 ; 50 ; 80 ]
+                let! t1 = genTree sumBias
+                let! glue = Gen.elements [ true ; false ]
+
+                if glue then
+                    let! t2 = genTree sumBias
+
+                    // Rename so that ids stay unique across the two halves.
+                    let rec bump (tree : RefTree) : RefTree =
+                        match tree with
+                        | RefTree.Named leaf ->
+                            RefTree.Named
+                                { leaf with
+                                    Id = leaf.Id + 100
+                                }
+                        | RefTree.Positional p ->
+                            RefTree.Positional
+                                { p with
+                                    Id = p.Id + 100
+                                }
+                        | RefTree.Product children -> RefTree.Product (children |> List.map bump)
+                        | RefTree.Sum (sumId, cases) ->
+                            RefTree.Sum (sumId + 100, cases |> List.map (fun (name, case) -> name, bump case))
+
+                    return RefTree.Product [ t1 ; bump t2 ]
+                else
+                    return t1
+            }
+
+        let property (tree : RefTree) : unit =
+            let expansionMax =
+                match interpretations tree with
+                | [] -> failwith "a tree always has at least one interpretation"
+                | interps -> interps |> List.map (fun i -> Set.count i.Positionals) |> List.max
+
+            maxPositionals tree |> shouldEqual expansionMax
+
+            if expansionMax > 1 then
+                overCapacityCount <- overCapacityCount + 1
+
+        let config = Config.QuickThrowOnFailure.WithMaxTest 1000
+        Check.One (config, Prop.forAll (Arb.fromGen cases) property)
+
+        // The glued regime must actually produce over-capacity trees, or the agreement is
+        // only being tested at 0 and 1.
+        overCapacityCount |> shouldBeGreaterThan 50
+
+    [<Test>]
+    let ``Every interpretation of a generated tree contains at most one positional leaf`` () =
+        let cases =
+            gen {
+                let! sumBias = Gen.elements [ 20 ; 50 ; 80 ]
+                return! genTree sumBias
+            }
+
+        let property (tree : RefTree) : unit =
+            maxPositionals tree |> shouldBeSmallerThan 2
+
+            for interp in interpretations tree do
+                Set.count interp.Positionals |> shouldBeSmallerThan 2
+
+        let config = Config.QuickThrowOnFailure.WithMaxTest 1000
+        Check.One (config, Prop.forAll (Arb.fromGen cases) property)
+
+    [<Test>]
+    let ``Acceptance is invariant under product identity and flattening`` () =
+        // Product [t] means the same as t, and Product [a; Product [b; c]] the same as
+        // Product [a; b; c]: the interpretations are equal as data, so outcomes coincide on
+        // every input.
+        let cases =
+            gen {
+                let! sumBias = Gen.elements [ 20 ; 50 ]
+                let! tree = genTree sumBias
+                let! input = genInput 20 50 20 tree
+                return tree, input
+            }
+
+        let property (tree : RefTree, input : RefInput) : unit =
+            exhaustiveSelect (RefTree.Product [ tree ]) input
+            |> shouldEqual (exhaustiveSelect tree input)
+
+            match tree with
+            | RefTree.Product (first :: rest) when not (List.isEmpty rest) ->
+                exhaustiveSelect (RefTree.Product [ first ; RefTree.Product rest ]) input
+                |> shouldEqual (exhaustiveSelect tree input)
+            | _ -> ()
+
+        let config = Config.QuickThrowOnFailure.WithMaxTest 1000
+        Check.One (config, Prop.forAll (Arb.fromGen cases) property)
+
+    [<Test>]
+    let ``Factorization: a common sink beside a sum accepts the same inputs as per-case sinks`` () =
+        // (A + B) × P and (A × P₁) + (B × P₂), with P₁ and P₂ spelt like P, accept exactly
+        // the same structural inputs, choosing the same case; only the identity of the
+        // active sink differs.
+        let mutable acceptCount = 0
+
+        let cases =
+            gen {
+                let! sumBias = Gen.elements [ 0 ; 40 ]
+                let! aCount = Gen.choose (1, 4)
+                let! bCount = Gen.choose (1, 4)
+                let! caseA = genTreeOver sumBias false (List.init aCount id)
+                let! caseB = genTreeOver sumBias false (List.init bCount (fun i -> 100 + i))
+                let! forms = genForms
+
+                let sink (id : int) : RefTree =
+                    RefTree.Positional
+                        {
+                            Id = id
+                            Forms = forms
+                        }
+
+                let common =
+                    RefTree.Product [ RefTree.Sum (0, [ "A", caseA ; "B", caseB ]) ; sink 1000 ]
+                    |> renumberSumsOnly
+
+                let factored =
+                    RefTree.Sum (
+                        0,
+                        [
+                            "A", RefTree.Product [ caseA ; sink 1000 ]
+                            "B", RefTree.Product [ caseB ; sink 1001 ]
+                        ]
+                    )
+                    |> renumberSumsOnly
+
+                let! input = genInput 20 50 20 common
+                return common, factored, input
+            }
+
+        let property (common : RefTree, factored : RefTree, input : RefInput) : unit =
+            let observable (outcome : RefOutcome) : Choice<Map<int, int> * Set<int>, unit, int> =
+                match outcome with
+                | RefOutcome.Unique interp -> Choice1Of3 (interp.Choices, interp.Named)
+                | RefOutcome.NoInterpretation -> Choice2Of3 ()
+                | RefOutcome.Ambiguous interps -> Choice3Of3 (List.length interps)
+
+            let commonOutcome = exhaustiveSelect common input
+            let factoredOutcome = exhaustiveSelect factored input
+
+            observable factoredOutcome |> shouldEqual (observable commonOutcome)
+
+            match commonOutcome with
+            | RefOutcome.Unique _ -> acceptCount <- acceptCount + 1
+            | _ -> ()
+
+        let config = Config.QuickThrowOnFailure.WithMaxTest 2000
+        Check.One (config, Prop.forAll (Arb.fromGen cases) property)
+
+        // The law is only interesting if some inputs are actually accepted.
+        acceptCount |> shouldBeGreaterThan 200
+
+    [<Test>]
+    let ``Bare-only inputs are never ambiguous when every sum passes the empty-ambiguity check`` () =
+        // The lemma which makes the generation-time check sufficient: bare tokens name every
+        // sink, so they cannot discriminate between cases; if two interpretations both
+        // accepted a bare-only input, both their cases (at the outermost sum where they
+        // differ) would have to be satisfiable with no named observations — exactly what the
+        // per-sum check forbids. Keyed events are excluded: a keyed form genuinely can
+        // discriminate, which is by design.
+        let mutable checkedTrees = 0
+        let mutable inputsWithEvents = 0
+
+        let cases =
+            gen {
+                let! sumBias = Gen.elements [ 30 ; 60 ; 90 ]
+                let! tree = genTree sumBias
+                let! rawInput = genInput 30 40 20 tree
+                let bareOnly = rawInput.PositionalEvents |> List.map (fun _ -> RefSpelling.Bare)
+
+                return
+                    tree,
+                    { rawInput with
+                        PositionalEvents = bareOnly
+                    }
+            }
+
+        let property (tree : RefTree, input : RefInput) : unit =
+            if sumsAreUnambiguous tree then
+                checkedTrees <- checkedTrees + 1
+
+                if not (List.isEmpty input.PositionalEvents) then
+                    inputsWithEvents <- inputsWithEvents + 1
+
+                match exhaustiveSelect tree input with
+                | RefOutcome.Ambiguous _ -> failwithf "ambiguous outcome for %A on %A" tree input
+                | RefOutcome.Unique _
+                | RefOutcome.NoInterpretation -> ()
+
+        let config = Config.QuickThrowOnFailure.WithMaxTest 2000
+        Check.One (config, Prop.forAll (Arb.fromGen cases) property)
+
+        checkedTrees |> shouldBeGreaterThan 500
+        inputsWithEvents |> shouldBeGreaterThan 200
+
+    [<Test>]
+    let ``The generator explores every outcome regime`` () =
+        let mutable unique = 0
+        let mutable noInterp = 0
+        let mutable ambiguous = 0
+        let mutable sharedSinkAccepts = 0
+        let mutable positionalFree = 0
+
+        let cases =
+            gen {
+                let! sumBias = Gen.elements [ 20 ; 50 ; 80 ]
+                let! tree = genTree sumBias
+                let! dropPct = Gen.elements [ 0 ; 0 ; 20 ]
+                let! optionalPct = Gen.elements [ 0 ; 50 ; 100 ]
+                let! noisePct = Gen.elements [ 0 ; 10 ; 40 ]
+                let! input = genInput dropPct optionalPct noisePct tree
+                return tree, input
+            }
+
+        let property (tree : RefTree, input : RefInput) : unit =
+            let sinks = positionalLeaves tree
+
+            let sharesForm =
+                sinks
+                |> List.exists (fun a ->
+                    sinks
+                    |> List.exists (fun b ->
+                        a.Id <> b.Id && (a.Forms |> List.exists (fun f -> b.Forms |> List.contains f))
+                    )
+                )
+
+            match exhaustiveSelect tree input with
+            | RefOutcome.Unique interp ->
+                unique <- unique + 1
+
+                if List.isEmpty sinks then
+                    positionalFree <- positionalFree + 1
+
+                if sharesForm && not (Set.isEmpty interp.Positionals) then
+                    sharedSinkAccepts <- sharedSinkAccepts + 1
+            | RefOutcome.NoInterpretation -> noInterp <- noInterp + 1
+            | RefOutcome.Ambiguous _ -> ambiguous <- ambiguous + 1
+
+        let config = Config.QuickThrowOnFailure.WithMaxTest 3000
+        Check.One (config, Prop.forAll (Arb.fromGen cases) property)
+
+        unique |> shouldBeGreaterThan 300
+        noInterp |> shouldBeGreaterThan 200
+        ambiguous |> shouldBeGreaterThan 20
+        sharedSinkAccepts |> shouldBeGreaterThan 20
+        positionalFree |> shouldBeGreaterThan 50
+
+    // ----------------------------------------------------------------------------------------
+    // Hand examples: the motivating shapes, pinned concretely.
+
+    let private req (id : int) : RefTree =
+        RefTree.Named
+            {
+                Id = id
+                Requirement = RefRequirement.Required
+            }
+
+    let private opt (id : int) : RefTree =
+        RefTree.Named
+            {
+                Id = id
+                Requirement = RefRequirement.Optional
+            }
+
+    let private sink (id : int) (forms : string list) : RefTree =
+        RefTree.Positional
+            {
+                Id = id
+                Forms = forms
+            }
+
+    /// (Foo × P₁) + (Bar × P₂), both sinks spelt --rest: the plan §8 example.
+    let private perCaseSinks : RefTree =
+        RefTree.Sum (
+            0,
+            [
+                "Foo", RefTree.Product [ req 0 ; sink 1000 [ "rest" ] ]
+                "Bar", RefTree.Product [ req 1 ; sink 1001 [ "rest" ] ]
+            ]
+        )
+
+    let private input (named : int list) (events : RefSpelling list) : RefInput =
+        {
+            ObservedNamed = Set.ofList named
+            PositionalEvents = events
+        }
+
+    [<Test>]
+    let ``Per-case sinks: a named discriminator selects the case and its sink`` () =
+        match exhaustiveSelect perCaseSinks (input [ 0 ] [ RefSpelling.Bare ; RefSpelling.Bare ]) with
+        | RefOutcome.Unique interp ->
+            interp.Choices |> shouldEqual (Map.ofList [ 0, 0 ])
+            interp.Positionals |> shouldEqual (Set.singleton 1000)
+        | other -> failwithf "unexpected outcome: %A" other
+
+        match exhaustiveSelect perCaseSinks (input [ 1 ] [ RefSpelling.Bare ]) with
+        | RefOutcome.Unique interp ->
+            interp.Choices |> shouldEqual (Map.ofList [ 0, 1 ])
+            interp.Positionals |> shouldEqual (Set.singleton 1001)
+        | other -> failwithf "unexpected outcome: %A" other
+
+    [<Test>]
+    let ``Per-case sinks: the shared --rest form stays neutral`` () =
+        // --rest names both sinks, so it does not select; the named discriminator does.
+        match exhaustiveSelect perCaseSinks (input [ 0 ] [ RefSpelling.Keyed "rest" ]) with
+        | RefOutcome.Unique interp -> interp.Choices |> shouldEqual (Map.ofList [ 0, 0 ])
+        | other -> failwithf "unexpected outcome: %A" other
+
+        // Keys match case-insensitively, like everything the scanner recognises.
+        match exhaustiveSelect perCaseSinks (input [ 1 ] [ RefSpelling.Keyed "REST" ]) with
+        | RefOutcome.Unique interp -> interp.Choices |> shouldEqual (Map.ofList [ 0, 1 ])
+        | other -> failwithf "unexpected outcome: %A" other
+
+    [<Test>]
+    let ``Per-case sinks: positional tokens alone select nothing`` () =
+        // Both cases have a required named leaf, so no interpretation accepts. Conversion is
+        // not part of the model at all: parseability could not have broken this tie.
+        exhaustiveSelect perCaseSinks (input [] [ RefSpelling.Bare ; RefSpelling.Bare ])
+        |> shouldEqual RefOutcome.NoInterpretation
+
+    [<Test>]
+    let ``Per-case sinks: a distinctive keyed form is itself a structural discriminator`` () =
+        let tree =
+            RefTree.Sum (
+                0,
+                [
+                    "Foo", RefTree.Product [ opt 0 ; sink 1000 [ "files" ] ]
+                    "Bar", RefTree.Product [ req 1 ; sink 1001 [ "nums" ] ]
+                ]
+            )
+
+        // Nothing but --files=x: only Foo's interpretation can consume the event.
+        match exhaustiveSelect tree (input [] [ RefSpelling.Keyed "files" ]) with
+        | RefOutcome.Unique interp ->
+            interp.Choices |> shouldEqual (Map.ofList [ 0, 0 ])
+            interp.Positionals |> shouldEqual (Set.singleton 1000)
+        | other -> failwithf "unexpected outcome: %A" other
+
+        // A keyed form belonging to the case the named observations exclude: no acceptance.
+        exhaustiveSelect tree (input [ 1 ] [ RefSpelling.Keyed "files" ])
+        |> shouldEqual RefOutcome.NoInterpretation
+
+    [<Test>]
+    let ``A common sink beside the sum accepts what either case accepts`` () =
+        let tree =
+            RefTree.Product [ RefTree.Sum (0, [ "Foo", req 0 ; "Bar", req 1 ]) ; sink 1000 [ "rest" ] ]
+
+        match exhaustiveSelect tree (input [ 0 ] [ RefSpelling.Bare ]) with
+        | RefOutcome.Unique interp ->
+            interp.Choices |> shouldEqual (Map.ofList [ 0, 0 ])
+            interp.Positionals |> shouldEqual (Set.singleton 1000)
+        | other -> failwithf "unexpected outcome: %A" other
+
+        exhaustiveSelect tree (input [] [ RefSpelling.Bare ])
+        |> shouldEqual RefOutcome.NoInterpretation
+
+    [<Test>]
+    let ``A product of two sinks is over capacity`` () =
+        // The linearity rule: argv has one positional stream, so P × Q is rejected by
+        // capacity while (A × P) + (B × Q) is fine. This is what schema validation will
+        // enforce; the model just states the arithmetic.
+        maxPositionals (RefTree.Product [ sink 1000 [ "rest" ] ; sink 1001 [ "files" ] ])
+        |> shouldEqual 2
+
+        maxPositionals perCaseSinks |> shouldEqual 1

--- a/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParserPositionalReference.fs
+++ b/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParserPositionalReference.fs
@@ -71,6 +71,14 @@ module TestArgParserPositionalReference =
 
     /// A structural input: which named leaves were observed, and the positional events in
     /// order. (Order does not affect acceptance; it is the candidate sets that matter.)
+    ///
+    /// This is *post-scanning* input, and the split into named observations and positional
+    /// events is well defined only under the existing restriction that a positional sink may
+    /// sit beside a union only in Reject mode: a Collect-mode sink turns an unrecognised
+    /// `--key` token into a positional event, so the split would itself depend on which case
+    /// the scan is trying to select. Deliberately unmodelled, therefore: unrecognised
+    /// flag-like tokens, `--help`, scanner errors, and repeat occurrences of a single named
+    /// leaf (this is a set, so the runtime's duplicate-argument error is out of scope).
     type RefInput =
         {
             ObservedNamed : Set<int>
@@ -174,6 +182,14 @@ module TestArgParserPositionalReference =
             |> List.map (fun p -> p.Id)
             |> Set.ofList
 
+    /// The named half of acceptance: every observed named leaf belongs to the interpretation,
+    /// and every required named leaf of the interpretation was observed. Named separately
+    /// because on a well-formed tree this half already selects: see the confirm-or-veto
+    /// property below.
+    let acceptsNamed (interp : Interpretation) (input : RefInput) : bool =
+        Set.isSubset input.ObservedNamed interp.Named
+        && Set.isSubset interp.RequiredNamed input.ObservedNamed
+
     /// The acceptance predicate: does this interpretation structurally accept this input?
     ///
     /// - every observed named leaf belongs to the interpretation;
@@ -183,8 +199,7 @@ module TestArgParserPositionalReference =
     ///
     /// Conversion is deliberately absent: whether values parse never features.
     let accepts (sinks : RefPositionalLeaf list) (interp : Interpretation) (input : RefInput) : bool =
-        Set.isSubset input.ObservedNamed interp.Named
-        && Set.isSubset interp.RequiredNamed input.ObservedNamed
+        acceptsNamed interp input
         && (List.isEmpty input.PositionalEvents
             || (
                 match Set.toList interp.Positionals with
@@ -197,7 +212,18 @@ module TestArgParserPositionalReference =
 
     /// The reference semantics: the parse is structurally successful exactly when one
     /// interpretation accepts.
+    ///
+    /// The tree must satisfy linearity (capacity at most one positional leaf). That is a
+    /// property of the schema, not of the input, so it is checked up front: the assertion
+    /// inside `accepts` fires only once an event needs routing, which would silently accept an
+    /// over-capacity tree on the inputs that happen to carry no positional events at all.
     let exhaustiveSelect (tree : RefTree) (input : RefInput) : RefOutcome =
+        match maxPositionals tree with
+        | 0
+        | 1 -> ()
+        | capacity ->
+            failwithf "linearity violated: this tree admits an interpretation with %i positional leaves" capacity
+
         let sinks = positionalLeaves tree
 
         match interpretations tree |> List.filter (fun interp -> accepts sinks interp input) with
@@ -647,28 +673,36 @@ module TestArgParserPositionalReference =
         acceptCount |> shouldBeGreaterThan 200
 
     [<Test>]
-    let ``Bare-only inputs are never ambiguous when every sum passes the empty-ambiguity check`` () =
-        // The lemma which makes the generation-time check sufficient: bare tokens name every
-        // sink, so they cannot discriminate between cases; if two interpretations both
-        // accepted a bare-only input, both their cases (at the outermost sum where they
-        // differ) would have to be satisfiable with no named observations — exactly what the
-        // per-sum check forbids. Keyed events are excluded: a keyed form genuinely can
-        // discriminate, which is by design.
+    let ``Positional events can only confirm or veto the interpretation the named half selects`` () =
+        // The lemma which makes the generation-time check sufficient, in its strongest form:
+        // the *named* half of acceptance already picks out at most one interpretation. Leaf
+        // ids are distinct across cases, so an observed leaf belongs to exactly one of them;
+        // and if two interpretations were both named-accepted, then at the outermost sum where
+        // they differ both their cases would have to be satisfiable with no named observations
+        // — exactly what the per-sum check forbids.
+        //
+        // Acceptance is a conjunction, so the positional half can only filter that singleton.
+        // Hence no input is ever ambiguous, and no positional event — bare *or* keyed — can
+        // change which case is chosen. A bare token names every sink and so is always neutral;
+        // a keyed token naming no sink of the selected interpretation vetoes it outright
+        // rather than selecting some other case.
+        //
+        // This is what licenses the production resolver to select structurally first and
+        // validate the events against the active sink afterwards. It rests on ids being
+        // distinct across cases, which the generator enforces by rejecting an argument name
+        // shared between two union cases; were that relaxed, a keyed form genuinely could
+        // select, and this property would fail.
         let mutable checkedTrees = 0
         let mutable inputsWithEvents = 0
+        let mutable inputsWithKeyedEvents = 0
+        let mutable vetoed = 0
 
         let cases =
             gen {
                 let! sumBias = Gen.elements [ 30 ; 60 ; 90 ]
                 let! tree = genTree sumBias
-                let! rawInput = genInput 30 40 20 tree
-                let bareOnly = rawInput.PositionalEvents |> List.map (fun _ -> RefSpelling.Bare)
-
-                return
-                    tree,
-                    { rawInput with
-                        PositionalEvents = bareOnly
-                    }
+                let! input = genInput 30 40 20 tree
+                return tree, input
             }
 
         let property (tree : RefTree, input : RefInput) : unit =
@@ -678,16 +712,42 @@ module TestArgParserPositionalReference =
                 if not (List.isEmpty input.PositionalEvents) then
                     inputsWithEvents <- inputsWithEvents + 1
 
+                let isKeyed (spelling : RefSpelling) : bool =
+                    match spelling with
+                    | RefSpelling.Keyed _ -> true
+                    | RefSpelling.Bare -> false
+
+                if input.PositionalEvents |> List.exists isKeyed then
+                    inputsWithKeyedEvents <- inputsWithKeyedEvents + 1
+
+                let namedOnly =
+                    interpretations tree |> List.filter (fun interp -> acceptsNamed interp input)
+
+                // The named half alone already selects.
+                List.length namedOnly |> shouldBeSmallerThan 2
+
                 match exhaustiveSelect tree input with
                 | RefOutcome.Ambiguous _ -> failwithf "ambiguous outcome for %A on %A" tree input
-                | RefOutcome.Unique _
-                | RefOutcome.NoInterpretation -> ()
+                | RefOutcome.Unique interp ->
+                    // Confirmation: the events agreed, and the case chosen is the one the
+                    // named half had already picked.
+                    match namedOnly with
+                    | [ only ] -> interp.Choices |> shouldEqual only.Choices
+                    | _ -> failwithf "accepted %A, which the named half did not select, on %A" interp input
+                | RefOutcome.NoInterpretation ->
+                    // Veto (or nothing was named-accepted in the first place).
+                    if not (List.isEmpty namedOnly) then
+                        vetoed <- vetoed + 1
 
         let config = Config.QuickThrowOnFailure.WithMaxTest 2000
         Check.One (config, Prop.forAll (Arb.fromGen cases) property)
 
         checkedTrees |> shouldBeGreaterThan 500
         inputsWithEvents |> shouldBeGreaterThan 200
+        // The keyed half of the law is the interesting one, and vetoes must actually happen:
+        // otherwise "confirm or veto" is only being tested on inputs which confirm.
+        inputsWithKeyedEvents |> shouldBeGreaterThan 100
+        vetoed |> shouldBeGreaterThan 20
 
     [<Test>]
     let ``The generator explores every outcome regime`` () =
@@ -815,7 +875,7 @@ module TestArgParserPositionalReference =
         |> shouldEqual RefOutcome.NoInterpretation
 
     [<Test>]
-    let ``Per-case sinks: a distinctive keyed form is itself a structural discriminator`` () =
+    let ``Per-case sinks: a distinctive keyed form confirms or vetoes, but never selects`` () =
         let tree =
             RefTree.Sum (
                 0,
@@ -825,14 +885,32 @@ module TestArgParserPositionalReference =
                 ]
             )
 
-        // Nothing but --files=x: only Foo's interpretation can consume the event.
+        // Foo is what the named half selects on no observations at all: it is empty-satisfiable
+        // and Bar, whose named leaf is required, is not.
+        match exhaustiveSelect tree (input [] []) with
+        | RefOutcome.Unique interp -> interp.Choices |> shouldEqual (Map.ofList [ 0, 0 ])
+        | other -> failwithf "unexpected outcome: %A" other
+
+        // --files=x therefore *confirms* that choice rather than making it: the sink Foo
+        // already carries is the one which claims the form, so the event routes and the
+        // outcome is unchanged.
         match exhaustiveSelect tree (input [] [ RefSpelling.Keyed "files" ]) with
         | RefOutcome.Unique interp ->
             interp.Choices |> shouldEqual (Map.ofList [ 0, 0 ])
             interp.Positionals |> shouldEqual (Set.singleton 1000)
         | other -> failwithf "unexpected outcome: %A" other
 
-        // A keyed form belonging to the case the named observations exclude: no acceptance.
+        // --nums=x names no sink of Foo, so it vetoes: the outcome is failure, and emphatically
+        // not a switch to Bar, whose required named leaf was never observed.
+        exhaustiveSelect tree (input [] [ RefSpelling.Keyed "nums" ])
+        |> shouldEqual RefOutcome.NoInterpretation
+
+        // Likewise where the named observations select Bar: --files belongs to the case they
+        // exclude, so it vetoes rather than dragging the choice back to Foo.
+        match exhaustiveSelect tree (input [ 1 ] []) with
+        | RefOutcome.Unique interp -> interp.Choices |> shouldEqual (Map.ofList [ 0, 1 ])
+        | other -> failwithf "unexpected outcome: %A" other
+
         exhaustiveSelect tree (input [ 1 ] [ RefSpelling.Keyed "files" ])
         |> shouldEqual RefOutcome.NoInterpretation
 
@@ -855,7 +933,18 @@ module TestArgParserPositionalReference =
         // The linearity rule: argv has one positional stream, so P × Q is rejected by
         // capacity while (A × P) + (B × Q) is fine. This is what schema validation will
         // enforce; the model just states the arithmetic.
-        maxPositionals (RefTree.Product [ sink 1000 [ "rest" ] ; sink 1001 [ "files" ] ])
-        |> shouldEqual 2
+        let overCapacity = RefTree.Product [ sink 1000 [ "rest" ] ; sink 1001 [ "files" ] ]
+
+        maxPositionals overCapacity |> shouldEqual 2
 
         maxPositionals perCaseSinks |> shouldEqual 1
+
+        // The model refuses to interpret such a tree at all. In particular it refuses on an
+        // input with no positional events, which routes nothing and so would otherwise sail
+        // past the routing-time check and report a unique interpretation holding both sinks.
+        for events in [ [] ; [ RefSpelling.Bare ] ; [ RefSpelling.Keyed "rest" ] ] do
+            let exc =
+                Assert.Throws<exn> (fun () -> exhaustiveSelect overCapacity (input [] events) |> ignore<RefOutcome>)
+
+            exc.Message
+            |> shouldEqual "linearity violated: this tree admits an interpretation with 2 positional leaves"

--- a/WoofWare.Myriad.Plugins.Test/WoofWare.Myriad.Plugins.Test.fsproj
+++ b/WoofWare.Myriad.Plugins.Test/WoofWare.Myriad.Plugins.Test.fsproj
@@ -47,6 +47,7 @@
     <Compile Include="TestArgParser\TestArgParserEdgeCases.fs" />
     <Compile Include="TestArgParser\TestArgParserDu.fs" />
     <Compile Include="TestArgParser\TestArgParserDuPositional.fs" />
+    <Compile Include="TestArgParser\TestArgParserPositionalReference.fs" />
     <Compile Include="TestArgParser\TestArgParserRuntime.fs" />
     <Compile Include="TestSwagger\TestSwaggerParse.fs" />
     <Compile Include="TestSwagger\TestSuccessResponse.fs" />


### PR DESCRIPTION
Stage 2 of the positional-args-with-unions stack (2/8). Stacked on #574.

Test-only: adds `TestArgParserPositionalReference.fs`, an executable reference model of the *design* for positional args as leaves in the parser tree. It defines the reference tree (`RefTree` with named and positional leaves), complete interpretations, the linearity rule (at most one positional sink per complete interpretation), candidate sets for bare and keyed (`--form=value`) positional spellings (case-insensitive), an acceptance predicate, and `exhaustiveSelect` — the definitional semantics that later stages' resolver must agree with.

Key properties established here (and relied on later):
- the factorization law: acceptance of a full input equals structural acceptance of its named part plus routing of its positional part;
- the bare-token-ambiguity lemma: because a bare token's candidate set is *all* sinks, the existing per-sum generation-time empty-ambiguity check already rules out the inputs that would make bare-token routing ambiguous at capacity ≤ 1.

The model is deliberately exhaustive/naive — it exists to be an oracle, not to be fast. The Stage 5 resolver is later property-tested for equivalence against it (which caught a real bug during development).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
