### PR TITLE
Put positional sinks into the erased runtime tree

### DIFF
--- a/ConsumePlugin/GeneratedArgParserNegationTests.fs
+++ b/ConsumePlugin/GeneratedArgParserNegationTests.fs
@@ -63,37 +63,49 @@ module private ArgParserRuntime_BoolNegation =
         /// Reject the parse (`[<PositionalArgs false>]` / `[<PositionalArgs>]`).
         | Reject
 
-    /// The positional-argument sink, if the schema has one.
+    /// A positional-argument sink: a consumer of the positional-token stream.
     type ErasedPositional =
         {
-            /// Index into the typed layer's converter table.
+            /// Index into the typed layer's positional converter table. Ids live in their own
+            /// space, independent of ErasedLeaf ids.
             Id : int
             /// The forms under which the sink itself can be addressed as `--form value` /
             /// `--form=value` (the field name argified, plus any explicit long forms); the head
-            /// is used in help text.
+            /// is used in help text. Two sinks in mutually exclusive Sum cases may share a
+            /// form: all keyed positional forms have the same arity, and the capacity rule
+            /// means the sinks can never both be active.
             Forms : string list
+            /// The flag-like policy is lexical (it controls tokenization, which happens before
+            /// any case is selected), so every sink in a schema must agree on it;
+            /// WellFormedSchema enforces the agreement.
             FlagLike : ErasedFlagLikeBehaviour
             TypeDescription : string
             Help : string option
         }
 
     /// The shape of a parser: a tree of products (records), sums (discriminated unions) and
-    /// leaves (actual arguments). Leaves are referred to by id; the flat leaf table plus this
-    /// tree fully describe the schema.
+    /// leaves (actual arguments, named or positional). Leaves are referred to by id; the flat
+    /// leaf tables plus this tree fully describe the schema.
     [<RequireQualifiedAccess>]
     type ErasedTree =
         | Leaf of leafId : int
+        /// A positional-stream consumer. At most one may appear in any complete
+        /// interpretation of the tree (one case chosen for every reachable Sum): argv holds a
+        /// single positional stream, and two unbounded consumers would admit no canonical
+        /// partition of it. WellFormedSchema enforces this capacity rule.
+        | PositionalLeaf of positionalId : int
         | Product of children : ErasedTree list
         /// Cases are in declaration order; the string is the case name, for messages.
         | Sum of sumId : int * cases : (string * ErasedTree) list
 
     type ErasedSchema =
         {
-            /// All leaves reachable in the tree, in field declaration order (the order in which
-            /// "missing required argument" errors are reported).
+            /// All named leaves reachable in the tree, in field declaration order (the order
+            /// in which "missing required argument" errors are reported).
             Leaves : ErasedLeaf list
             Tree : ErasedTree
-            Positional : ErasedPositional option
+            /// All positional sinks reachable in the tree, in declaration order.
+            Positionals : ErasedPositional list
         }
 
     /// One observed occurrence of a named argument.
@@ -214,20 +226,23 @@ module private ArgParserRuntime_BoolNegation =
     /// - Any other token in key position is positional.
     let scan (schema : ErasedSchema) (args : string list) : ScanEvent list =
         let collectFlagLike =
-            match schema.Positional with
-            | Some p ->
-                match p.FlagLike with
-                | ErasedFlagLikeBehaviour.Collect -> true
-                | ErasedFlagLikeBehaviour.Reject -> false
-            | None -> false
+            match schema.Positionals with
+            | [] -> false
+            | positionals ->
+                positionals
+                |> List.forall (fun p ->
+                    match p.FlagLike with
+                    | ErasedFlagLikeBehaviour.Collect -> true
+                    | ErasedFlagLikeBehaviour.Reject -> false
+                )
 
-        /// Does this full `--key` token (value part already split off) name the positional sink?
+        /// Does this full `--key` token (value part already split off) name a positional sink?
         let isPositionalKey (key : string) : bool =
-            match schema.Positional with
-            | None -> false
-            | Some p ->
+            schema.Positionals
+            |> List.exists (fun p ->
                 p.Forms
                 |> List.exists (fun form -> String.Equals (key, "--" + form, StringComparison.OrdinalIgnoreCase))
+            )
 
         /// Resolve a pending key which will receive no value (end of input, or `--` next).
         let resolvePending (state : ScanState) : ScanEvent list =
@@ -368,13 +383,17 @@ module private ArgParserRuntime_BoolNegation =
     type Selection =
         {
             Choices : Map<int, int>
-            /// Ids of leaves which are part of the selected interpretation.
+            /// Ids of named leaves which are part of the selected interpretation.
             ActiveLeaves : Set<int>
+            /// The positional sink which is part of the selected interpretation, if any. The
+            /// capacity rule (enforced by WellFormedSchema) guarantees there is at most one.
+            ActivePositional : int option
             Errors : SelectionError list
         }
 
-    /// Can this subtree be satisfied with zero occurrences? A leaf can iff it is not required; a
-    /// product can iff all its children can; a sum can iff some case can.
+    /// Can this subtree be satisfied with zero occurrences? A named leaf can iff it is not
+    /// required; a positional leaf always can (an empty stream is fine); a product can iff all
+    /// its children can; a sum can iff some case can.
     let rec private emptyOk (leaves : Map<int, ErasedLeaf>) (tree : ErasedTree) : bool =
         match tree with
         | ErasedTree.Leaf leafId ->
@@ -382,15 +401,38 @@ module private ArgParserRuntime_BoolNegation =
             | ErasedRequirement.Required -> false
             | ErasedRequirement.Optional
             | ErasedRequirement.HasDefault -> true
+        | ErasedTree.PositionalLeaf _ -> true
         | ErasedTree.Product children -> children |> List.forall (emptyOk leaves)
         | ErasedTree.Sum (_, cases) -> cases |> List.exists (fun (_, case) -> emptyOk leaves case)
 
-    /// All leaf ids under a subtree, in declaration order.
+    /// All named-leaf ids under a subtree, in declaration order.
     let rec leafIds (tree : ErasedTree) : int list =
         match tree with
         | ErasedTree.Leaf leafId -> [ leafId ]
+        | ErasedTree.PositionalLeaf _ -> []
         | ErasedTree.Product children -> children |> List.collect leafIds
         | ErasedTree.Sum (_, cases) -> cases |> List.collect (fun (_, case) -> leafIds case)
+
+    /// All positional-sink ids under a subtree, in declaration order.
+    let rec positionalIds (tree : ErasedTree) : int list =
+        match tree with
+        | ErasedTree.Leaf _ -> []
+        | ErasedTree.PositionalLeaf positionalId -> [ positionalId ]
+        | ErasedTree.Product children -> children |> List.collect positionalIds
+        | ErasedTree.Sum (_, cases) -> cases |> List.collect (fun (_, case) -> positionalIds case)
+
+    /// The maximum number of positional sinks any complete interpretation of the tree can
+    /// contain: a product's interpretations combine its children's, a sum's take the maximum
+    /// over its cases.
+    let rec maxPositionals (tree : ErasedTree) : int =
+        match tree with
+        | ErasedTree.Leaf _ -> 0
+        | ErasedTree.PositionalLeaf _ -> 1
+        | ErasedTree.Product children -> children |> List.sumBy maxPositionals
+        | ErasedTree.Sum (_, cases) ->
+            match cases with
+            | [] -> 0
+            | cases -> cases |> List.map (fun (_, case) -> maxPositionals case) |> List.max
 
     /// Select a case for every Sum node reachable in the selected interpretation, given a witness
     /// (an example source token) for every leaf which received an occurrence.
@@ -402,15 +444,16 @@ module private ArgParserRuntime_BoolNegation =
     let select (schema : ErasedSchema) (observed : Map<int, string>) : Selection =
         let leavesById = schema.Leaves |> List.map (fun leaf -> leaf.Id, leaf) |> Map.ofList
 
-        let rec go (tree : ErasedTree) : Map<int, int> * Set<int> * SelectionError list =
+        let rec go (tree : ErasedTree) : Map<int, int> * Set<int> * Set<int> * SelectionError list =
             match tree with
-            | ErasedTree.Leaf leafId -> Map.empty, Set.singleton leafId, []
+            | ErasedTree.Leaf leafId -> Map.empty, Set.singleton leafId, Set.empty, []
+            | ErasedTree.PositionalLeaf positionalId -> Map.empty, Set.empty, Set.singleton positionalId, []
             | ErasedTree.Product children ->
-                ((Map.empty, Set.empty, []), children)
-                ||> List.fold (fun (choices, active, errors) child ->
-                    let childChoices, childActive, childErrors = go child
+                ((Map.empty, Set.empty, Set.empty, []), children)
+                ||> List.fold (fun (choices, active, activePos, errors) child ->
+                    let childChoices, childActive, childActivePos, childErrors = go child
                     let choices = (choices, childChoices) ||> Map.fold (fun m k v -> Map.add k v m)
-                    choices, Set.union active childActive, errors @ childErrors
+                    choices, Set.union active childActive, Set.union activePos childActivePos, errors @ childErrors
                 )
             | ErasedTree.Sum (sumId, cases) ->
                 let touched =
@@ -428,8 +471,8 @@ module private ArgParserRuntime_BoolNegation =
                 match touched with
                 | [ (index, _, _) ] ->
                     let _, case = List.item index cases
-                    let childChoices, childActive, childErrors = go case
-                    Map.add sumId index childChoices, childActive, childErrors
+                    let childChoices, childActive, childActivePos, childErrors = go case
+                    Map.add sumId index childChoices, childActive, childActivePos, childErrors
                 | [] ->
                     let satisfiable =
                         cases
@@ -438,23 +481,30 @@ module private ArgParserRuntime_BoolNegation =
 
                     match satisfiable with
                     | [ (index, (_, case)) ] ->
-                        let childChoices, childActive, childErrors = go case
-                        Map.add sumId index childChoices, childActive, childErrors
+                        let childChoices, childActive, childActivePos, childErrors = go case
+                        Map.add sumId index childChoices, childActive, childActivePos, childErrors
                     | [] ->
                         let names = cases |> List.map fst
-                        Map.empty, Set.empty, [ SelectionError.NoCaseSelected (sumId, names) ]
+                        Map.empty, Set.empty, Set.empty, [ SelectionError.NoCaseSelected (sumId, names) ]
                     | multiple ->
                         let names = multiple |> List.map (fun (_, (name, _)) -> name)
-                        Map.empty, Set.empty, [ SelectionError.AmbiguousEmptyCases (sumId, names) ]
+                        Map.empty, Set.empty, Set.empty, [ SelectionError.AmbiguousEmptyCases (sumId, names) ]
                 | multiple ->
                     let witnesses = multiple |> List.map (fun (_, name, source) -> name, source)
-                    Map.empty, Set.empty, [ SelectionError.ConflictingCases (sumId, witnesses) ]
+                    Map.empty, Set.empty, Set.empty, [ SelectionError.ConflictingCases (sumId, witnesses) ]
 
-        let choices, active, errors = go schema.Tree
+        let choices, active, activePos, errors = go schema.Tree
 
         {
             Choices = choices
             ActiveLeaves = active
+            ActivePositional =
+                match Set.toList activePos with
+                | [] -> None
+                | [ p ] -> Some p
+                | _ ->
+                    failwith
+                        "WoofWare.Myriad internal error: two positional sinks were active at once; the schema was not validated"
             Errors = errors
         }
 
@@ -537,9 +587,9 @@ module private ArgParserRuntime_BoolNegation =
             )
 
         let noSink =
-            match schema.Positional with
-            | Some _ -> []
-            | None ->
+            match schema.Positionals with
+            | _ :: _ -> []
+            | [] ->
                 let tokens =
                     events
                     |> List.choose (fun event ->
@@ -603,8 +653,26 @@ module private ArgParserRuntime_BoolNegation =
         /// case-insensitive matching (so e.g. forms `foo` and `FOO` collide, as do a literal
         /// form `no-foo` and the negated variant of a negatable `foo`). The token is reported
         /// in the first claimant's spelling; the claimant descriptions are human-readable, in
-        /// declaration order.
+        /// declaration order. Positional sinks *may* share forms with each other (a keyed
+        /// positional form always has the same meaning whichever sink wins), so a collision
+        /// is only reported when at least one claimant is not a sink.
         | TokenCollision of token : string * claimants : string list
+        /// Two positional sinks in the table share an id.
+        | DuplicatePositionalId of positionalId : int
+        /// The tree refers to this positional sink more than once.
+        | PositionalRepeatedInTree of positionalId : int
+        /// The tree refers to a positional-sink id which is not in the table.
+        | PositionalNotInTable of positionalId : int
+        /// A positional sink in the table is not reachable in the tree.
+        | PositionalNotInTree of positionalId : int
+        /// Some complete interpretation of the tree contains more than one positional sink.
+        /// argv holds a single positional stream, and two unbounded consumers would admit no
+        /// canonical partition of it: `P × Q` is malformed, while `(A × P) + (B × Q)` is fine.
+        | PositionalCapacityExceeded of maximum : int
+        /// Positional sinks disagree on the treatment of unrecognised flag-like tokens. The
+        /// policy is lexical — it controls tokenization, which happens before any case is
+        /// selected — so it must be schema-global.
+        | FlagLikePolicyDisagreement
 
     [<RequireQualifiedAccess>]
     module SchemaError =
@@ -634,6 +702,20 @@ module private ArgParserRuntime_BoolNegation =
                     "the token '%s' is claimed by: %s (argument names are matched case-insensitively)"
                     token
                     (String.concat "; " claimants)
+            | SchemaError.DuplicatePositionalId positionalId ->
+                sprintf "two positional-args sinks share the id %i" positionalId
+            | SchemaError.PositionalRepeatedInTree positionalId ->
+                sprintf "the schema tree refers to positional-args sink id %i more than once" positionalId
+            | SchemaError.PositionalNotInTable positionalId ->
+                sprintf "the schema tree refers to positional-args sink id %i, which does not exist" positionalId
+            | SchemaError.PositionalNotInTree positionalId ->
+                sprintf "positional-args sink id %i is not reachable in the schema tree" positionalId
+            | SchemaError.PositionalCapacityExceeded maximum ->
+                sprintf
+                    "some alternative of the schema contains %i positional-args sinks; at most one may be active, because argv holds a single stream of positional args"
+                    maximum
+            | SchemaError.FlagLikePolicyDisagreement ->
+                "positional-args sinks disagree on whether to collect unrecognised flag-like tokens; that choice affects tokenization, which happens before alternatives are chosen between, so all sinks must agree"
 
     /// An ErasedSchema which has passed the structural checks in WellFormedSchema.check.
     ///
@@ -677,10 +759,63 @@ module private ArgParserRuntime_BoolNegation =
                 |> List.filter (fun leafId -> not (Set.contains leafId treeIdSet))
                 |> List.map SchemaError.LeafNotInTree
 
+            let positionalTreeIds = positionalIds schema.Tree
+            let positionalTableIds = schema.Positionals |> List.map (fun p -> p.Id)
+            let positionalTreeIdSet = Set.ofList positionalTreeIds
+            let positionalTableIdSet = Set.ofList positionalTableIds
+
+            let duplicatePositionalIds =
+                positionalTableIds
+                |> List.countBy (fun positionalId -> positionalId)
+                |> List.filter (fun (_, count) -> count > 1)
+                |> List.map (fun (positionalId, _) -> SchemaError.DuplicatePositionalId positionalId)
+
+            let positionalRepeatedInTree =
+                positionalTreeIds
+                |> List.countBy (fun positionalId -> positionalId)
+                |> List.filter (fun (_, count) -> count > 1)
+                |> List.map (fun (positionalId, _) -> SchemaError.PositionalRepeatedInTree positionalId)
+
+            let positionalNotInTable =
+                positionalTreeIds
+                |> List.distinct
+                |> List.filter (fun positionalId -> not (Set.contains positionalId positionalTableIdSet))
+                |> List.map SchemaError.PositionalNotInTable
+
+            let positionalNotInTree =
+                positionalTableIds
+                |> List.distinct
+                |> List.filter (fun positionalId -> not (Set.contains positionalId positionalTreeIdSet))
+                |> List.map SchemaError.PositionalNotInTree
+
+            let capacityExceeded =
+                let maximum = maxPositionals schema.Tree
+
+                if maximum > 1 then
+                    [ SchemaError.PositionalCapacityExceeded maximum ]
+                else
+                    []
+
+            let policyDisagreement =
+                let policies =
+                    schema.Positionals
+                    |> List.map (fun p ->
+                        match p.FlagLike with
+                        | ErasedFlagLikeBehaviour.Collect -> true
+                        | ErasedFlagLikeBehaviour.Reject -> false
+                    )
+                    |> List.distinct
+
+                match policies with
+                | []
+                | [ _ ] -> []
+                | _ -> [ SchemaError.FlagLikePolicyDisagreement ]
+
             let duplicateSumIds =
                 let rec sumIds (tree : ErasedTree) : int list =
                     match tree with
                     | ErasedTree.Leaf _ -> []
+                    | ErasedTree.PositionalLeaf _ -> []
                     | ErasedTree.Product children -> children |> List.collect sumIds
                     | ErasedTree.Sum (sumId, cases) -> sumId :: (cases |> List.collect (fun (_, case) -> sumIds case))
 
@@ -710,48 +845,57 @@ module private ArgParserRuntime_BoolNegation =
                 (schema.Leaves
                  |> List.collect (fun leaf ->
                      let plain =
-                         leaf.Forms |> List.map (fun form -> "--" + form, sprintf "argument '--%s'" form)
+                         leaf.Forms
+                         |> List.map (fun form -> "--" + form, sprintf "argument '--%s'" form, false)
 
                      let negated =
                          if leaf.AcceptsNegation then
                              leaf.Forms
-                             |> List.map (fun form -> "--no-" + form, sprintf "the --no- form of argument '--%s'" form)
+                             |> List.map (fun form ->
+                                 "--no-" + form, sprintf "the --no- form of argument '--%s'" form, false
+                             )
                          else
                              []
 
                      plain @ negated
                  ))
-                @ (
-                    match schema.Positional with
-                    | None -> []
-                    | Some positional ->
-                        positional.Forms
-                        |> List.map (fun form -> "--" + form, sprintf "the positional-args sink '--%s'" form)
-                )
-                @ [ "--help", "the built-in help flag" ]
+                @ (schema.Positionals
+                   |> List.collect (fun positional ->
+                       positional.Forms
+                       |> List.map (fun form -> "--" + form, sprintf "the positional-args sink '--%s'" form, true)
+                   ))
+                @ [ "--help", "the built-in help flag", false ]
 
             let collisions =
                 let indexOf =
                     System.Collections.Generic.Dictionary<string, int> (StringComparer.OrdinalIgnoreCase)
 
-                let buckets = ResizeArray<ResizeArray<string * string>> ()
+                let buckets = ResizeArray<ResizeArray<string * string * bool>> ()
 
-                for token, claimant in claims do
+                for token, claimant, isSink in claims do
                     match indexOf.TryGetValue token with
-                    | true, index -> buckets.[index].Add ((token, claimant))
+                    | true, index -> buckets.[index].Add ((token, claimant, isSink))
                     | false, _ ->
                         indexOf.[token] <- buckets.Count
                         let bucket = ResizeArray ()
-                        bucket.Add ((token, claimant))
+                        bucket.Add ((token, claimant, isSink))
                         buckets.Add bucket
 
                 buckets
                 |> Seq.choose (fun bucket ->
-                    if bucket.Count < 2 then
+                    let allSinks = bucket |> Seq.forall (fun (_, _, isSink) -> isSink)
+
+                    if bucket.Count < 2 || allSinks then
                         None
                     else
-                        let token, _ = bucket.[0]
-                        Some (SchemaError.TokenCollision (token, bucket |> Seq.map snd |> List.ofSeq))
+                        let token, _, _ = bucket.[0]
+
+                        Some (
+                            SchemaError.TokenCollision (
+                                token,
+                                bucket |> Seq.map (fun (_, claimant, _) -> claimant) |> List.ofSeq
+                            )
+                        )
                 )
                 |> List.ofSeq
 
@@ -770,27 +914,31 @@ module private ArgParserRuntime_BoolNegation =
                              []
                      )
                  ))
-                @ (
-                    match schema.Positional with
-                    | None -> []
-                    | Some positional ->
-                        let claimant = "the positional-args sink"
+                @ (schema.Positionals
+                   |> List.collect (fun positional ->
+                       let claimant = sprintf "positional-args sink id %i" positional.Id
 
-                        positional.Forms
-                        |> List.collect (fun form ->
-                            if form = "" then
-                                [ SchemaError.EmptyForm claimant ]
-                            elif form.Contains "=" then
-                                [ SchemaError.FormContainsEquals (claimant, form) ]
-                            else
-                                []
-                        )
-                )
+                       positional.Forms
+                       |> List.collect (fun form ->
+                           if form = "" then
+                               [ SchemaError.EmptyForm claimant ]
+                           elif form.Contains "=" then
+                               [ SchemaError.FormContainsEquals (claimant, form) ]
+                           else
+                               []
+                       )
+                   ))
 
             duplicateLeafIds
             @ repeatedInTree
             @ notInTable
             @ notInTree
+            @ duplicatePositionalIds
+            @ positionalRepeatedInTree
+            @ positionalNotInTable
+            @ positionalNotInTree
+            @ capacityExceeded
+            @ policyDisagreement
             @ duplicateSumIds
             @ noForms
             @ negationOnNonBool
@@ -936,9 +1084,9 @@ module private ArgParserRuntime_BoolNegation =
 
                     consume rest
                 | ScanEvent.Positional (value, afterSeparator, _) ->
-                    match schema.Positional with
-                    | None -> consume rest
-                    | Some _ ->
+                    match schema.Positionals with
+                    | [] -> consume rest
+                    | _ :: _ ->
                         match callbacks.StorePositional value afterSeparator with
                         | Some error -> errors.Add error
                         | None -> ()
@@ -1054,7 +1202,7 @@ module BoolNegationArgParse =
                         (ArgParserRuntime_BoolNegation.ErasedTree.Product (
                             [ ArgParserRuntime_BoolNegation.ErasedTree.Leaf 0 ]
                         ))
-                    Positional = None
+                    Positionals = List.empty
                 }
 
             let parser_storeOccurrence (occurrence : ArgParserRuntime_BoolNegation.ErasedOccurrence) : string option =
@@ -1162,7 +1310,7 @@ module FlagNegationArgParse =
                         (ArgParserRuntime_BoolNegation.ErasedTree.Product (
                             [ ArgParserRuntime_BoolNegation.ErasedTree.Leaf 0 ]
                         ))
-                    Positional = None
+                    Positionals = List.empty
                 }
 
             let parser_storeOccurrence (occurrence : ArgParserRuntime_BoolNegation.ErasedOccurrence) : string option =
@@ -1299,7 +1447,7 @@ module MultipleFormsNegationArgParse =
                         (ArgParserRuntime_BoolNegation.ErasedTree.Product (
                             [ ArgParserRuntime_BoolNegation.ErasedTree.Leaf 0 ]
                         ))
-                    Positional = None
+                    Positionals = List.empty
                 }
 
             let parser_storeOccurrence (occurrence : ArgParserRuntime_BoolNegation.ErasedOccurrence) : string option =
@@ -1451,7 +1599,7 @@ module CombinedFeaturesArgParse =
                                 ArgParserRuntime_BoolNegation.ErasedTree.Leaf 2
                             ]
                         ))
-                    Positional = None
+                    Positionals = List.empty
                 }
 
             let parser_storeOccurrence (occurrence : ArgParserRuntime_BoolNegation.ErasedOccurrence) : string option =

--- a/ConsumePlugin/GeneratedArgs.fs
+++ b/ConsumePlugin/GeneratedArgs.fs
@@ -63,37 +63,49 @@ module private ArgParserRuntime_BasicNoPositionals =
         /// Reject the parse (`[<PositionalArgs false>]` / `[<PositionalArgs>]`).
         | Reject
 
-    /// The positional-argument sink, if the schema has one.
+    /// A positional-argument sink: a consumer of the positional-token stream.
     type ErasedPositional =
         {
-            /// Index into the typed layer's converter table.
+            /// Index into the typed layer's positional converter table. Ids live in their own
+            /// space, independent of ErasedLeaf ids.
             Id : int
             /// The forms under which the sink itself can be addressed as `--form value` /
             /// `--form=value` (the field name argified, plus any explicit long forms); the head
-            /// is used in help text.
+            /// is used in help text. Two sinks in mutually exclusive Sum cases may share a
+            /// form: all keyed positional forms have the same arity, and the capacity rule
+            /// means the sinks can never both be active.
             Forms : string list
+            /// The flag-like policy is lexical (it controls tokenization, which happens before
+            /// any case is selected), so every sink in a schema must agree on it;
+            /// WellFormedSchema enforces the agreement.
             FlagLike : ErasedFlagLikeBehaviour
             TypeDescription : string
             Help : string option
         }
 
     /// The shape of a parser: a tree of products (records), sums (discriminated unions) and
-    /// leaves (actual arguments). Leaves are referred to by id; the flat leaf table plus this
-    /// tree fully describe the schema.
+    /// leaves (actual arguments, named or positional). Leaves are referred to by id; the flat
+    /// leaf tables plus this tree fully describe the schema.
     [<RequireQualifiedAccess>]
     type ErasedTree =
         | Leaf of leafId : int
+        /// A positional-stream consumer. At most one may appear in any complete
+        /// interpretation of the tree (one case chosen for every reachable Sum): argv holds a
+        /// single positional stream, and two unbounded consumers would admit no canonical
+        /// partition of it. WellFormedSchema enforces this capacity rule.
+        | PositionalLeaf of positionalId : int
         | Product of children : ErasedTree list
         /// Cases are in declaration order; the string is the case name, for messages.
         | Sum of sumId : int * cases : (string * ErasedTree) list
 
     type ErasedSchema =
         {
-            /// All leaves reachable in the tree, in field declaration order (the order in which
-            /// "missing required argument" errors are reported).
+            /// All named leaves reachable in the tree, in field declaration order (the order
+            /// in which "missing required argument" errors are reported).
             Leaves : ErasedLeaf list
             Tree : ErasedTree
-            Positional : ErasedPositional option
+            /// All positional sinks reachable in the tree, in declaration order.
+            Positionals : ErasedPositional list
         }
 
     /// One observed occurrence of a named argument.
@@ -214,20 +226,23 @@ module private ArgParserRuntime_BasicNoPositionals =
     /// - Any other token in key position is positional.
     let scan (schema : ErasedSchema) (args : string list) : ScanEvent list =
         let collectFlagLike =
-            match schema.Positional with
-            | Some p ->
-                match p.FlagLike with
-                | ErasedFlagLikeBehaviour.Collect -> true
-                | ErasedFlagLikeBehaviour.Reject -> false
-            | None -> false
+            match schema.Positionals with
+            | [] -> false
+            | positionals ->
+                positionals
+                |> List.forall (fun p ->
+                    match p.FlagLike with
+                    | ErasedFlagLikeBehaviour.Collect -> true
+                    | ErasedFlagLikeBehaviour.Reject -> false
+                )
 
-        /// Does this full `--key` token (value part already split off) name the positional sink?
+        /// Does this full `--key` token (value part already split off) name a positional sink?
         let isPositionalKey (key : string) : bool =
-            match schema.Positional with
-            | None -> false
-            | Some p ->
+            schema.Positionals
+            |> List.exists (fun p ->
                 p.Forms
                 |> List.exists (fun form -> String.Equals (key, "--" + form, StringComparison.OrdinalIgnoreCase))
+            )
 
         /// Resolve a pending key which will receive no value (end of input, or `--` next).
         let resolvePending (state : ScanState) : ScanEvent list =
@@ -368,13 +383,17 @@ module private ArgParserRuntime_BasicNoPositionals =
     type Selection =
         {
             Choices : Map<int, int>
-            /// Ids of leaves which are part of the selected interpretation.
+            /// Ids of named leaves which are part of the selected interpretation.
             ActiveLeaves : Set<int>
+            /// The positional sink which is part of the selected interpretation, if any. The
+            /// capacity rule (enforced by WellFormedSchema) guarantees there is at most one.
+            ActivePositional : int option
             Errors : SelectionError list
         }
 
-    /// Can this subtree be satisfied with zero occurrences? A leaf can iff it is not required; a
-    /// product can iff all its children can; a sum can iff some case can.
+    /// Can this subtree be satisfied with zero occurrences? A named leaf can iff it is not
+    /// required; a positional leaf always can (an empty stream is fine); a product can iff all
+    /// its children can; a sum can iff some case can.
     let rec private emptyOk (leaves : Map<int, ErasedLeaf>) (tree : ErasedTree) : bool =
         match tree with
         | ErasedTree.Leaf leafId ->
@@ -382,15 +401,38 @@ module private ArgParserRuntime_BasicNoPositionals =
             | ErasedRequirement.Required -> false
             | ErasedRequirement.Optional
             | ErasedRequirement.HasDefault -> true
+        | ErasedTree.PositionalLeaf _ -> true
         | ErasedTree.Product children -> children |> List.forall (emptyOk leaves)
         | ErasedTree.Sum (_, cases) -> cases |> List.exists (fun (_, case) -> emptyOk leaves case)
 
-    /// All leaf ids under a subtree, in declaration order.
+    /// All named-leaf ids under a subtree, in declaration order.
     let rec leafIds (tree : ErasedTree) : int list =
         match tree with
         | ErasedTree.Leaf leafId -> [ leafId ]
+        | ErasedTree.PositionalLeaf _ -> []
         | ErasedTree.Product children -> children |> List.collect leafIds
         | ErasedTree.Sum (_, cases) -> cases |> List.collect (fun (_, case) -> leafIds case)
+
+    /// All positional-sink ids under a subtree, in declaration order.
+    let rec positionalIds (tree : ErasedTree) : int list =
+        match tree with
+        | ErasedTree.Leaf _ -> []
+        | ErasedTree.PositionalLeaf positionalId -> [ positionalId ]
+        | ErasedTree.Product children -> children |> List.collect positionalIds
+        | ErasedTree.Sum (_, cases) -> cases |> List.collect (fun (_, case) -> positionalIds case)
+
+    /// The maximum number of positional sinks any complete interpretation of the tree can
+    /// contain: a product's interpretations combine its children's, a sum's take the maximum
+    /// over its cases.
+    let rec maxPositionals (tree : ErasedTree) : int =
+        match tree with
+        | ErasedTree.Leaf _ -> 0
+        | ErasedTree.PositionalLeaf _ -> 1
+        | ErasedTree.Product children -> children |> List.sumBy maxPositionals
+        | ErasedTree.Sum (_, cases) ->
+            match cases with
+            | [] -> 0
+            | cases -> cases |> List.map (fun (_, case) -> maxPositionals case) |> List.max
 
     /// Select a case for every Sum node reachable in the selected interpretation, given a witness
     /// (an example source token) for every leaf which received an occurrence.
@@ -402,15 +444,16 @@ module private ArgParserRuntime_BasicNoPositionals =
     let select (schema : ErasedSchema) (observed : Map<int, string>) : Selection =
         let leavesById = schema.Leaves |> List.map (fun leaf -> leaf.Id, leaf) |> Map.ofList
 
-        let rec go (tree : ErasedTree) : Map<int, int> * Set<int> * SelectionError list =
+        let rec go (tree : ErasedTree) : Map<int, int> * Set<int> * Set<int> * SelectionError list =
             match tree with
-            | ErasedTree.Leaf leafId -> Map.empty, Set.singleton leafId, []
+            | ErasedTree.Leaf leafId -> Map.empty, Set.singleton leafId, Set.empty, []
+            | ErasedTree.PositionalLeaf positionalId -> Map.empty, Set.empty, Set.singleton positionalId, []
             | ErasedTree.Product children ->
-                ((Map.empty, Set.empty, []), children)
-                ||> List.fold (fun (choices, active, errors) child ->
-                    let childChoices, childActive, childErrors = go child
+                ((Map.empty, Set.empty, Set.empty, []), children)
+                ||> List.fold (fun (choices, active, activePos, errors) child ->
+                    let childChoices, childActive, childActivePos, childErrors = go child
                     let choices = (choices, childChoices) ||> Map.fold (fun m k v -> Map.add k v m)
-                    choices, Set.union active childActive, errors @ childErrors
+                    choices, Set.union active childActive, Set.union activePos childActivePos, errors @ childErrors
                 )
             | ErasedTree.Sum (sumId, cases) ->
                 let touched =
@@ -428,8 +471,8 @@ module private ArgParserRuntime_BasicNoPositionals =
                 match touched with
                 | [ (index, _, _) ] ->
                     let _, case = List.item index cases
-                    let childChoices, childActive, childErrors = go case
-                    Map.add sumId index childChoices, childActive, childErrors
+                    let childChoices, childActive, childActivePos, childErrors = go case
+                    Map.add sumId index childChoices, childActive, childActivePos, childErrors
                 | [] ->
                     let satisfiable =
                         cases
@@ -438,23 +481,30 @@ module private ArgParserRuntime_BasicNoPositionals =
 
                     match satisfiable with
                     | [ (index, (_, case)) ] ->
-                        let childChoices, childActive, childErrors = go case
-                        Map.add sumId index childChoices, childActive, childErrors
+                        let childChoices, childActive, childActivePos, childErrors = go case
+                        Map.add sumId index childChoices, childActive, childActivePos, childErrors
                     | [] ->
                         let names = cases |> List.map fst
-                        Map.empty, Set.empty, [ SelectionError.NoCaseSelected (sumId, names) ]
+                        Map.empty, Set.empty, Set.empty, [ SelectionError.NoCaseSelected (sumId, names) ]
                     | multiple ->
                         let names = multiple |> List.map (fun (_, (name, _)) -> name)
-                        Map.empty, Set.empty, [ SelectionError.AmbiguousEmptyCases (sumId, names) ]
+                        Map.empty, Set.empty, Set.empty, [ SelectionError.AmbiguousEmptyCases (sumId, names) ]
                 | multiple ->
                     let witnesses = multiple |> List.map (fun (_, name, source) -> name, source)
-                    Map.empty, Set.empty, [ SelectionError.ConflictingCases (sumId, witnesses) ]
+                    Map.empty, Set.empty, Set.empty, [ SelectionError.ConflictingCases (sumId, witnesses) ]
 
-        let choices, active, errors = go schema.Tree
+        let choices, active, activePos, errors = go schema.Tree
 
         {
             Choices = choices
             ActiveLeaves = active
+            ActivePositional =
+                match Set.toList activePos with
+                | [] -> None
+                | [ p ] -> Some p
+                | _ ->
+                    failwith
+                        "WoofWare.Myriad internal error: two positional sinks were active at once; the schema was not validated"
             Errors = errors
         }
 
@@ -537,9 +587,9 @@ module private ArgParserRuntime_BasicNoPositionals =
             )
 
         let noSink =
-            match schema.Positional with
-            | Some _ -> []
-            | None ->
+            match schema.Positionals with
+            | _ :: _ -> []
+            | [] ->
                 let tokens =
                     events
                     |> List.choose (fun event ->
@@ -603,8 +653,26 @@ module private ArgParserRuntime_BasicNoPositionals =
         /// case-insensitive matching (so e.g. forms `foo` and `FOO` collide, as do a literal
         /// form `no-foo` and the negated variant of a negatable `foo`). The token is reported
         /// in the first claimant's spelling; the claimant descriptions are human-readable, in
-        /// declaration order.
+        /// declaration order. Positional sinks *may* share forms with each other (a keyed
+        /// positional form always has the same meaning whichever sink wins), so a collision
+        /// is only reported when at least one claimant is not a sink.
         | TokenCollision of token : string * claimants : string list
+        /// Two positional sinks in the table share an id.
+        | DuplicatePositionalId of positionalId : int
+        /// The tree refers to this positional sink more than once.
+        | PositionalRepeatedInTree of positionalId : int
+        /// The tree refers to a positional-sink id which is not in the table.
+        | PositionalNotInTable of positionalId : int
+        /// A positional sink in the table is not reachable in the tree.
+        | PositionalNotInTree of positionalId : int
+        /// Some complete interpretation of the tree contains more than one positional sink.
+        /// argv holds a single positional stream, and two unbounded consumers would admit no
+        /// canonical partition of it: `P × Q` is malformed, while `(A × P) + (B × Q)` is fine.
+        | PositionalCapacityExceeded of maximum : int
+        /// Positional sinks disagree on the treatment of unrecognised flag-like tokens. The
+        /// policy is lexical — it controls tokenization, which happens before any case is
+        /// selected — so it must be schema-global.
+        | FlagLikePolicyDisagreement
 
     [<RequireQualifiedAccess>]
     module SchemaError =
@@ -634,6 +702,20 @@ module private ArgParserRuntime_BasicNoPositionals =
                     "the token '%s' is claimed by: %s (argument names are matched case-insensitively)"
                     token
                     (String.concat "; " claimants)
+            | SchemaError.DuplicatePositionalId positionalId ->
+                sprintf "two positional-args sinks share the id %i" positionalId
+            | SchemaError.PositionalRepeatedInTree positionalId ->
+                sprintf "the schema tree refers to positional-args sink id %i more than once" positionalId
+            | SchemaError.PositionalNotInTable positionalId ->
+                sprintf "the schema tree refers to positional-args sink id %i, which does not exist" positionalId
+            | SchemaError.PositionalNotInTree positionalId ->
+                sprintf "positional-args sink id %i is not reachable in the schema tree" positionalId
+            | SchemaError.PositionalCapacityExceeded maximum ->
+                sprintf
+                    "some alternative of the schema contains %i positional-args sinks; at most one may be active, because argv holds a single stream of positional args"
+                    maximum
+            | SchemaError.FlagLikePolicyDisagreement ->
+                "positional-args sinks disagree on whether to collect unrecognised flag-like tokens; that choice affects tokenization, which happens before alternatives are chosen between, so all sinks must agree"
 
     /// An ErasedSchema which has passed the structural checks in WellFormedSchema.check.
     ///
@@ -677,10 +759,63 @@ module private ArgParserRuntime_BasicNoPositionals =
                 |> List.filter (fun leafId -> not (Set.contains leafId treeIdSet))
                 |> List.map SchemaError.LeafNotInTree
 
+            let positionalTreeIds = positionalIds schema.Tree
+            let positionalTableIds = schema.Positionals |> List.map (fun p -> p.Id)
+            let positionalTreeIdSet = Set.ofList positionalTreeIds
+            let positionalTableIdSet = Set.ofList positionalTableIds
+
+            let duplicatePositionalIds =
+                positionalTableIds
+                |> List.countBy (fun positionalId -> positionalId)
+                |> List.filter (fun (_, count) -> count > 1)
+                |> List.map (fun (positionalId, _) -> SchemaError.DuplicatePositionalId positionalId)
+
+            let positionalRepeatedInTree =
+                positionalTreeIds
+                |> List.countBy (fun positionalId -> positionalId)
+                |> List.filter (fun (_, count) -> count > 1)
+                |> List.map (fun (positionalId, _) -> SchemaError.PositionalRepeatedInTree positionalId)
+
+            let positionalNotInTable =
+                positionalTreeIds
+                |> List.distinct
+                |> List.filter (fun positionalId -> not (Set.contains positionalId positionalTableIdSet))
+                |> List.map SchemaError.PositionalNotInTable
+
+            let positionalNotInTree =
+                positionalTableIds
+                |> List.distinct
+                |> List.filter (fun positionalId -> not (Set.contains positionalId positionalTreeIdSet))
+                |> List.map SchemaError.PositionalNotInTree
+
+            let capacityExceeded =
+                let maximum = maxPositionals schema.Tree
+
+                if maximum > 1 then
+                    [ SchemaError.PositionalCapacityExceeded maximum ]
+                else
+                    []
+
+            let policyDisagreement =
+                let policies =
+                    schema.Positionals
+                    |> List.map (fun p ->
+                        match p.FlagLike with
+                        | ErasedFlagLikeBehaviour.Collect -> true
+                        | ErasedFlagLikeBehaviour.Reject -> false
+                    )
+                    |> List.distinct
+
+                match policies with
+                | []
+                | [ _ ] -> []
+                | _ -> [ SchemaError.FlagLikePolicyDisagreement ]
+
             let duplicateSumIds =
                 let rec sumIds (tree : ErasedTree) : int list =
                     match tree with
                     | ErasedTree.Leaf _ -> []
+                    | ErasedTree.PositionalLeaf _ -> []
                     | ErasedTree.Product children -> children |> List.collect sumIds
                     | ErasedTree.Sum (sumId, cases) -> sumId :: (cases |> List.collect (fun (_, case) -> sumIds case))
 
@@ -710,48 +845,57 @@ module private ArgParserRuntime_BasicNoPositionals =
                 (schema.Leaves
                  |> List.collect (fun leaf ->
                      let plain =
-                         leaf.Forms |> List.map (fun form -> "--" + form, sprintf "argument '--%s'" form)
+                         leaf.Forms
+                         |> List.map (fun form -> "--" + form, sprintf "argument '--%s'" form, false)
 
                      let negated =
                          if leaf.AcceptsNegation then
                              leaf.Forms
-                             |> List.map (fun form -> "--no-" + form, sprintf "the --no- form of argument '--%s'" form)
+                             |> List.map (fun form ->
+                                 "--no-" + form, sprintf "the --no- form of argument '--%s'" form, false
+                             )
                          else
                              []
 
                      plain @ negated
                  ))
-                @ (
-                    match schema.Positional with
-                    | None -> []
-                    | Some positional ->
-                        positional.Forms
-                        |> List.map (fun form -> "--" + form, sprintf "the positional-args sink '--%s'" form)
-                )
-                @ [ "--help", "the built-in help flag" ]
+                @ (schema.Positionals
+                   |> List.collect (fun positional ->
+                       positional.Forms
+                       |> List.map (fun form -> "--" + form, sprintf "the positional-args sink '--%s'" form, true)
+                   ))
+                @ [ "--help", "the built-in help flag", false ]
 
             let collisions =
                 let indexOf =
                     System.Collections.Generic.Dictionary<string, int> (StringComparer.OrdinalIgnoreCase)
 
-                let buckets = ResizeArray<ResizeArray<string * string>> ()
+                let buckets = ResizeArray<ResizeArray<string * string * bool>> ()
 
-                for token, claimant in claims do
+                for token, claimant, isSink in claims do
                     match indexOf.TryGetValue token with
-                    | true, index -> buckets.[index].Add ((token, claimant))
+                    | true, index -> buckets.[index].Add ((token, claimant, isSink))
                     | false, _ ->
                         indexOf.[token] <- buckets.Count
                         let bucket = ResizeArray ()
-                        bucket.Add ((token, claimant))
+                        bucket.Add ((token, claimant, isSink))
                         buckets.Add bucket
 
                 buckets
                 |> Seq.choose (fun bucket ->
-                    if bucket.Count < 2 then
+                    let allSinks = bucket |> Seq.forall (fun (_, _, isSink) -> isSink)
+
+                    if bucket.Count < 2 || allSinks then
                         None
                     else
-                        let token, _ = bucket.[0]
-                        Some (SchemaError.TokenCollision (token, bucket |> Seq.map snd |> List.ofSeq))
+                        let token, _, _ = bucket.[0]
+
+                        Some (
+                            SchemaError.TokenCollision (
+                                token,
+                                bucket |> Seq.map (fun (_, claimant, _) -> claimant) |> List.ofSeq
+                            )
+                        )
                 )
                 |> List.ofSeq
 
@@ -770,27 +914,31 @@ module private ArgParserRuntime_BasicNoPositionals =
                              []
                      )
                  ))
-                @ (
-                    match schema.Positional with
-                    | None -> []
-                    | Some positional ->
-                        let claimant = "the positional-args sink"
+                @ (schema.Positionals
+                   |> List.collect (fun positional ->
+                       let claimant = sprintf "positional-args sink id %i" positional.Id
 
-                        positional.Forms
-                        |> List.collect (fun form ->
-                            if form = "" then
-                                [ SchemaError.EmptyForm claimant ]
-                            elif form.Contains "=" then
-                                [ SchemaError.FormContainsEquals (claimant, form) ]
-                            else
-                                []
-                        )
-                )
+                       positional.Forms
+                       |> List.collect (fun form ->
+                           if form = "" then
+                               [ SchemaError.EmptyForm claimant ]
+                           elif form.Contains "=" then
+                               [ SchemaError.FormContainsEquals (claimant, form) ]
+                           else
+                               []
+                       )
+                   ))
 
             duplicateLeafIds
             @ repeatedInTree
             @ notInTable
             @ notInTree
+            @ duplicatePositionalIds
+            @ positionalRepeatedInTree
+            @ positionalNotInTable
+            @ positionalNotInTree
+            @ capacityExceeded
+            @ policyDisagreement
             @ duplicateSumIds
             @ noForms
             @ negationOnNonBool
@@ -936,9 +1084,9 @@ module private ArgParserRuntime_BasicNoPositionals =
 
                     consume rest
                 | ScanEvent.Positional (value, afterSeparator, _) ->
-                    match schema.Positional with
-                    | None -> consume rest
-                    | Some _ ->
+                    match schema.Positionals with
+                    | [] -> consume rest
+                    | _ :: _ ->
                         match callbacks.StorePositional value afterSeparator with
                         | Some error -> errors.Add error
                         | None -> ()
@@ -1096,7 +1244,7 @@ module BasicNoPositionals =
                             ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 3
                         ]
                     ))
-                Positional = None
+                Positionals = List.empty
             }
 
         let parser_storeOccurrence (occurrence : ArgParserRuntime_BasicNoPositionals.ErasedOccurrence) : string option =
@@ -1294,18 +1442,19 @@ module Basic =
                             ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 0
                             ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 1
                             ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 2
+                            ArgParserRuntime_BasicNoPositionals.ErasedTree.PositionalLeaf 0
                         ]
                     ))
-                Positional =
-                    ({
-                        ArgParserRuntime_BasicNoPositionals.ErasedPositional.Id = 3
-                        ArgParserRuntime_BasicNoPositionals.ErasedPositional.Forms = [ "rest" ]
-                        ArgParserRuntime_BasicNoPositionals.ErasedPositional.FlagLike =
-                            ArgParserRuntime_BasicNoPositionals.ErasedFlagLikeBehaviour.Reject
-                        ArgParserRuntime_BasicNoPositionals.ErasedPositional.TypeDescription = ""
-                        ArgParserRuntime_BasicNoPositionals.ErasedPositional.Help = None
-                    })
-                    |> Some
+                Positionals =
+                    [
+                        {
+                            Id = 0
+                            Forms = [ "rest" ]
+                            FlagLike = ArgParserRuntime_BasicNoPositionals.ErasedFlagLikeBehaviour.Reject
+                            TypeDescription = ""
+                            Help = None
+                        }
+                    ]
             }
 
         let parser_storeOccurrence (occurrence : ArgParserRuntime_BasicNoPositionals.ErasedOccurrence) : string option =
@@ -1494,18 +1643,19 @@ module BasicWithIntPositionals =
                             ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 0
                             ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 1
                             ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 2
+                            ArgParserRuntime_BasicNoPositionals.ErasedTree.PositionalLeaf 0
                         ]
                     ))
-                Positional =
-                    ({
-                        ArgParserRuntime_BasicNoPositionals.ErasedPositional.Id = 3
-                        ArgParserRuntime_BasicNoPositionals.ErasedPositional.Forms = [ "rest" ]
-                        ArgParserRuntime_BasicNoPositionals.ErasedPositional.FlagLike =
-                            ArgParserRuntime_BasicNoPositionals.ErasedFlagLikeBehaviour.Reject
-                        ArgParserRuntime_BasicNoPositionals.ErasedPositional.TypeDescription = ""
-                        ArgParserRuntime_BasicNoPositionals.ErasedPositional.Help = None
-                    })
-                    |> Some
+                Positionals =
+                    [
+                        {
+                            Id = 0
+                            Forms = [ "rest" ]
+                            FlagLike = ArgParserRuntime_BasicNoPositionals.ErasedFlagLikeBehaviour.Reject
+                            TypeDescription = ""
+                            Help = None
+                        }
+                    ]
             }
 
         let parser_storeOccurrence (occurrence : ArgParserRuntime_BasicNoPositionals.ErasedOccurrence) : string option =
@@ -1811,18 +1961,19 @@ module LoadsOfTypes =
                             ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 7
                             ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 8
                             ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 9
+                            ArgParserRuntime_BasicNoPositionals.ErasedTree.PositionalLeaf 0
                         ]
                     ))
-                Positional =
-                    ({
-                        ArgParserRuntime_BasicNoPositionals.ErasedPositional.Id = 10
-                        ArgParserRuntime_BasicNoPositionals.ErasedPositional.Forms = [ "positionals" ]
-                        ArgParserRuntime_BasicNoPositionals.ErasedPositional.FlagLike =
-                            ArgParserRuntime_BasicNoPositionals.ErasedFlagLikeBehaviour.Reject
-                        ArgParserRuntime_BasicNoPositionals.ErasedPositional.TypeDescription = ""
-                        ArgParserRuntime_BasicNoPositionals.ErasedPositional.Help = None
-                    })
-                    |> Some
+                Positionals =
+                    [
+                        {
+                            Id = 0
+                            Forms = [ "positionals" ]
+                            FlagLike = ArgParserRuntime_BasicNoPositionals.ErasedFlagLikeBehaviour.Reject
+                            TypeDescription = ""
+                            Help = None
+                        }
+                    ]
             }
 
         let parser_storeOccurrence (occurrence : ArgParserRuntime_BasicNoPositionals.ErasedOccurrence) : string option =
@@ -2304,7 +2455,7 @@ module LoadsOfTypesNoPositionals =
                             ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 9
                         ]
                     ))
-                Positional = None
+                Positionals = List.empty
             }
 
         let parser_storeOccurrence (occurrence : ArgParserRuntime_BasicNoPositionals.ErasedOccurrence) : string option =
@@ -2690,7 +2841,7 @@ module DatesAndTimesArgParse =
                                 ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 3
                             ]
                         ))
-                    Positional = None
+                    Positionals = List.empty
                 }
 
             let parser_storeOccurrence
@@ -2938,7 +3089,7 @@ module ParentRecordArgParse =
                                 ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 2
                             ]
                         ))
-                    Positional = None
+                    Positionals = List.empty
                 }
 
             let parser_storeOccurrence
@@ -3129,7 +3280,7 @@ module ParentRecordChildDefaultArgParse =
                                 ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 1
                             ]
                         ))
-                    Positional = None
+                    Positionals = List.empty
                 }
 
             let parser_storeOccurrence
@@ -3291,20 +3442,23 @@ module ParentRecordChildPosArgParse =
                             [
                                 ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 0
                                 ArgParserRuntime_BasicNoPositionals.ErasedTree.Product (
-                                    [ ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 1 ]
+                                    [
+                                        ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 1
+                                        ArgParserRuntime_BasicNoPositionals.ErasedTree.PositionalLeaf 0
+                                    ]
                                 )
                             ]
                         ))
-                    Positional =
-                        ({
-                            ArgParserRuntime_BasicNoPositionals.ErasedPositional.Id = 2
-                            ArgParserRuntime_BasicNoPositionals.ErasedPositional.Forms = [ "thing2" ]
-                            ArgParserRuntime_BasicNoPositionals.ErasedPositional.FlagLike =
-                                ArgParserRuntime_BasicNoPositionals.ErasedFlagLikeBehaviour.Reject
-                            ArgParserRuntime_BasicNoPositionals.ErasedPositional.TypeDescription = ""
-                            ArgParserRuntime_BasicNoPositionals.ErasedPositional.Help = None
-                        })
-                        |> Some
+                    Positionals =
+                        [
+                            {
+                                Id = 0
+                                Forms = [ "thing2" ]
+                                FlagLike = ArgParserRuntime_BasicNoPositionals.ErasedFlagLikeBehaviour.Reject
+                                TypeDescription = ""
+                                Help = None
+                            }
+                        ]
                 }
 
             let parser_storeOccurrence
@@ -3472,18 +3626,19 @@ module ParentRecordSelfPosArgParse =
                                         ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 1
                                     ]
                                 )
+                                ArgParserRuntime_BasicNoPositionals.ErasedTree.PositionalLeaf 0
                             ]
                         ))
-                    Positional =
-                        ({
-                            ArgParserRuntime_BasicNoPositionals.ErasedPositional.Id = 2
-                            ArgParserRuntime_BasicNoPositionals.ErasedPositional.Forms = [ "and-another" ]
-                            ArgParserRuntime_BasicNoPositionals.ErasedPositional.FlagLike =
-                                ArgParserRuntime_BasicNoPositionals.ErasedFlagLikeBehaviour.Reject
-                            ArgParserRuntime_BasicNoPositionals.ErasedPositional.TypeDescription = ""
-                            ArgParserRuntime_BasicNoPositionals.ErasedPositional.Help = None
-                        })
-                        |> Some
+                    Positionals =
+                        [
+                            {
+                                Id = 0
+                                Forms = [ "and-another" ]
+                                FlagLike = ArgParserRuntime_BasicNoPositionals.ErasedFlagLikeBehaviour.Reject
+                                TypeDescription = ""
+                                Help = None
+                            }
+                        ]
                 }
 
             let parser_storeOccurrence
@@ -3614,17 +3769,20 @@ module ChoicePositionalsArgParse =
             let parser_schema : ArgParserRuntime_BasicNoPositionals.ErasedSchema =
                 {
                     Leaves = List.empty
-                    Tree = (ArgParserRuntime_BasicNoPositionals.ErasedTree.Product (List.empty))
-                    Positional =
-                        ({
-                            ArgParserRuntime_BasicNoPositionals.ErasedPositional.Id = 0
-                            ArgParserRuntime_BasicNoPositionals.ErasedPositional.Forms = [ "args" ]
-                            ArgParserRuntime_BasicNoPositionals.ErasedPositional.FlagLike =
-                                ArgParserRuntime_BasicNoPositionals.ErasedFlagLikeBehaviour.Reject
-                            ArgParserRuntime_BasicNoPositionals.ErasedPositional.TypeDescription = ""
-                            ArgParserRuntime_BasicNoPositionals.ErasedPositional.Help = None
-                        })
-                        |> Some
+                    Tree =
+                        (ArgParserRuntime_BasicNoPositionals.ErasedTree.Product (
+                            [ ArgParserRuntime_BasicNoPositionals.ErasedTree.PositionalLeaf 0 ]
+                        ))
+                    Positionals =
+                        [
+                            {
+                                Id = 0
+                                Forms = [ "args" ]
+                                FlagLike = ArgParserRuntime_BasicNoPositionals.ErasedFlagLikeBehaviour.Reject
+                                TypeDescription = ""
+                                Help = None
+                            }
+                        ]
                 }
 
             let parser_storeOccurrence
@@ -3731,7 +3889,7 @@ module ContainsBoolEnvVarArgParse =
                         (ArgParserRuntime_BasicNoPositionals.ErasedTree.Product (
                             [ ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 0 ]
                         ))
-                    Positional = None
+                    Positionals = List.empty
                 }
 
             let parser_storeOccurrence
@@ -3871,7 +4029,7 @@ module WithFlagDuArgParse =
                         (ArgParserRuntime_BasicNoPositionals.ErasedTree.Product (
                             [ ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 0 ]
                         ))
-                    Positional = None
+                    Positionals = List.empty
                 }
 
             let parser_storeOccurrence
@@ -4013,7 +4171,7 @@ module ContainsFlagEnvVarArgParse =
                         (ArgParserRuntime_BasicNoPositionals.ErasedTree.Product (
                             [ ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 0 ]
                         ))
-                    Positional = None
+                    Positionals = List.empty
                 }
 
             let parser_storeOccurrence
@@ -4204,7 +4362,7 @@ module ContainsFlagDefaultValueArgParse =
                         (ArgParserRuntime_BasicNoPositionals.ErasedTree.Product (
                             [ ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 0 ]
                         ))
-                    Positional = None
+                    Positionals = List.empty
                 }
 
             let parser_storeOccurrence
@@ -4361,7 +4519,7 @@ module ManyLongFormsArgParse =
                                 ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 1
                             ]
                         ))
-                    Positional = None
+                    Positionals = List.empty
                 }
 
             let parser_storeOccurrence
@@ -4505,18 +4663,21 @@ module AliasedPositionalsArgParse =
                         ]
                     Tree =
                         (ArgParserRuntime_BasicNoPositionals.ErasedTree.Product (
-                            [ ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 0 ]
+                            [
+                                ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 0
+                                ArgParserRuntime_BasicNoPositionals.ErasedTree.PositionalLeaf 0
+                            ]
                         ))
-                    Positional =
-                        ({
-                            ArgParserRuntime_BasicNoPositionals.ErasedPositional.Id = 1
-                            ArgParserRuntime_BasicNoPositionals.ErasedPositional.Forms = [ "rest" ; "remainder" ]
-                            ArgParserRuntime_BasicNoPositionals.ErasedPositional.FlagLike =
-                                ArgParserRuntime_BasicNoPositionals.ErasedFlagLikeBehaviour.Reject
-                            ArgParserRuntime_BasicNoPositionals.ErasedPositional.TypeDescription = ""
-                            ArgParserRuntime_BasicNoPositionals.ErasedPositional.Help = None
-                        })
-                        |> Some
+                    Positionals =
+                        [
+                            {
+                                Id = 0
+                                Forms = [ "rest" ; "remainder" ]
+                                FlagLike = ArgParserRuntime_BasicNoPositionals.ErasedFlagLikeBehaviour.Reject
+                                TypeDescription = ""
+                                Help = None
+                            }
+                        ]
                 }
 
             let parser_storeOccurrence
@@ -4640,21 +4801,25 @@ module FlagsIntoPositionalArgsArgParse =
                         ]
                     Tree =
                         (ArgParserRuntime_BasicNoPositionals.ErasedTree.Product (
-                            [ ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 0 ]
+                            [
+                                ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 0
+                                ArgParserRuntime_BasicNoPositionals.ErasedTree.PositionalLeaf 0
+                            ]
                         ))
-                    Positional =
-                        ({
-                            ArgParserRuntime_BasicNoPositionals.ErasedPositional.Id = 1
-                            ArgParserRuntime_BasicNoPositionals.ErasedPositional.Forms = [ "grab-everything" ]
-                            ArgParserRuntime_BasicNoPositionals.ErasedPositional.FlagLike =
-                                (if true then
-                                     ArgParserRuntime_BasicNoPositionals.ErasedFlagLikeBehaviour.Collect
-                                 else
-                                     ArgParserRuntime_BasicNoPositionals.ErasedFlagLikeBehaviour.Reject)
-                            ArgParserRuntime_BasicNoPositionals.ErasedPositional.TypeDescription = ""
-                            ArgParserRuntime_BasicNoPositionals.ErasedPositional.Help = None
-                        })
-                        |> Some
+                    Positionals =
+                        [
+                            {
+                                Id = 0
+                                Forms = [ "grab-everything" ]
+                                FlagLike =
+                                    (if true then
+                                         ArgParserRuntime_BasicNoPositionals.ErasedFlagLikeBehaviour.Collect
+                                     else
+                                         ArgParserRuntime_BasicNoPositionals.ErasedFlagLikeBehaviour.Reject)
+                                TypeDescription = ""
+                                Help = None
+                            }
+                        ]
                 }
 
             let parser_storeOccurrence
@@ -4778,21 +4943,25 @@ module FlagsIntoPositionalArgsChoiceArgParse =
                         ]
                     Tree =
                         (ArgParserRuntime_BasicNoPositionals.ErasedTree.Product (
-                            [ ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 0 ]
+                            [
+                                ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 0
+                                ArgParserRuntime_BasicNoPositionals.ErasedTree.PositionalLeaf 0
+                            ]
                         ))
-                    Positional =
-                        ({
-                            ArgParserRuntime_BasicNoPositionals.ErasedPositional.Id = 1
-                            ArgParserRuntime_BasicNoPositionals.ErasedPositional.Forms = [ "grab-everything" ]
-                            ArgParserRuntime_BasicNoPositionals.ErasedPositional.FlagLike =
-                                (if true then
-                                     ArgParserRuntime_BasicNoPositionals.ErasedFlagLikeBehaviour.Collect
-                                 else
-                                     ArgParserRuntime_BasicNoPositionals.ErasedFlagLikeBehaviour.Reject)
-                            ArgParserRuntime_BasicNoPositionals.ErasedPositional.TypeDescription = ""
-                            ArgParserRuntime_BasicNoPositionals.ErasedPositional.Help = None
-                        })
-                        |> Some
+                    Positionals =
+                        [
+                            {
+                                Id = 0
+                                Forms = [ "grab-everything" ]
+                                FlagLike =
+                                    (if true then
+                                         ArgParserRuntime_BasicNoPositionals.ErasedFlagLikeBehaviour.Collect
+                                     else
+                                         ArgParserRuntime_BasicNoPositionals.ErasedFlagLikeBehaviour.Reject)
+                                TypeDescription = ""
+                                Help = None
+                            }
+                        ]
                 }
 
             let parser_storeOccurrence
@@ -4922,21 +5091,25 @@ module FlagsIntoPositionalArgsIntArgParse =
                         ]
                     Tree =
                         (ArgParserRuntime_BasicNoPositionals.ErasedTree.Product (
-                            [ ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 0 ]
+                            [
+                                ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 0
+                                ArgParserRuntime_BasicNoPositionals.ErasedTree.PositionalLeaf 0
+                            ]
                         ))
-                    Positional =
-                        ({
-                            ArgParserRuntime_BasicNoPositionals.ErasedPositional.Id = 1
-                            ArgParserRuntime_BasicNoPositionals.ErasedPositional.Forms = [ "grab-everything" ]
-                            ArgParserRuntime_BasicNoPositionals.ErasedPositional.FlagLike =
-                                (if true then
-                                     ArgParserRuntime_BasicNoPositionals.ErasedFlagLikeBehaviour.Collect
-                                 else
-                                     ArgParserRuntime_BasicNoPositionals.ErasedFlagLikeBehaviour.Reject)
-                            ArgParserRuntime_BasicNoPositionals.ErasedPositional.TypeDescription = ""
-                            ArgParserRuntime_BasicNoPositionals.ErasedPositional.Help = None
-                        })
-                        |> Some
+                    Positionals =
+                        [
+                            {
+                                Id = 0
+                                Forms = [ "grab-everything" ]
+                                FlagLike =
+                                    (if true then
+                                         ArgParserRuntime_BasicNoPositionals.ErasedFlagLikeBehaviour.Collect
+                                     else
+                                         ArgParserRuntime_BasicNoPositionals.ErasedFlagLikeBehaviour.Reject)
+                                TypeDescription = ""
+                                Help = None
+                            }
+                        ]
                 }
 
             let parser_storeOccurrence
@@ -5060,21 +5233,25 @@ module FlagsIntoPositionalArgsIntChoiceArgParse =
                         ]
                     Tree =
                         (ArgParserRuntime_BasicNoPositionals.ErasedTree.Product (
-                            [ ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 0 ]
+                            [
+                                ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 0
+                                ArgParserRuntime_BasicNoPositionals.ErasedTree.PositionalLeaf 0
+                            ]
                         ))
-                    Positional =
-                        ({
-                            ArgParserRuntime_BasicNoPositionals.ErasedPositional.Id = 1
-                            ArgParserRuntime_BasicNoPositionals.ErasedPositional.Forms = [ "grab-everything" ]
-                            ArgParserRuntime_BasicNoPositionals.ErasedPositional.FlagLike =
-                                (if true then
-                                     ArgParserRuntime_BasicNoPositionals.ErasedFlagLikeBehaviour.Collect
-                                 else
-                                     ArgParserRuntime_BasicNoPositionals.ErasedFlagLikeBehaviour.Reject)
-                            ArgParserRuntime_BasicNoPositionals.ErasedPositional.TypeDescription = ""
-                            ArgParserRuntime_BasicNoPositionals.ErasedPositional.Help = None
-                        })
-                        |> Some
+                    Positionals =
+                        [
+                            {
+                                Id = 0
+                                Forms = [ "grab-everything" ]
+                                FlagLike =
+                                    (if true then
+                                         ArgParserRuntime_BasicNoPositionals.ErasedFlagLikeBehaviour.Collect
+                                     else
+                                         ArgParserRuntime_BasicNoPositionals.ErasedFlagLikeBehaviour.Reject)
+                                TypeDescription = ""
+                                Help = None
+                            }
+                        ]
                 }
 
             let parser_storeOccurrence
@@ -5204,21 +5381,25 @@ module FlagsIntoPositionalArgs'ArgParse =
                         ]
                     Tree =
                         (ArgParserRuntime_BasicNoPositionals.ErasedTree.Product (
-                            [ ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 0 ]
+                            [
+                                ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 0
+                                ArgParserRuntime_BasicNoPositionals.ErasedTree.PositionalLeaf 0
+                            ]
                         ))
-                    Positional =
-                        ({
-                            ArgParserRuntime_BasicNoPositionals.ErasedPositional.Id = 1
-                            ArgParserRuntime_BasicNoPositionals.ErasedPositional.Forms = [ "dont-grab-everything" ]
-                            ArgParserRuntime_BasicNoPositionals.ErasedPositional.FlagLike =
-                                (if false then
-                                     ArgParserRuntime_BasicNoPositionals.ErasedFlagLikeBehaviour.Collect
-                                 else
-                                     ArgParserRuntime_BasicNoPositionals.ErasedFlagLikeBehaviour.Reject)
-                            ArgParserRuntime_BasicNoPositionals.ErasedPositional.TypeDescription = ""
-                            ArgParserRuntime_BasicNoPositionals.ErasedPositional.Help = None
-                        })
-                        |> Some
+                    Positionals =
+                        [
+                            {
+                                Id = 0
+                                Forms = [ "dont-grab-everything" ]
+                                FlagLike =
+                                    (if false then
+                                         ArgParserRuntime_BasicNoPositionals.ErasedFlagLikeBehaviour.Collect
+                                     else
+                                         ArgParserRuntime_BasicNoPositionals.ErasedFlagLikeBehaviour.Reject)
+                                TypeDescription = ""
+                                Help = None
+                            }
+                        ]
                 }
 
             let parser_storeOccurrence
@@ -5369,7 +5550,7 @@ module WithTypeHelp =
                             ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 2
                         ]
                     ))
-                Positional = None
+                Positionals = List.empty
             }
 
         let parser_storeOccurrence (occurrence : ArgParserRuntime_BasicNoPositionals.ErasedOccurrence) : string option =
@@ -5558,7 +5739,7 @@ You can use this to provide detailed documentation for your argument parser."
                             ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 2
                         ]
                     ))
-                Positional = None
+                Positionals = List.empty
             }
 
         let parser_storeOccurrence (occurrence : ArgParserRuntime_BasicNoPositionals.ErasedOccurrence) : string option =
@@ -5711,7 +5892,7 @@ module NonPositionalBoolList =
                     (ArgParserRuntime_BasicNoPositionals.ErasedTree.Product (
                         [ ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 0 ]
                     ))
-                Positional = None
+                Positionals = List.empty
             }
 
         let parser_storeOccurrence (occurrence : ArgParserRuntime_BasicNoPositionals.ErasedOccurrence) : string option =

--- a/ConsumePlugin/GeneratedDuArgs.fs
+++ b/ConsumePlugin/GeneratedDuArgs.fs
@@ -63,37 +63,49 @@ module private ArgParserRuntime_DuArgs =
         /// Reject the parse (`[<PositionalArgs false>]` / `[<PositionalArgs>]`).
         | Reject
 
-    /// The positional-argument sink, if the schema has one.
+    /// A positional-argument sink: a consumer of the positional-token stream.
     type ErasedPositional =
         {
-            /// Index into the typed layer's converter table.
+            /// Index into the typed layer's positional converter table. Ids live in their own
+            /// space, independent of ErasedLeaf ids.
             Id : int
             /// The forms under which the sink itself can be addressed as `--form value` /
             /// `--form=value` (the field name argified, plus any explicit long forms); the head
-            /// is used in help text.
+            /// is used in help text. Two sinks in mutually exclusive Sum cases may share a
+            /// form: all keyed positional forms have the same arity, and the capacity rule
+            /// means the sinks can never both be active.
             Forms : string list
+            /// The flag-like policy is lexical (it controls tokenization, which happens before
+            /// any case is selected), so every sink in a schema must agree on it;
+            /// WellFormedSchema enforces the agreement.
             FlagLike : ErasedFlagLikeBehaviour
             TypeDescription : string
             Help : string option
         }
 
     /// The shape of a parser: a tree of products (records), sums (discriminated unions) and
-    /// leaves (actual arguments). Leaves are referred to by id; the flat leaf table plus this
-    /// tree fully describe the schema.
+    /// leaves (actual arguments, named or positional). Leaves are referred to by id; the flat
+    /// leaf tables plus this tree fully describe the schema.
     [<RequireQualifiedAccess>]
     type ErasedTree =
         | Leaf of leafId : int
+        /// A positional-stream consumer. At most one may appear in any complete
+        /// interpretation of the tree (one case chosen for every reachable Sum): argv holds a
+        /// single positional stream, and two unbounded consumers would admit no canonical
+        /// partition of it. WellFormedSchema enforces this capacity rule.
+        | PositionalLeaf of positionalId : int
         | Product of children : ErasedTree list
         /// Cases are in declaration order; the string is the case name, for messages.
         | Sum of sumId : int * cases : (string * ErasedTree) list
 
     type ErasedSchema =
         {
-            /// All leaves reachable in the tree, in field declaration order (the order in which
-            /// "missing required argument" errors are reported).
+            /// All named leaves reachable in the tree, in field declaration order (the order
+            /// in which "missing required argument" errors are reported).
             Leaves : ErasedLeaf list
             Tree : ErasedTree
-            Positional : ErasedPositional option
+            /// All positional sinks reachable in the tree, in declaration order.
+            Positionals : ErasedPositional list
         }
 
     /// One observed occurrence of a named argument.
@@ -214,20 +226,23 @@ module private ArgParserRuntime_DuArgs =
     /// - Any other token in key position is positional.
     let scan (schema : ErasedSchema) (args : string list) : ScanEvent list =
         let collectFlagLike =
-            match schema.Positional with
-            | Some p ->
-                match p.FlagLike with
-                | ErasedFlagLikeBehaviour.Collect -> true
-                | ErasedFlagLikeBehaviour.Reject -> false
-            | None -> false
+            match schema.Positionals with
+            | [] -> false
+            | positionals ->
+                positionals
+                |> List.forall (fun p ->
+                    match p.FlagLike with
+                    | ErasedFlagLikeBehaviour.Collect -> true
+                    | ErasedFlagLikeBehaviour.Reject -> false
+                )
 
-        /// Does this full `--key` token (value part already split off) name the positional sink?
+        /// Does this full `--key` token (value part already split off) name a positional sink?
         let isPositionalKey (key : string) : bool =
-            match schema.Positional with
-            | None -> false
-            | Some p ->
+            schema.Positionals
+            |> List.exists (fun p ->
                 p.Forms
                 |> List.exists (fun form -> String.Equals (key, "--" + form, StringComparison.OrdinalIgnoreCase))
+            )
 
         /// Resolve a pending key which will receive no value (end of input, or `--` next).
         let resolvePending (state : ScanState) : ScanEvent list =
@@ -368,13 +383,17 @@ module private ArgParserRuntime_DuArgs =
     type Selection =
         {
             Choices : Map<int, int>
-            /// Ids of leaves which are part of the selected interpretation.
+            /// Ids of named leaves which are part of the selected interpretation.
             ActiveLeaves : Set<int>
+            /// The positional sink which is part of the selected interpretation, if any. The
+            /// capacity rule (enforced by WellFormedSchema) guarantees there is at most one.
+            ActivePositional : int option
             Errors : SelectionError list
         }
 
-    /// Can this subtree be satisfied with zero occurrences? A leaf can iff it is not required; a
-    /// product can iff all its children can; a sum can iff some case can.
+    /// Can this subtree be satisfied with zero occurrences? A named leaf can iff it is not
+    /// required; a positional leaf always can (an empty stream is fine); a product can iff all
+    /// its children can; a sum can iff some case can.
     let rec private emptyOk (leaves : Map<int, ErasedLeaf>) (tree : ErasedTree) : bool =
         match tree with
         | ErasedTree.Leaf leafId ->
@@ -382,15 +401,38 @@ module private ArgParserRuntime_DuArgs =
             | ErasedRequirement.Required -> false
             | ErasedRequirement.Optional
             | ErasedRequirement.HasDefault -> true
+        | ErasedTree.PositionalLeaf _ -> true
         | ErasedTree.Product children -> children |> List.forall (emptyOk leaves)
         | ErasedTree.Sum (_, cases) -> cases |> List.exists (fun (_, case) -> emptyOk leaves case)
 
-    /// All leaf ids under a subtree, in declaration order.
+    /// All named-leaf ids under a subtree, in declaration order.
     let rec leafIds (tree : ErasedTree) : int list =
         match tree with
         | ErasedTree.Leaf leafId -> [ leafId ]
+        | ErasedTree.PositionalLeaf _ -> []
         | ErasedTree.Product children -> children |> List.collect leafIds
         | ErasedTree.Sum (_, cases) -> cases |> List.collect (fun (_, case) -> leafIds case)
+
+    /// All positional-sink ids under a subtree, in declaration order.
+    let rec positionalIds (tree : ErasedTree) : int list =
+        match tree with
+        | ErasedTree.Leaf _ -> []
+        | ErasedTree.PositionalLeaf positionalId -> [ positionalId ]
+        | ErasedTree.Product children -> children |> List.collect positionalIds
+        | ErasedTree.Sum (_, cases) -> cases |> List.collect (fun (_, case) -> positionalIds case)
+
+    /// The maximum number of positional sinks any complete interpretation of the tree can
+    /// contain: a product's interpretations combine its children's, a sum's take the maximum
+    /// over its cases.
+    let rec maxPositionals (tree : ErasedTree) : int =
+        match tree with
+        | ErasedTree.Leaf _ -> 0
+        | ErasedTree.PositionalLeaf _ -> 1
+        | ErasedTree.Product children -> children |> List.sumBy maxPositionals
+        | ErasedTree.Sum (_, cases) ->
+            match cases with
+            | [] -> 0
+            | cases -> cases |> List.map (fun (_, case) -> maxPositionals case) |> List.max
 
     /// Select a case for every Sum node reachable in the selected interpretation, given a witness
     /// (an example source token) for every leaf which received an occurrence.
@@ -402,15 +444,16 @@ module private ArgParserRuntime_DuArgs =
     let select (schema : ErasedSchema) (observed : Map<int, string>) : Selection =
         let leavesById = schema.Leaves |> List.map (fun leaf -> leaf.Id, leaf) |> Map.ofList
 
-        let rec go (tree : ErasedTree) : Map<int, int> * Set<int> * SelectionError list =
+        let rec go (tree : ErasedTree) : Map<int, int> * Set<int> * Set<int> * SelectionError list =
             match tree with
-            | ErasedTree.Leaf leafId -> Map.empty, Set.singleton leafId, []
+            | ErasedTree.Leaf leafId -> Map.empty, Set.singleton leafId, Set.empty, []
+            | ErasedTree.PositionalLeaf positionalId -> Map.empty, Set.empty, Set.singleton positionalId, []
             | ErasedTree.Product children ->
-                ((Map.empty, Set.empty, []), children)
-                ||> List.fold (fun (choices, active, errors) child ->
-                    let childChoices, childActive, childErrors = go child
+                ((Map.empty, Set.empty, Set.empty, []), children)
+                ||> List.fold (fun (choices, active, activePos, errors) child ->
+                    let childChoices, childActive, childActivePos, childErrors = go child
                     let choices = (choices, childChoices) ||> Map.fold (fun m k v -> Map.add k v m)
-                    choices, Set.union active childActive, errors @ childErrors
+                    choices, Set.union active childActive, Set.union activePos childActivePos, errors @ childErrors
                 )
             | ErasedTree.Sum (sumId, cases) ->
                 let touched =
@@ -428,8 +471,8 @@ module private ArgParserRuntime_DuArgs =
                 match touched with
                 | [ (index, _, _) ] ->
                     let _, case = List.item index cases
-                    let childChoices, childActive, childErrors = go case
-                    Map.add sumId index childChoices, childActive, childErrors
+                    let childChoices, childActive, childActivePos, childErrors = go case
+                    Map.add sumId index childChoices, childActive, childActivePos, childErrors
                 | [] ->
                     let satisfiable =
                         cases
@@ -438,23 +481,30 @@ module private ArgParserRuntime_DuArgs =
 
                     match satisfiable with
                     | [ (index, (_, case)) ] ->
-                        let childChoices, childActive, childErrors = go case
-                        Map.add sumId index childChoices, childActive, childErrors
+                        let childChoices, childActive, childActivePos, childErrors = go case
+                        Map.add sumId index childChoices, childActive, childActivePos, childErrors
                     | [] ->
                         let names = cases |> List.map fst
-                        Map.empty, Set.empty, [ SelectionError.NoCaseSelected (sumId, names) ]
+                        Map.empty, Set.empty, Set.empty, [ SelectionError.NoCaseSelected (sumId, names) ]
                     | multiple ->
                         let names = multiple |> List.map (fun (_, (name, _)) -> name)
-                        Map.empty, Set.empty, [ SelectionError.AmbiguousEmptyCases (sumId, names) ]
+                        Map.empty, Set.empty, Set.empty, [ SelectionError.AmbiguousEmptyCases (sumId, names) ]
                 | multiple ->
                     let witnesses = multiple |> List.map (fun (_, name, source) -> name, source)
-                    Map.empty, Set.empty, [ SelectionError.ConflictingCases (sumId, witnesses) ]
+                    Map.empty, Set.empty, Set.empty, [ SelectionError.ConflictingCases (sumId, witnesses) ]
 
-        let choices, active, errors = go schema.Tree
+        let choices, active, activePos, errors = go schema.Tree
 
         {
             Choices = choices
             ActiveLeaves = active
+            ActivePositional =
+                match Set.toList activePos with
+                | [] -> None
+                | [ p ] -> Some p
+                | _ ->
+                    failwith
+                        "WoofWare.Myriad internal error: two positional sinks were active at once; the schema was not validated"
             Errors = errors
         }
 
@@ -537,9 +587,9 @@ module private ArgParserRuntime_DuArgs =
             )
 
         let noSink =
-            match schema.Positional with
-            | Some _ -> []
-            | None ->
+            match schema.Positionals with
+            | _ :: _ -> []
+            | [] ->
                 let tokens =
                     events
                     |> List.choose (fun event ->
@@ -603,8 +653,26 @@ module private ArgParserRuntime_DuArgs =
         /// case-insensitive matching (so e.g. forms `foo` and `FOO` collide, as do a literal
         /// form `no-foo` and the negated variant of a negatable `foo`). The token is reported
         /// in the first claimant's spelling; the claimant descriptions are human-readable, in
-        /// declaration order.
+        /// declaration order. Positional sinks *may* share forms with each other (a keyed
+        /// positional form always has the same meaning whichever sink wins), so a collision
+        /// is only reported when at least one claimant is not a sink.
         | TokenCollision of token : string * claimants : string list
+        /// Two positional sinks in the table share an id.
+        | DuplicatePositionalId of positionalId : int
+        /// The tree refers to this positional sink more than once.
+        | PositionalRepeatedInTree of positionalId : int
+        /// The tree refers to a positional-sink id which is not in the table.
+        | PositionalNotInTable of positionalId : int
+        /// A positional sink in the table is not reachable in the tree.
+        | PositionalNotInTree of positionalId : int
+        /// Some complete interpretation of the tree contains more than one positional sink.
+        /// argv holds a single positional stream, and two unbounded consumers would admit no
+        /// canonical partition of it: `P × Q` is malformed, while `(A × P) + (B × Q)` is fine.
+        | PositionalCapacityExceeded of maximum : int
+        /// Positional sinks disagree on the treatment of unrecognised flag-like tokens. The
+        /// policy is lexical — it controls tokenization, which happens before any case is
+        /// selected — so it must be schema-global.
+        | FlagLikePolicyDisagreement
 
     [<RequireQualifiedAccess>]
     module SchemaError =
@@ -634,6 +702,20 @@ module private ArgParserRuntime_DuArgs =
                     "the token '%s' is claimed by: %s (argument names are matched case-insensitively)"
                     token
                     (String.concat "; " claimants)
+            | SchemaError.DuplicatePositionalId positionalId ->
+                sprintf "two positional-args sinks share the id %i" positionalId
+            | SchemaError.PositionalRepeatedInTree positionalId ->
+                sprintf "the schema tree refers to positional-args sink id %i more than once" positionalId
+            | SchemaError.PositionalNotInTable positionalId ->
+                sprintf "the schema tree refers to positional-args sink id %i, which does not exist" positionalId
+            | SchemaError.PositionalNotInTree positionalId ->
+                sprintf "positional-args sink id %i is not reachable in the schema tree" positionalId
+            | SchemaError.PositionalCapacityExceeded maximum ->
+                sprintf
+                    "some alternative of the schema contains %i positional-args sinks; at most one may be active, because argv holds a single stream of positional args"
+                    maximum
+            | SchemaError.FlagLikePolicyDisagreement ->
+                "positional-args sinks disagree on whether to collect unrecognised flag-like tokens; that choice affects tokenization, which happens before alternatives are chosen between, so all sinks must agree"
 
     /// An ErasedSchema which has passed the structural checks in WellFormedSchema.check.
     ///
@@ -677,10 +759,63 @@ module private ArgParserRuntime_DuArgs =
                 |> List.filter (fun leafId -> not (Set.contains leafId treeIdSet))
                 |> List.map SchemaError.LeafNotInTree
 
+            let positionalTreeIds = positionalIds schema.Tree
+            let positionalTableIds = schema.Positionals |> List.map (fun p -> p.Id)
+            let positionalTreeIdSet = Set.ofList positionalTreeIds
+            let positionalTableIdSet = Set.ofList positionalTableIds
+
+            let duplicatePositionalIds =
+                positionalTableIds
+                |> List.countBy (fun positionalId -> positionalId)
+                |> List.filter (fun (_, count) -> count > 1)
+                |> List.map (fun (positionalId, _) -> SchemaError.DuplicatePositionalId positionalId)
+
+            let positionalRepeatedInTree =
+                positionalTreeIds
+                |> List.countBy (fun positionalId -> positionalId)
+                |> List.filter (fun (_, count) -> count > 1)
+                |> List.map (fun (positionalId, _) -> SchemaError.PositionalRepeatedInTree positionalId)
+
+            let positionalNotInTable =
+                positionalTreeIds
+                |> List.distinct
+                |> List.filter (fun positionalId -> not (Set.contains positionalId positionalTableIdSet))
+                |> List.map SchemaError.PositionalNotInTable
+
+            let positionalNotInTree =
+                positionalTableIds
+                |> List.distinct
+                |> List.filter (fun positionalId -> not (Set.contains positionalId positionalTreeIdSet))
+                |> List.map SchemaError.PositionalNotInTree
+
+            let capacityExceeded =
+                let maximum = maxPositionals schema.Tree
+
+                if maximum > 1 then
+                    [ SchemaError.PositionalCapacityExceeded maximum ]
+                else
+                    []
+
+            let policyDisagreement =
+                let policies =
+                    schema.Positionals
+                    |> List.map (fun p ->
+                        match p.FlagLike with
+                        | ErasedFlagLikeBehaviour.Collect -> true
+                        | ErasedFlagLikeBehaviour.Reject -> false
+                    )
+                    |> List.distinct
+
+                match policies with
+                | []
+                | [ _ ] -> []
+                | _ -> [ SchemaError.FlagLikePolicyDisagreement ]
+
             let duplicateSumIds =
                 let rec sumIds (tree : ErasedTree) : int list =
                     match tree with
                     | ErasedTree.Leaf _ -> []
+                    | ErasedTree.PositionalLeaf _ -> []
                     | ErasedTree.Product children -> children |> List.collect sumIds
                     | ErasedTree.Sum (sumId, cases) -> sumId :: (cases |> List.collect (fun (_, case) -> sumIds case))
 
@@ -710,48 +845,57 @@ module private ArgParserRuntime_DuArgs =
                 (schema.Leaves
                  |> List.collect (fun leaf ->
                      let plain =
-                         leaf.Forms |> List.map (fun form -> "--" + form, sprintf "argument '--%s'" form)
+                         leaf.Forms
+                         |> List.map (fun form -> "--" + form, sprintf "argument '--%s'" form, false)
 
                      let negated =
                          if leaf.AcceptsNegation then
                              leaf.Forms
-                             |> List.map (fun form -> "--no-" + form, sprintf "the --no- form of argument '--%s'" form)
+                             |> List.map (fun form ->
+                                 "--no-" + form, sprintf "the --no- form of argument '--%s'" form, false
+                             )
                          else
                              []
 
                      plain @ negated
                  ))
-                @ (
-                    match schema.Positional with
-                    | None -> []
-                    | Some positional ->
-                        positional.Forms
-                        |> List.map (fun form -> "--" + form, sprintf "the positional-args sink '--%s'" form)
-                )
-                @ [ "--help", "the built-in help flag" ]
+                @ (schema.Positionals
+                   |> List.collect (fun positional ->
+                       positional.Forms
+                       |> List.map (fun form -> "--" + form, sprintf "the positional-args sink '--%s'" form, true)
+                   ))
+                @ [ "--help", "the built-in help flag", false ]
 
             let collisions =
                 let indexOf =
                     System.Collections.Generic.Dictionary<string, int> (StringComparer.OrdinalIgnoreCase)
 
-                let buckets = ResizeArray<ResizeArray<string * string>> ()
+                let buckets = ResizeArray<ResizeArray<string * string * bool>> ()
 
-                for token, claimant in claims do
+                for token, claimant, isSink in claims do
                     match indexOf.TryGetValue token with
-                    | true, index -> buckets.[index].Add ((token, claimant))
+                    | true, index -> buckets.[index].Add ((token, claimant, isSink))
                     | false, _ ->
                         indexOf.[token] <- buckets.Count
                         let bucket = ResizeArray ()
-                        bucket.Add ((token, claimant))
+                        bucket.Add ((token, claimant, isSink))
                         buckets.Add bucket
 
                 buckets
                 |> Seq.choose (fun bucket ->
-                    if bucket.Count < 2 then
+                    let allSinks = bucket |> Seq.forall (fun (_, _, isSink) -> isSink)
+
+                    if bucket.Count < 2 || allSinks then
                         None
                     else
-                        let token, _ = bucket.[0]
-                        Some (SchemaError.TokenCollision (token, bucket |> Seq.map snd |> List.ofSeq))
+                        let token, _, _ = bucket.[0]
+
+                        Some (
+                            SchemaError.TokenCollision (
+                                token,
+                                bucket |> Seq.map (fun (_, claimant, _) -> claimant) |> List.ofSeq
+                            )
+                        )
                 )
                 |> List.ofSeq
 
@@ -770,27 +914,31 @@ module private ArgParserRuntime_DuArgs =
                              []
                      )
                  ))
-                @ (
-                    match schema.Positional with
-                    | None -> []
-                    | Some positional ->
-                        let claimant = "the positional-args sink"
+                @ (schema.Positionals
+                   |> List.collect (fun positional ->
+                       let claimant = sprintf "positional-args sink id %i" positional.Id
 
-                        positional.Forms
-                        |> List.collect (fun form ->
-                            if form = "" then
-                                [ SchemaError.EmptyForm claimant ]
-                            elif form.Contains "=" then
-                                [ SchemaError.FormContainsEquals (claimant, form) ]
-                            else
-                                []
-                        )
-                )
+                       positional.Forms
+                       |> List.collect (fun form ->
+                           if form = "" then
+                               [ SchemaError.EmptyForm claimant ]
+                           elif form.Contains "=" then
+                               [ SchemaError.FormContainsEquals (claimant, form) ]
+                           else
+                               []
+                       )
+                   ))
 
             duplicateLeafIds
             @ repeatedInTree
             @ notInTable
             @ notInTree
+            @ duplicatePositionalIds
+            @ positionalRepeatedInTree
+            @ positionalNotInTable
+            @ positionalNotInTree
+            @ capacityExceeded
+            @ policyDisagreement
             @ duplicateSumIds
             @ noForms
             @ negationOnNonBool
@@ -936,9 +1084,9 @@ module private ArgParserRuntime_DuArgs =
 
                     consume rest
                 | ScanEvent.Positional (value, afterSeparator, _) ->
-                    match schema.Positional with
-                    | None -> consume rest
-                    | Some _ ->
+                    match schema.Positionals with
+                    | [] -> consume rest
+                    | _ :: _ ->
                         match callbacks.StorePositional value afterSeparator with
                         | Some error -> errors.Add error
                         | None -> ()
@@ -1090,7 +1238,7 @@ module DuArgs =
                               ))
                          ])
                     ))
-                Positional = None
+                Positionals = List.empty
             }
 
         let parser_storeOccurrence (occurrence : ArgParserRuntime_DuArgs.ErasedOccurrence) : string option =
@@ -1295,7 +1443,7 @@ module WithModeArgs =
                             )
                         ]
                     ))
-                Positional = None
+                Positionals = List.empty
             }
 
         let parser_storeOccurrence (occurrence : ArgParserRuntime_DuArgs.ErasedOccurrence) : string option =
@@ -1488,7 +1636,7 @@ module DuWithDefaultArgs =
                               ArgParserRuntime_DuArgs.ErasedTree.Product ([ ArgParserRuntime_DuArgs.ErasedTree.Leaf 1 ]))
                          ])
                     ))
-                Positional = None
+                Positionals = List.empty
             }
 
         let parser_storeOccurrence (occurrence : ArgParserRuntime_DuArgs.ErasedOccurrence) : string option =
@@ -1658,18 +1806,19 @@ module ModeAndPositionals =
                                       ))
                                  ])
                             )
+                            ArgParserRuntime_DuArgs.ErasedTree.PositionalLeaf 0
                         ]
                     ))
-                Positional =
-                    ({
-                        ArgParserRuntime_DuArgs.ErasedPositional.Id = 2
-                        ArgParserRuntime_DuArgs.ErasedPositional.Forms = [ "rest" ]
-                        ArgParserRuntime_DuArgs.ErasedPositional.FlagLike =
-                            ArgParserRuntime_DuArgs.ErasedFlagLikeBehaviour.Reject
-                        ArgParserRuntime_DuArgs.ErasedPositional.TypeDescription = ""
-                        ArgParserRuntime_DuArgs.ErasedPositional.Help = None
-                    })
-                    |> Some
+                Positionals =
+                    [
+                        {
+                            Id = 0
+                            Forms = [ "rest" ]
+                            FlagLike = ArgParserRuntime_DuArgs.ErasedFlagLikeBehaviour.Reject
+                            TypeDescription = ""
+                            Help = None
+                        }
+                    ]
             }
 
         let parser_storeOccurrence (occurrence : ArgParserRuntime_DuArgs.ErasedOccurrence) : string option =
@@ -1857,21 +2006,23 @@ module CommandAndPositionals =
                                       ))
                                  ])
                             )
+                            ArgParserRuntime_DuArgs.ErasedTree.PositionalLeaf 0
                         ]
                     ))
-                Positional =
-                    ({
-                        ArgParserRuntime_DuArgs.ErasedPositional.Id = 3
-                        ArgParserRuntime_DuArgs.ErasedPositional.Forms = [ "paths" ]
-                        ArgParserRuntime_DuArgs.ErasedPositional.FlagLike =
-                            (if false then
-                                 ArgParserRuntime_DuArgs.ErasedFlagLikeBehaviour.Collect
-                             else
-                                 ArgParserRuntime_DuArgs.ErasedFlagLikeBehaviour.Reject)
-                        ArgParserRuntime_DuArgs.ErasedPositional.TypeDescription = ""
-                        ArgParserRuntime_DuArgs.ErasedPositional.Help = None
-                    })
-                    |> Some
+                Positionals =
+                    [
+                        {
+                            Id = 0
+                            Forms = [ "paths" ]
+                            FlagLike =
+                                (if false then
+                                     ArgParserRuntime_DuArgs.ErasedFlagLikeBehaviour.Collect
+                                 else
+                                     ArgParserRuntime_DuArgs.ErasedFlagLikeBehaviour.Reject)
+                            TypeDescription = ""
+                            Help = None
+                        }
+                    ]
             }
 
         let parser_storeOccurrence (occurrence : ArgParserRuntime_DuArgs.ErasedOccurrence) : string option =

--- a/ConsumePlugin/GeneratedOpensLeakRegression.fs
+++ b/ConsumePlugin/GeneratedOpensLeakRegression.fs
@@ -63,37 +63,49 @@ module private ArgParserRuntime_LeakArgs =
         /// Reject the parse (`[<PositionalArgs false>]` / `[<PositionalArgs>]`).
         | Reject
 
-    /// The positional-argument sink, if the schema has one.
+    /// A positional-argument sink: a consumer of the positional-token stream.
     type ErasedPositional =
         {
-            /// Index into the typed layer's converter table.
+            /// Index into the typed layer's positional converter table. Ids live in their own
+            /// space, independent of ErasedLeaf ids.
             Id : int
             /// The forms under which the sink itself can be addressed as `--form value` /
             /// `--form=value` (the field name argified, plus any explicit long forms); the head
-            /// is used in help text.
+            /// is used in help text. Two sinks in mutually exclusive Sum cases may share a
+            /// form: all keyed positional forms have the same arity, and the capacity rule
+            /// means the sinks can never both be active.
             Forms : string list
+            /// The flag-like policy is lexical (it controls tokenization, which happens before
+            /// any case is selected), so every sink in a schema must agree on it;
+            /// WellFormedSchema enforces the agreement.
             FlagLike : ErasedFlagLikeBehaviour
             TypeDescription : string
             Help : string option
         }
 
     /// The shape of a parser: a tree of products (records), sums (discriminated unions) and
-    /// leaves (actual arguments). Leaves are referred to by id; the flat leaf table plus this
-    /// tree fully describe the schema.
+    /// leaves (actual arguments, named or positional). Leaves are referred to by id; the flat
+    /// leaf tables plus this tree fully describe the schema.
     [<RequireQualifiedAccess>]
     type ErasedTree =
         | Leaf of leafId : int
+        /// A positional-stream consumer. At most one may appear in any complete
+        /// interpretation of the tree (one case chosen for every reachable Sum): argv holds a
+        /// single positional stream, and two unbounded consumers would admit no canonical
+        /// partition of it. WellFormedSchema enforces this capacity rule.
+        | PositionalLeaf of positionalId : int
         | Product of children : ErasedTree list
         /// Cases are in declaration order; the string is the case name, for messages.
         | Sum of sumId : int * cases : (string * ErasedTree) list
 
     type ErasedSchema =
         {
-            /// All leaves reachable in the tree, in field declaration order (the order in which
-            /// "missing required argument" errors are reported).
+            /// All named leaves reachable in the tree, in field declaration order (the order
+            /// in which "missing required argument" errors are reported).
             Leaves : ErasedLeaf list
             Tree : ErasedTree
-            Positional : ErasedPositional option
+            /// All positional sinks reachable in the tree, in declaration order.
+            Positionals : ErasedPositional list
         }
 
     /// One observed occurrence of a named argument.
@@ -214,20 +226,23 @@ module private ArgParserRuntime_LeakArgs =
     /// - Any other token in key position is positional.
     let scan (schema : ErasedSchema) (args : string list) : ScanEvent list =
         let collectFlagLike =
-            match schema.Positional with
-            | Some p ->
-                match p.FlagLike with
-                | ErasedFlagLikeBehaviour.Collect -> true
-                | ErasedFlagLikeBehaviour.Reject -> false
-            | None -> false
+            match schema.Positionals with
+            | [] -> false
+            | positionals ->
+                positionals
+                |> List.forall (fun p ->
+                    match p.FlagLike with
+                    | ErasedFlagLikeBehaviour.Collect -> true
+                    | ErasedFlagLikeBehaviour.Reject -> false
+                )
 
-        /// Does this full `--key` token (value part already split off) name the positional sink?
+        /// Does this full `--key` token (value part already split off) name a positional sink?
         let isPositionalKey (key : string) : bool =
-            match schema.Positional with
-            | None -> false
-            | Some p ->
+            schema.Positionals
+            |> List.exists (fun p ->
                 p.Forms
                 |> List.exists (fun form -> String.Equals (key, "--" + form, StringComparison.OrdinalIgnoreCase))
+            )
 
         /// Resolve a pending key which will receive no value (end of input, or `--` next).
         let resolvePending (state : ScanState) : ScanEvent list =
@@ -368,13 +383,17 @@ module private ArgParserRuntime_LeakArgs =
     type Selection =
         {
             Choices : Map<int, int>
-            /// Ids of leaves which are part of the selected interpretation.
+            /// Ids of named leaves which are part of the selected interpretation.
             ActiveLeaves : Set<int>
+            /// The positional sink which is part of the selected interpretation, if any. The
+            /// capacity rule (enforced by WellFormedSchema) guarantees there is at most one.
+            ActivePositional : int option
             Errors : SelectionError list
         }
 
-    /// Can this subtree be satisfied with zero occurrences? A leaf can iff it is not required; a
-    /// product can iff all its children can; a sum can iff some case can.
+    /// Can this subtree be satisfied with zero occurrences? A named leaf can iff it is not
+    /// required; a positional leaf always can (an empty stream is fine); a product can iff all
+    /// its children can; a sum can iff some case can.
     let rec private emptyOk (leaves : Map<int, ErasedLeaf>) (tree : ErasedTree) : bool =
         match tree with
         | ErasedTree.Leaf leafId ->
@@ -382,15 +401,38 @@ module private ArgParserRuntime_LeakArgs =
             | ErasedRequirement.Required -> false
             | ErasedRequirement.Optional
             | ErasedRequirement.HasDefault -> true
+        | ErasedTree.PositionalLeaf _ -> true
         | ErasedTree.Product children -> children |> List.forall (emptyOk leaves)
         | ErasedTree.Sum (_, cases) -> cases |> List.exists (fun (_, case) -> emptyOk leaves case)
 
-    /// All leaf ids under a subtree, in declaration order.
+    /// All named-leaf ids under a subtree, in declaration order.
     let rec leafIds (tree : ErasedTree) : int list =
         match tree with
         | ErasedTree.Leaf leafId -> [ leafId ]
+        | ErasedTree.PositionalLeaf _ -> []
         | ErasedTree.Product children -> children |> List.collect leafIds
         | ErasedTree.Sum (_, cases) -> cases |> List.collect (fun (_, case) -> leafIds case)
+
+    /// All positional-sink ids under a subtree, in declaration order.
+    let rec positionalIds (tree : ErasedTree) : int list =
+        match tree with
+        | ErasedTree.Leaf _ -> []
+        | ErasedTree.PositionalLeaf positionalId -> [ positionalId ]
+        | ErasedTree.Product children -> children |> List.collect positionalIds
+        | ErasedTree.Sum (_, cases) -> cases |> List.collect (fun (_, case) -> positionalIds case)
+
+    /// The maximum number of positional sinks any complete interpretation of the tree can
+    /// contain: a product's interpretations combine its children's, a sum's take the maximum
+    /// over its cases.
+    let rec maxPositionals (tree : ErasedTree) : int =
+        match tree with
+        | ErasedTree.Leaf _ -> 0
+        | ErasedTree.PositionalLeaf _ -> 1
+        | ErasedTree.Product children -> children |> List.sumBy maxPositionals
+        | ErasedTree.Sum (_, cases) ->
+            match cases with
+            | [] -> 0
+            | cases -> cases |> List.map (fun (_, case) -> maxPositionals case) |> List.max
 
     /// Select a case for every Sum node reachable in the selected interpretation, given a witness
     /// (an example source token) for every leaf which received an occurrence.
@@ -402,15 +444,16 @@ module private ArgParserRuntime_LeakArgs =
     let select (schema : ErasedSchema) (observed : Map<int, string>) : Selection =
         let leavesById = schema.Leaves |> List.map (fun leaf -> leaf.Id, leaf) |> Map.ofList
 
-        let rec go (tree : ErasedTree) : Map<int, int> * Set<int> * SelectionError list =
+        let rec go (tree : ErasedTree) : Map<int, int> * Set<int> * Set<int> * SelectionError list =
             match tree with
-            | ErasedTree.Leaf leafId -> Map.empty, Set.singleton leafId, []
+            | ErasedTree.Leaf leafId -> Map.empty, Set.singleton leafId, Set.empty, []
+            | ErasedTree.PositionalLeaf positionalId -> Map.empty, Set.empty, Set.singleton positionalId, []
             | ErasedTree.Product children ->
-                ((Map.empty, Set.empty, []), children)
-                ||> List.fold (fun (choices, active, errors) child ->
-                    let childChoices, childActive, childErrors = go child
+                ((Map.empty, Set.empty, Set.empty, []), children)
+                ||> List.fold (fun (choices, active, activePos, errors) child ->
+                    let childChoices, childActive, childActivePos, childErrors = go child
                     let choices = (choices, childChoices) ||> Map.fold (fun m k v -> Map.add k v m)
-                    choices, Set.union active childActive, errors @ childErrors
+                    choices, Set.union active childActive, Set.union activePos childActivePos, errors @ childErrors
                 )
             | ErasedTree.Sum (sumId, cases) ->
                 let touched =
@@ -428,8 +471,8 @@ module private ArgParserRuntime_LeakArgs =
                 match touched with
                 | [ (index, _, _) ] ->
                     let _, case = List.item index cases
-                    let childChoices, childActive, childErrors = go case
-                    Map.add sumId index childChoices, childActive, childErrors
+                    let childChoices, childActive, childActivePos, childErrors = go case
+                    Map.add sumId index childChoices, childActive, childActivePos, childErrors
                 | [] ->
                     let satisfiable =
                         cases
@@ -438,23 +481,30 @@ module private ArgParserRuntime_LeakArgs =
 
                     match satisfiable with
                     | [ (index, (_, case)) ] ->
-                        let childChoices, childActive, childErrors = go case
-                        Map.add sumId index childChoices, childActive, childErrors
+                        let childChoices, childActive, childActivePos, childErrors = go case
+                        Map.add sumId index childChoices, childActive, childActivePos, childErrors
                     | [] ->
                         let names = cases |> List.map fst
-                        Map.empty, Set.empty, [ SelectionError.NoCaseSelected (sumId, names) ]
+                        Map.empty, Set.empty, Set.empty, [ SelectionError.NoCaseSelected (sumId, names) ]
                     | multiple ->
                         let names = multiple |> List.map (fun (_, (name, _)) -> name)
-                        Map.empty, Set.empty, [ SelectionError.AmbiguousEmptyCases (sumId, names) ]
+                        Map.empty, Set.empty, Set.empty, [ SelectionError.AmbiguousEmptyCases (sumId, names) ]
                 | multiple ->
                     let witnesses = multiple |> List.map (fun (_, name, source) -> name, source)
-                    Map.empty, Set.empty, [ SelectionError.ConflictingCases (sumId, witnesses) ]
+                    Map.empty, Set.empty, Set.empty, [ SelectionError.ConflictingCases (sumId, witnesses) ]
 
-        let choices, active, errors = go schema.Tree
+        let choices, active, activePos, errors = go schema.Tree
 
         {
             Choices = choices
             ActiveLeaves = active
+            ActivePositional =
+                match Set.toList activePos with
+                | [] -> None
+                | [ p ] -> Some p
+                | _ ->
+                    failwith
+                        "WoofWare.Myriad internal error: two positional sinks were active at once; the schema was not validated"
             Errors = errors
         }
 
@@ -537,9 +587,9 @@ module private ArgParserRuntime_LeakArgs =
             )
 
         let noSink =
-            match schema.Positional with
-            | Some _ -> []
-            | None ->
+            match schema.Positionals with
+            | _ :: _ -> []
+            | [] ->
                 let tokens =
                     events
                     |> List.choose (fun event ->
@@ -603,8 +653,26 @@ module private ArgParserRuntime_LeakArgs =
         /// case-insensitive matching (so e.g. forms `foo` and `FOO` collide, as do a literal
         /// form `no-foo` and the negated variant of a negatable `foo`). The token is reported
         /// in the first claimant's spelling; the claimant descriptions are human-readable, in
-        /// declaration order.
+        /// declaration order. Positional sinks *may* share forms with each other (a keyed
+        /// positional form always has the same meaning whichever sink wins), so a collision
+        /// is only reported when at least one claimant is not a sink.
         | TokenCollision of token : string * claimants : string list
+        /// Two positional sinks in the table share an id.
+        | DuplicatePositionalId of positionalId : int
+        /// The tree refers to this positional sink more than once.
+        | PositionalRepeatedInTree of positionalId : int
+        /// The tree refers to a positional-sink id which is not in the table.
+        | PositionalNotInTable of positionalId : int
+        /// A positional sink in the table is not reachable in the tree.
+        | PositionalNotInTree of positionalId : int
+        /// Some complete interpretation of the tree contains more than one positional sink.
+        /// argv holds a single positional stream, and two unbounded consumers would admit no
+        /// canonical partition of it: `P × Q` is malformed, while `(A × P) + (B × Q)` is fine.
+        | PositionalCapacityExceeded of maximum : int
+        /// Positional sinks disagree on the treatment of unrecognised flag-like tokens. The
+        /// policy is lexical — it controls tokenization, which happens before any case is
+        /// selected — so it must be schema-global.
+        | FlagLikePolicyDisagreement
 
     [<RequireQualifiedAccess>]
     module SchemaError =
@@ -634,6 +702,20 @@ module private ArgParserRuntime_LeakArgs =
                     "the token '%s' is claimed by: %s (argument names are matched case-insensitively)"
                     token
                     (String.concat "; " claimants)
+            | SchemaError.DuplicatePositionalId positionalId ->
+                sprintf "two positional-args sinks share the id %i" positionalId
+            | SchemaError.PositionalRepeatedInTree positionalId ->
+                sprintf "the schema tree refers to positional-args sink id %i more than once" positionalId
+            | SchemaError.PositionalNotInTable positionalId ->
+                sprintf "the schema tree refers to positional-args sink id %i, which does not exist" positionalId
+            | SchemaError.PositionalNotInTree positionalId ->
+                sprintf "positional-args sink id %i is not reachable in the schema tree" positionalId
+            | SchemaError.PositionalCapacityExceeded maximum ->
+                sprintf
+                    "some alternative of the schema contains %i positional-args sinks; at most one may be active, because argv holds a single stream of positional args"
+                    maximum
+            | SchemaError.FlagLikePolicyDisagreement ->
+                "positional-args sinks disagree on whether to collect unrecognised flag-like tokens; that choice affects tokenization, which happens before alternatives are chosen between, so all sinks must agree"
 
     /// An ErasedSchema which has passed the structural checks in WellFormedSchema.check.
     ///
@@ -677,10 +759,63 @@ module private ArgParserRuntime_LeakArgs =
                 |> List.filter (fun leafId -> not (Set.contains leafId treeIdSet))
                 |> List.map SchemaError.LeafNotInTree
 
+            let positionalTreeIds = positionalIds schema.Tree
+            let positionalTableIds = schema.Positionals |> List.map (fun p -> p.Id)
+            let positionalTreeIdSet = Set.ofList positionalTreeIds
+            let positionalTableIdSet = Set.ofList positionalTableIds
+
+            let duplicatePositionalIds =
+                positionalTableIds
+                |> List.countBy (fun positionalId -> positionalId)
+                |> List.filter (fun (_, count) -> count > 1)
+                |> List.map (fun (positionalId, _) -> SchemaError.DuplicatePositionalId positionalId)
+
+            let positionalRepeatedInTree =
+                positionalTreeIds
+                |> List.countBy (fun positionalId -> positionalId)
+                |> List.filter (fun (_, count) -> count > 1)
+                |> List.map (fun (positionalId, _) -> SchemaError.PositionalRepeatedInTree positionalId)
+
+            let positionalNotInTable =
+                positionalTreeIds
+                |> List.distinct
+                |> List.filter (fun positionalId -> not (Set.contains positionalId positionalTableIdSet))
+                |> List.map SchemaError.PositionalNotInTable
+
+            let positionalNotInTree =
+                positionalTableIds
+                |> List.distinct
+                |> List.filter (fun positionalId -> not (Set.contains positionalId positionalTreeIdSet))
+                |> List.map SchemaError.PositionalNotInTree
+
+            let capacityExceeded =
+                let maximum = maxPositionals schema.Tree
+
+                if maximum > 1 then
+                    [ SchemaError.PositionalCapacityExceeded maximum ]
+                else
+                    []
+
+            let policyDisagreement =
+                let policies =
+                    schema.Positionals
+                    |> List.map (fun p ->
+                        match p.FlagLike with
+                        | ErasedFlagLikeBehaviour.Collect -> true
+                        | ErasedFlagLikeBehaviour.Reject -> false
+                    )
+                    |> List.distinct
+
+                match policies with
+                | []
+                | [ _ ] -> []
+                | _ -> [ SchemaError.FlagLikePolicyDisagreement ]
+
             let duplicateSumIds =
                 let rec sumIds (tree : ErasedTree) : int list =
                     match tree with
                     | ErasedTree.Leaf _ -> []
+                    | ErasedTree.PositionalLeaf _ -> []
                     | ErasedTree.Product children -> children |> List.collect sumIds
                     | ErasedTree.Sum (sumId, cases) -> sumId :: (cases |> List.collect (fun (_, case) -> sumIds case))
 
@@ -710,48 +845,57 @@ module private ArgParserRuntime_LeakArgs =
                 (schema.Leaves
                  |> List.collect (fun leaf ->
                      let plain =
-                         leaf.Forms |> List.map (fun form -> "--" + form, sprintf "argument '--%s'" form)
+                         leaf.Forms
+                         |> List.map (fun form -> "--" + form, sprintf "argument '--%s'" form, false)
 
                      let negated =
                          if leaf.AcceptsNegation then
                              leaf.Forms
-                             |> List.map (fun form -> "--no-" + form, sprintf "the --no- form of argument '--%s'" form)
+                             |> List.map (fun form ->
+                                 "--no-" + form, sprintf "the --no- form of argument '--%s'" form, false
+                             )
                          else
                              []
 
                      plain @ negated
                  ))
-                @ (
-                    match schema.Positional with
-                    | None -> []
-                    | Some positional ->
-                        positional.Forms
-                        |> List.map (fun form -> "--" + form, sprintf "the positional-args sink '--%s'" form)
-                )
-                @ [ "--help", "the built-in help flag" ]
+                @ (schema.Positionals
+                   |> List.collect (fun positional ->
+                       positional.Forms
+                       |> List.map (fun form -> "--" + form, sprintf "the positional-args sink '--%s'" form, true)
+                   ))
+                @ [ "--help", "the built-in help flag", false ]
 
             let collisions =
                 let indexOf =
                     System.Collections.Generic.Dictionary<string, int> (StringComparer.OrdinalIgnoreCase)
 
-                let buckets = ResizeArray<ResizeArray<string * string>> ()
+                let buckets = ResizeArray<ResizeArray<string * string * bool>> ()
 
-                for token, claimant in claims do
+                for token, claimant, isSink in claims do
                     match indexOf.TryGetValue token with
-                    | true, index -> buckets.[index].Add ((token, claimant))
+                    | true, index -> buckets.[index].Add ((token, claimant, isSink))
                     | false, _ ->
                         indexOf.[token] <- buckets.Count
                         let bucket = ResizeArray ()
-                        bucket.Add ((token, claimant))
+                        bucket.Add ((token, claimant, isSink))
                         buckets.Add bucket
 
                 buckets
                 |> Seq.choose (fun bucket ->
-                    if bucket.Count < 2 then
+                    let allSinks = bucket |> Seq.forall (fun (_, _, isSink) -> isSink)
+
+                    if bucket.Count < 2 || allSinks then
                         None
                     else
-                        let token, _ = bucket.[0]
-                        Some (SchemaError.TokenCollision (token, bucket |> Seq.map snd |> List.ofSeq))
+                        let token, _, _ = bucket.[0]
+
+                        Some (
+                            SchemaError.TokenCollision (
+                                token,
+                                bucket |> Seq.map (fun (_, claimant, _) -> claimant) |> List.ofSeq
+                            )
+                        )
                 )
                 |> List.ofSeq
 
@@ -770,27 +914,31 @@ module private ArgParserRuntime_LeakArgs =
                              []
                      )
                  ))
-                @ (
-                    match schema.Positional with
-                    | None -> []
-                    | Some positional ->
-                        let claimant = "the positional-args sink"
+                @ (schema.Positionals
+                   |> List.collect (fun positional ->
+                       let claimant = sprintf "positional-args sink id %i" positional.Id
 
-                        positional.Forms
-                        |> List.collect (fun form ->
-                            if form = "" then
-                                [ SchemaError.EmptyForm claimant ]
-                            elif form.Contains "=" then
-                                [ SchemaError.FormContainsEquals (claimant, form) ]
-                            else
-                                []
-                        )
-                )
+                       positional.Forms
+                       |> List.collect (fun form ->
+                           if form = "" then
+                               [ SchemaError.EmptyForm claimant ]
+                           elif form.Contains "=" then
+                               [ SchemaError.FormContainsEquals (claimant, form) ]
+                           else
+                               []
+                       )
+                   ))
 
             duplicateLeafIds
             @ repeatedInTree
             @ notInTable
             @ notInTree
+            @ duplicatePositionalIds
+            @ positionalRepeatedInTree
+            @ positionalNotInTable
+            @ positionalNotInTree
+            @ capacityExceeded
+            @ policyDisagreement
             @ duplicateSumIds
             @ noForms
             @ negationOnNonBool
@@ -936,9 +1084,9 @@ module private ArgParserRuntime_LeakArgs =
 
                     consume rest
                 | ScanEvent.Positional (value, afterSeparator, _) ->
-                    match schema.Positional with
-                    | None -> consume rest
-                    | Some _ ->
+                    match schema.Positionals with
+                    | [] -> consume rest
+                    | _ :: _ ->
                         match callbacks.StorePositional value afterSeparator with
                         | Some error -> errors.Add error
                         | None -> ()
@@ -1045,7 +1193,7 @@ module LeakArgs =
                         }
                     ]
                 Tree = (ArgParserRuntime_LeakArgs.ErasedTree.Product ([ ArgParserRuntime_LeakArgs.ErasedTree.Leaf 0 ]))
-                Positional = None
+                Positionals = List.empty
             }
 
         let parser_storeOccurrence (occurrence : ArgParserRuntime_LeakArgs.ErasedOccurrence) : string option =

--- a/ConsumePlugin/Nested/GeneratedArgs.fs
+++ b/ConsumePlugin/Nested/GeneratedArgs.fs
@@ -63,37 +63,49 @@ module private ArgParserRuntime_SameBaseNameArgs =
         /// Reject the parse (`[<PositionalArgs false>]` / `[<PositionalArgs>]`).
         | Reject
 
-    /// The positional-argument sink, if the schema has one.
+    /// A positional-argument sink: a consumer of the positional-token stream.
     type ErasedPositional =
         {
-            /// Index into the typed layer's converter table.
+            /// Index into the typed layer's positional converter table. Ids live in their own
+            /// space, independent of ErasedLeaf ids.
             Id : int
             /// The forms under which the sink itself can be addressed as `--form value` /
             /// `--form=value` (the field name argified, plus any explicit long forms); the head
-            /// is used in help text.
+            /// is used in help text. Two sinks in mutually exclusive Sum cases may share a
+            /// form: all keyed positional forms have the same arity, and the capacity rule
+            /// means the sinks can never both be active.
             Forms : string list
+            /// The flag-like policy is lexical (it controls tokenization, which happens before
+            /// any case is selected), so every sink in a schema must agree on it;
+            /// WellFormedSchema enforces the agreement.
             FlagLike : ErasedFlagLikeBehaviour
             TypeDescription : string
             Help : string option
         }
 
     /// The shape of a parser: a tree of products (records), sums (discriminated unions) and
-    /// leaves (actual arguments). Leaves are referred to by id; the flat leaf table plus this
-    /// tree fully describe the schema.
+    /// leaves (actual arguments, named or positional). Leaves are referred to by id; the flat
+    /// leaf tables plus this tree fully describe the schema.
     [<RequireQualifiedAccess>]
     type ErasedTree =
         | Leaf of leafId : int
+        /// A positional-stream consumer. At most one may appear in any complete
+        /// interpretation of the tree (one case chosen for every reachable Sum): argv holds a
+        /// single positional stream, and two unbounded consumers would admit no canonical
+        /// partition of it. WellFormedSchema enforces this capacity rule.
+        | PositionalLeaf of positionalId : int
         | Product of children : ErasedTree list
         /// Cases are in declaration order; the string is the case name, for messages.
         | Sum of sumId : int * cases : (string * ErasedTree) list
 
     type ErasedSchema =
         {
-            /// All leaves reachable in the tree, in field declaration order (the order in which
-            /// "missing required argument" errors are reported).
+            /// All named leaves reachable in the tree, in field declaration order (the order
+            /// in which "missing required argument" errors are reported).
             Leaves : ErasedLeaf list
             Tree : ErasedTree
-            Positional : ErasedPositional option
+            /// All positional sinks reachable in the tree, in declaration order.
+            Positionals : ErasedPositional list
         }
 
     /// One observed occurrence of a named argument.
@@ -214,20 +226,23 @@ module private ArgParserRuntime_SameBaseNameArgs =
     /// - Any other token in key position is positional.
     let scan (schema : ErasedSchema) (args : string list) : ScanEvent list =
         let collectFlagLike =
-            match schema.Positional with
-            | Some p ->
-                match p.FlagLike with
-                | ErasedFlagLikeBehaviour.Collect -> true
-                | ErasedFlagLikeBehaviour.Reject -> false
-            | None -> false
+            match schema.Positionals with
+            | [] -> false
+            | positionals ->
+                positionals
+                |> List.forall (fun p ->
+                    match p.FlagLike with
+                    | ErasedFlagLikeBehaviour.Collect -> true
+                    | ErasedFlagLikeBehaviour.Reject -> false
+                )
 
-        /// Does this full `--key` token (value part already split off) name the positional sink?
+        /// Does this full `--key` token (value part already split off) name a positional sink?
         let isPositionalKey (key : string) : bool =
-            match schema.Positional with
-            | None -> false
-            | Some p ->
+            schema.Positionals
+            |> List.exists (fun p ->
                 p.Forms
                 |> List.exists (fun form -> String.Equals (key, "--" + form, StringComparison.OrdinalIgnoreCase))
+            )
 
         /// Resolve a pending key which will receive no value (end of input, or `--` next).
         let resolvePending (state : ScanState) : ScanEvent list =
@@ -368,13 +383,17 @@ module private ArgParserRuntime_SameBaseNameArgs =
     type Selection =
         {
             Choices : Map<int, int>
-            /// Ids of leaves which are part of the selected interpretation.
+            /// Ids of named leaves which are part of the selected interpretation.
             ActiveLeaves : Set<int>
+            /// The positional sink which is part of the selected interpretation, if any. The
+            /// capacity rule (enforced by WellFormedSchema) guarantees there is at most one.
+            ActivePositional : int option
             Errors : SelectionError list
         }
 
-    /// Can this subtree be satisfied with zero occurrences? A leaf can iff it is not required; a
-    /// product can iff all its children can; a sum can iff some case can.
+    /// Can this subtree be satisfied with zero occurrences? A named leaf can iff it is not
+    /// required; a positional leaf always can (an empty stream is fine); a product can iff all
+    /// its children can; a sum can iff some case can.
     let rec private emptyOk (leaves : Map<int, ErasedLeaf>) (tree : ErasedTree) : bool =
         match tree with
         | ErasedTree.Leaf leafId ->
@@ -382,15 +401,38 @@ module private ArgParserRuntime_SameBaseNameArgs =
             | ErasedRequirement.Required -> false
             | ErasedRequirement.Optional
             | ErasedRequirement.HasDefault -> true
+        | ErasedTree.PositionalLeaf _ -> true
         | ErasedTree.Product children -> children |> List.forall (emptyOk leaves)
         | ErasedTree.Sum (_, cases) -> cases |> List.exists (fun (_, case) -> emptyOk leaves case)
 
-    /// All leaf ids under a subtree, in declaration order.
+    /// All named-leaf ids under a subtree, in declaration order.
     let rec leafIds (tree : ErasedTree) : int list =
         match tree with
         | ErasedTree.Leaf leafId -> [ leafId ]
+        | ErasedTree.PositionalLeaf _ -> []
         | ErasedTree.Product children -> children |> List.collect leafIds
         | ErasedTree.Sum (_, cases) -> cases |> List.collect (fun (_, case) -> leafIds case)
+
+    /// All positional-sink ids under a subtree, in declaration order.
+    let rec positionalIds (tree : ErasedTree) : int list =
+        match tree with
+        | ErasedTree.Leaf _ -> []
+        | ErasedTree.PositionalLeaf positionalId -> [ positionalId ]
+        | ErasedTree.Product children -> children |> List.collect positionalIds
+        | ErasedTree.Sum (_, cases) -> cases |> List.collect (fun (_, case) -> positionalIds case)
+
+    /// The maximum number of positional sinks any complete interpretation of the tree can
+    /// contain: a product's interpretations combine its children's, a sum's take the maximum
+    /// over its cases.
+    let rec maxPositionals (tree : ErasedTree) : int =
+        match tree with
+        | ErasedTree.Leaf _ -> 0
+        | ErasedTree.PositionalLeaf _ -> 1
+        | ErasedTree.Product children -> children |> List.sumBy maxPositionals
+        | ErasedTree.Sum (_, cases) ->
+            match cases with
+            | [] -> 0
+            | cases -> cases |> List.map (fun (_, case) -> maxPositionals case) |> List.max
 
     /// Select a case for every Sum node reachable in the selected interpretation, given a witness
     /// (an example source token) for every leaf which received an occurrence.
@@ -402,15 +444,16 @@ module private ArgParserRuntime_SameBaseNameArgs =
     let select (schema : ErasedSchema) (observed : Map<int, string>) : Selection =
         let leavesById = schema.Leaves |> List.map (fun leaf -> leaf.Id, leaf) |> Map.ofList
 
-        let rec go (tree : ErasedTree) : Map<int, int> * Set<int> * SelectionError list =
+        let rec go (tree : ErasedTree) : Map<int, int> * Set<int> * Set<int> * SelectionError list =
             match tree with
-            | ErasedTree.Leaf leafId -> Map.empty, Set.singleton leafId, []
+            | ErasedTree.Leaf leafId -> Map.empty, Set.singleton leafId, Set.empty, []
+            | ErasedTree.PositionalLeaf positionalId -> Map.empty, Set.empty, Set.singleton positionalId, []
             | ErasedTree.Product children ->
-                ((Map.empty, Set.empty, []), children)
-                ||> List.fold (fun (choices, active, errors) child ->
-                    let childChoices, childActive, childErrors = go child
+                ((Map.empty, Set.empty, Set.empty, []), children)
+                ||> List.fold (fun (choices, active, activePos, errors) child ->
+                    let childChoices, childActive, childActivePos, childErrors = go child
                     let choices = (choices, childChoices) ||> Map.fold (fun m k v -> Map.add k v m)
-                    choices, Set.union active childActive, errors @ childErrors
+                    choices, Set.union active childActive, Set.union activePos childActivePos, errors @ childErrors
                 )
             | ErasedTree.Sum (sumId, cases) ->
                 let touched =
@@ -428,8 +471,8 @@ module private ArgParserRuntime_SameBaseNameArgs =
                 match touched with
                 | [ (index, _, _) ] ->
                     let _, case = List.item index cases
-                    let childChoices, childActive, childErrors = go case
-                    Map.add sumId index childChoices, childActive, childErrors
+                    let childChoices, childActive, childActivePos, childErrors = go case
+                    Map.add sumId index childChoices, childActive, childActivePos, childErrors
                 | [] ->
                     let satisfiable =
                         cases
@@ -438,23 +481,30 @@ module private ArgParserRuntime_SameBaseNameArgs =
 
                     match satisfiable with
                     | [ (index, (_, case)) ] ->
-                        let childChoices, childActive, childErrors = go case
-                        Map.add sumId index childChoices, childActive, childErrors
+                        let childChoices, childActive, childActivePos, childErrors = go case
+                        Map.add sumId index childChoices, childActive, childActivePos, childErrors
                     | [] ->
                         let names = cases |> List.map fst
-                        Map.empty, Set.empty, [ SelectionError.NoCaseSelected (sumId, names) ]
+                        Map.empty, Set.empty, Set.empty, [ SelectionError.NoCaseSelected (sumId, names) ]
                     | multiple ->
                         let names = multiple |> List.map (fun (_, (name, _)) -> name)
-                        Map.empty, Set.empty, [ SelectionError.AmbiguousEmptyCases (sumId, names) ]
+                        Map.empty, Set.empty, Set.empty, [ SelectionError.AmbiguousEmptyCases (sumId, names) ]
                 | multiple ->
                     let witnesses = multiple |> List.map (fun (_, name, source) -> name, source)
-                    Map.empty, Set.empty, [ SelectionError.ConflictingCases (sumId, witnesses) ]
+                    Map.empty, Set.empty, Set.empty, [ SelectionError.ConflictingCases (sumId, witnesses) ]
 
-        let choices, active, errors = go schema.Tree
+        let choices, active, activePos, errors = go schema.Tree
 
         {
             Choices = choices
             ActiveLeaves = active
+            ActivePositional =
+                match Set.toList activePos with
+                | [] -> None
+                | [ p ] -> Some p
+                | _ ->
+                    failwith
+                        "WoofWare.Myriad internal error: two positional sinks were active at once; the schema was not validated"
             Errors = errors
         }
 
@@ -537,9 +587,9 @@ module private ArgParserRuntime_SameBaseNameArgs =
             )
 
         let noSink =
-            match schema.Positional with
-            | Some _ -> []
-            | None ->
+            match schema.Positionals with
+            | _ :: _ -> []
+            | [] ->
                 let tokens =
                     events
                     |> List.choose (fun event ->
@@ -603,8 +653,26 @@ module private ArgParserRuntime_SameBaseNameArgs =
         /// case-insensitive matching (so e.g. forms `foo` and `FOO` collide, as do a literal
         /// form `no-foo` and the negated variant of a negatable `foo`). The token is reported
         /// in the first claimant's spelling; the claimant descriptions are human-readable, in
-        /// declaration order.
+        /// declaration order. Positional sinks *may* share forms with each other (a keyed
+        /// positional form always has the same meaning whichever sink wins), so a collision
+        /// is only reported when at least one claimant is not a sink.
         | TokenCollision of token : string * claimants : string list
+        /// Two positional sinks in the table share an id.
+        | DuplicatePositionalId of positionalId : int
+        /// The tree refers to this positional sink more than once.
+        | PositionalRepeatedInTree of positionalId : int
+        /// The tree refers to a positional-sink id which is not in the table.
+        | PositionalNotInTable of positionalId : int
+        /// A positional sink in the table is not reachable in the tree.
+        | PositionalNotInTree of positionalId : int
+        /// Some complete interpretation of the tree contains more than one positional sink.
+        /// argv holds a single positional stream, and two unbounded consumers would admit no
+        /// canonical partition of it: `P × Q` is malformed, while `(A × P) + (B × Q)` is fine.
+        | PositionalCapacityExceeded of maximum : int
+        /// Positional sinks disagree on the treatment of unrecognised flag-like tokens. The
+        /// policy is lexical — it controls tokenization, which happens before any case is
+        /// selected — so it must be schema-global.
+        | FlagLikePolicyDisagreement
 
     [<RequireQualifiedAccess>]
     module SchemaError =
@@ -634,6 +702,20 @@ module private ArgParserRuntime_SameBaseNameArgs =
                     "the token '%s' is claimed by: %s (argument names are matched case-insensitively)"
                     token
                     (String.concat "; " claimants)
+            | SchemaError.DuplicatePositionalId positionalId ->
+                sprintf "two positional-args sinks share the id %i" positionalId
+            | SchemaError.PositionalRepeatedInTree positionalId ->
+                sprintf "the schema tree refers to positional-args sink id %i more than once" positionalId
+            | SchemaError.PositionalNotInTable positionalId ->
+                sprintf "the schema tree refers to positional-args sink id %i, which does not exist" positionalId
+            | SchemaError.PositionalNotInTree positionalId ->
+                sprintf "positional-args sink id %i is not reachable in the schema tree" positionalId
+            | SchemaError.PositionalCapacityExceeded maximum ->
+                sprintf
+                    "some alternative of the schema contains %i positional-args sinks; at most one may be active, because argv holds a single stream of positional args"
+                    maximum
+            | SchemaError.FlagLikePolicyDisagreement ->
+                "positional-args sinks disagree on whether to collect unrecognised flag-like tokens; that choice affects tokenization, which happens before alternatives are chosen between, so all sinks must agree"
 
     /// An ErasedSchema which has passed the structural checks in WellFormedSchema.check.
     ///
@@ -677,10 +759,63 @@ module private ArgParserRuntime_SameBaseNameArgs =
                 |> List.filter (fun leafId -> not (Set.contains leafId treeIdSet))
                 |> List.map SchemaError.LeafNotInTree
 
+            let positionalTreeIds = positionalIds schema.Tree
+            let positionalTableIds = schema.Positionals |> List.map (fun p -> p.Id)
+            let positionalTreeIdSet = Set.ofList positionalTreeIds
+            let positionalTableIdSet = Set.ofList positionalTableIds
+
+            let duplicatePositionalIds =
+                positionalTableIds
+                |> List.countBy (fun positionalId -> positionalId)
+                |> List.filter (fun (_, count) -> count > 1)
+                |> List.map (fun (positionalId, _) -> SchemaError.DuplicatePositionalId positionalId)
+
+            let positionalRepeatedInTree =
+                positionalTreeIds
+                |> List.countBy (fun positionalId -> positionalId)
+                |> List.filter (fun (_, count) -> count > 1)
+                |> List.map (fun (positionalId, _) -> SchemaError.PositionalRepeatedInTree positionalId)
+
+            let positionalNotInTable =
+                positionalTreeIds
+                |> List.distinct
+                |> List.filter (fun positionalId -> not (Set.contains positionalId positionalTableIdSet))
+                |> List.map SchemaError.PositionalNotInTable
+
+            let positionalNotInTree =
+                positionalTableIds
+                |> List.distinct
+                |> List.filter (fun positionalId -> not (Set.contains positionalId positionalTreeIdSet))
+                |> List.map SchemaError.PositionalNotInTree
+
+            let capacityExceeded =
+                let maximum = maxPositionals schema.Tree
+
+                if maximum > 1 then
+                    [ SchemaError.PositionalCapacityExceeded maximum ]
+                else
+                    []
+
+            let policyDisagreement =
+                let policies =
+                    schema.Positionals
+                    |> List.map (fun p ->
+                        match p.FlagLike with
+                        | ErasedFlagLikeBehaviour.Collect -> true
+                        | ErasedFlagLikeBehaviour.Reject -> false
+                    )
+                    |> List.distinct
+
+                match policies with
+                | []
+                | [ _ ] -> []
+                | _ -> [ SchemaError.FlagLikePolicyDisagreement ]
+
             let duplicateSumIds =
                 let rec sumIds (tree : ErasedTree) : int list =
                     match tree with
                     | ErasedTree.Leaf _ -> []
+                    | ErasedTree.PositionalLeaf _ -> []
                     | ErasedTree.Product children -> children |> List.collect sumIds
                     | ErasedTree.Sum (sumId, cases) -> sumId :: (cases |> List.collect (fun (_, case) -> sumIds case))
 
@@ -710,48 +845,57 @@ module private ArgParserRuntime_SameBaseNameArgs =
                 (schema.Leaves
                  |> List.collect (fun leaf ->
                      let plain =
-                         leaf.Forms |> List.map (fun form -> "--" + form, sprintf "argument '--%s'" form)
+                         leaf.Forms
+                         |> List.map (fun form -> "--" + form, sprintf "argument '--%s'" form, false)
 
                      let negated =
                          if leaf.AcceptsNegation then
                              leaf.Forms
-                             |> List.map (fun form -> "--no-" + form, sprintf "the --no- form of argument '--%s'" form)
+                             |> List.map (fun form ->
+                                 "--no-" + form, sprintf "the --no- form of argument '--%s'" form, false
+                             )
                          else
                              []
 
                      plain @ negated
                  ))
-                @ (
-                    match schema.Positional with
-                    | None -> []
-                    | Some positional ->
-                        positional.Forms
-                        |> List.map (fun form -> "--" + form, sprintf "the positional-args sink '--%s'" form)
-                )
-                @ [ "--help", "the built-in help flag" ]
+                @ (schema.Positionals
+                   |> List.collect (fun positional ->
+                       positional.Forms
+                       |> List.map (fun form -> "--" + form, sprintf "the positional-args sink '--%s'" form, true)
+                   ))
+                @ [ "--help", "the built-in help flag", false ]
 
             let collisions =
                 let indexOf =
                     System.Collections.Generic.Dictionary<string, int> (StringComparer.OrdinalIgnoreCase)
 
-                let buckets = ResizeArray<ResizeArray<string * string>> ()
+                let buckets = ResizeArray<ResizeArray<string * string * bool>> ()
 
-                for token, claimant in claims do
+                for token, claimant, isSink in claims do
                     match indexOf.TryGetValue token with
-                    | true, index -> buckets.[index].Add ((token, claimant))
+                    | true, index -> buckets.[index].Add ((token, claimant, isSink))
                     | false, _ ->
                         indexOf.[token] <- buckets.Count
                         let bucket = ResizeArray ()
-                        bucket.Add ((token, claimant))
+                        bucket.Add ((token, claimant, isSink))
                         buckets.Add bucket
 
                 buckets
                 |> Seq.choose (fun bucket ->
-                    if bucket.Count < 2 then
+                    let allSinks = bucket |> Seq.forall (fun (_, _, isSink) -> isSink)
+
+                    if bucket.Count < 2 || allSinks then
                         None
                     else
-                        let token, _ = bucket.[0]
-                        Some (SchemaError.TokenCollision (token, bucket |> Seq.map snd |> List.ofSeq))
+                        let token, _, _ = bucket.[0]
+
+                        Some (
+                            SchemaError.TokenCollision (
+                                token,
+                                bucket |> Seq.map (fun (_, claimant, _) -> claimant) |> List.ofSeq
+                            )
+                        )
                 )
                 |> List.ofSeq
 
@@ -770,27 +914,31 @@ module private ArgParserRuntime_SameBaseNameArgs =
                              []
                      )
                  ))
-                @ (
-                    match schema.Positional with
-                    | None -> []
-                    | Some positional ->
-                        let claimant = "the positional-args sink"
+                @ (schema.Positionals
+                   |> List.collect (fun positional ->
+                       let claimant = sprintf "positional-args sink id %i" positional.Id
 
-                        positional.Forms
-                        |> List.collect (fun form ->
-                            if form = "" then
-                                [ SchemaError.EmptyForm claimant ]
-                            elif form.Contains "=" then
-                                [ SchemaError.FormContainsEquals (claimant, form) ]
-                            else
-                                []
-                        )
-                )
+                       positional.Forms
+                       |> List.collect (fun form ->
+                           if form = "" then
+                               [ SchemaError.EmptyForm claimant ]
+                           elif form.Contains "=" then
+                               [ SchemaError.FormContainsEquals (claimant, form) ]
+                           else
+                               []
+                       )
+                   ))
 
             duplicateLeafIds
             @ repeatedInTree
             @ notInTable
             @ notInTree
+            @ duplicatePositionalIds
+            @ positionalRepeatedInTree
+            @ positionalNotInTable
+            @ positionalNotInTree
+            @ capacityExceeded
+            @ policyDisagreement
             @ duplicateSumIds
             @ noForms
             @ negationOnNonBool
@@ -936,9 +1084,9 @@ module private ArgParserRuntime_SameBaseNameArgs =
 
                     consume rest
                 | ScanEvent.Positional (value, afterSeparator, _) ->
-                    match schema.Positional with
-                    | None -> consume rest
-                    | Some _ ->
+                    match schema.Positionals with
+                    | [] -> consume rest
+                    | _ :: _ ->
                         match callbacks.StorePositional value afterSeparator with
                         | Some error -> errors.Add error
                         | None -> ()
@@ -1054,18 +1202,21 @@ module SameBaseNameArgs =
                     ]
                 Tree =
                     (ArgParserRuntime_SameBaseNameArgs.ErasedTree.Product (
-                        [ ArgParserRuntime_SameBaseNameArgs.ErasedTree.Leaf 0 ]
+                        [
+                            ArgParserRuntime_SameBaseNameArgs.ErasedTree.Leaf 0
+                            ArgParserRuntime_SameBaseNameArgs.ErasedTree.PositionalLeaf 0
+                        ]
                     ))
-                Positional =
-                    ({
-                        ArgParserRuntime_SameBaseNameArgs.ErasedPositional.Id = 1
-                        ArgParserRuntime_SameBaseNameArgs.ErasedPositional.Forms = [ "rest" ; "others" ]
-                        ArgParserRuntime_SameBaseNameArgs.ErasedPositional.FlagLike =
-                            ArgParserRuntime_SameBaseNameArgs.ErasedFlagLikeBehaviour.Reject
-                        ArgParserRuntime_SameBaseNameArgs.ErasedPositional.TypeDescription = ""
-                        ArgParserRuntime_SameBaseNameArgs.ErasedPositional.Help = None
-                    })
-                    |> Some
+                Positionals =
+                    [
+                        {
+                            Id = 0
+                            Forms = [ "rest" ; "others" ]
+                            FlagLike = ArgParserRuntime_SameBaseNameArgs.ErasedFlagLikeBehaviour.Reject
+                            TypeDescription = ""
+                            Help = None
+                        }
+                    ]
             }
 
         let parser_storeOccurrence (occurrence : ArgParserRuntime_SameBaseNameArgs.ErasedOccurrence) : string option =

--- a/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParserRuntime.fs
+++ b/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParserRuntime.fs
@@ -26,11 +26,15 @@ module TestArgParserRuntime =
             Help = None
         }
 
-    let private productSchema (leaves : ErasedLeaf list) (positional : ErasedPositional option) : ErasedSchema =
+    let private productSchema (leaves : ErasedLeaf list) (positionals : ErasedPositional list) : ErasedSchema =
         {
             Leaves = leaves
-            Tree = ErasedTree.Product (leaves |> List.map (fun l -> ErasedTree.Leaf l.Id))
-            Positional = positional
+            Tree =
+                ErasedTree.Product (
+                    (leaves |> List.map (fun l -> ErasedTree.Leaf l.Id))
+                    @ (positionals |> List.map (fun p -> ErasedTree.PositionalLeaf p.Id))
+                )
+            Positionals = positionals
         }
 
     /// Shadows the kernel's runParse: every schema in these tests is well-formed, so go through
@@ -53,7 +57,7 @@ module TestArgParserRuntime =
     [<Test>]
     let ``Equals form and space form produce the same occurrence`` () =
         let schema =
-            productSchema [ leaf 0 "foo" ErasedArity.One ErasedRequirement.Required ] None
+            productSchema [ leaf 0 "foo" ErasedArity.One ErasedRequirement.Required ] []
 
         scan schema [ "--foo=3" ] |> shouldEqual [ occ 0 (Some "3") false "--foo=3" ]
 
@@ -62,7 +66,7 @@ module TestArgParserRuntime =
     [<Test>]
     let ``Keys match case-insensitively`` () =
         let schema =
-            productSchema [ leaf 0 "foo" ErasedArity.One ErasedRequirement.Required ] None
+            productSchema [ leaf 0 "foo" ErasedArity.One ErasedRequirement.Required ] []
 
         scan schema [ "--FOO=3" ] |> shouldEqual [ occ 0 (Some "3") false "--FOO=3" ]
 
@@ -74,7 +78,7 @@ module TestArgParserRuntime =
                     leaf 0 "a" ErasedArity.One ErasedRequirement.Required
                     leaf 1 "b" ErasedArity.One ErasedRequirement.Optional
                 ]
-                None
+                []
 
         scan schema [ "--a" ; "--b=false" ]
         |> shouldEqual [ occ 0 (Some "--b=false") false "--a" ]
@@ -87,7 +91,7 @@ module TestArgParserRuntime =
                     leaf 0 "flag" ErasedArity.BoolLike ErasedRequirement.Required
                     leaf 1 "b" ErasedArity.One ErasedRequirement.Optional
                 ]
-                None
+                []
 
         scan schema [ "--flag" ; "TRUE" ]
         |> shouldEqual [ occ 0 (Some "TRUE") false "--flag" ]
@@ -104,7 +108,7 @@ module TestArgParserRuntime =
                     leaf 0 "flag" ErasedArity.BoolLike ErasedRequirement.Required
                     leaf 1 "b" ErasedArity.One ErasedRequirement.Optional
                 ]
-                None
+                []
 
         scan schema [ "--flag" ] |> shouldEqual [ occ 0 None false "--flag" ]
 
@@ -120,7 +124,7 @@ module TestArgParserRuntime =
     [<Test>]
     let ``Help is recognised case-insensitively in key position but not in value position`` () =
         let schema =
-            productSchema [ leaf 0 "foo" ErasedArity.One ErasedRequirement.Required ] None
+            productSchema [ leaf 0 "foo" ErasedArity.One ErasedRequirement.Required ] []
 
         scan schema [ "--HELP" ] |> shouldEqual [ ScanEvent.Help "--HELP" ]
 
@@ -136,7 +140,7 @@ module TestArgParserRuntime =
                         AcceptsNegation = true
                     }
                 ]
-                None
+                []
 
         scan schema [ "--no-flag" ] |> shouldEqual [ occ 0 None true "--no-flag" ]
         scan schema [ "--NO-FLAG" ] |> shouldEqual [ occ 0 None true "--NO-FLAG" ]
@@ -153,9 +157,7 @@ module TestArgParserRuntime =
             }
 
         let schema =
-            { productSchema [ leaf 0 "a" ErasedArity.One ErasedRequirement.Required ] (Some sink) with
-                Positional = Some sink
-            }
+            productSchema [ leaf 0 "a" ErasedArity.One ErasedRequirement.Required ] [ sink ]
 
         scan schema [ "--unknown" ; "foo" ]
         |> shouldEqual
@@ -186,7 +188,7 @@ module TestArgParserRuntime =
             }
 
         let schema =
-            productSchema [ leaf 0 "a" ErasedArity.One ErasedRequirement.Optional ] (Some sink)
+            productSchema [ leaf 0 "a" ErasedArity.One ErasedRequirement.Optional ] [ sink ]
 
         scan schema [ "--rest=5" ; "--rest" ; "6" ; "plain" ]
         |> shouldEqual
@@ -222,7 +224,7 @@ module TestArgParserRuntime =
             }
 
         let schema =
-            productSchema [ leaf 0 "a" ErasedArity.One ErasedRequirement.Optional ] (Some sink)
+            productSchema [ leaf 0 "a" ErasedArity.One ErasedRequirement.Optional ] [ sink ]
 
         scan schema [ "--remainder=5" ; "--REMAINDER" ; "6" ]
         |> shouldEqual
@@ -237,7 +239,7 @@ module TestArgParserRuntime =
     [<Test>]
     let ``An unknown key is an error where flag-like collection is not allowed`` () =
         let schema =
-            productSchema [ leaf 0 "a" ErasedArity.One ErasedRequirement.Required ] None
+            productSchema [ leaf 0 "a" ErasedArity.One ErasedRequirement.Required ] []
 
         scan schema [ "--unknown=3" ]
         |> shouldEqual [ ScanEvent.Error (ScanError.UnknownKeyEqualsValue ("--unknown", "3")) ]
@@ -272,7 +274,7 @@ module TestArgParserRuntime =
                         "BarCase", ErasedTree.Product [ ErasedTree.Leaf 1 ; ErasedTree.Leaf 2 ]
                     ]
                 )
-            Positional = None
+            Positionals = []
         }
 
     let private observedOf (events : ScanEvent list) : Map<int, string> =
@@ -347,7 +349,7 @@ module TestArgParserRuntime =
                         AcceptsNegation = true
                     }
                 ]
-                None
+                []
 
         // Twice through different spellings: still a duplicate of the one leaf.
         let events = scan schema [ "--flag=true" ; "--no-alias" ]
@@ -368,7 +370,7 @@ module TestArgParserRuntime =
                         Repeatable = true
                     }
                 ]
-                None
+                []
 
         let events = scan schema [ "--rest=1" ; "--rest=2" ]
         let selection = select schema (observedOf events)
@@ -443,6 +445,7 @@ module TestArgParserRuntime =
         {
             Choices = Map.empty
             ActiveLeaves = schema.Leaves |> List.map (fun l -> l.Id) |> Set.ofList
+            ActivePositional = schema.Positionals |> List.tryHead |> Option.map (fun p -> p.Id)
             Errors = []
         }
 
@@ -454,7 +457,7 @@ module TestArgParserRuntime =
                     leaf 0 "foo" ErasedArity.One ErasedRequirement.Required
                     leaf 1 "bar" ErasedArity.One ErasedRequirement.HasDefault
                 ]
-                None
+                []
 
         let fake = FakeTyped.Fresh ()
 
@@ -473,7 +476,7 @@ module TestArgParserRuntime =
                     leaf 0 "foo" ErasedArity.One ErasedRequirement.Required
                     leaf 1 "bar" ErasedArity.One ErasedRequirement.HasDefault
                 ]
-                None
+                []
 
         let fake = FakeTyped.Fresh ()
 
@@ -496,7 +499,7 @@ module TestArgParserRuntime =
                     leaf 0 "foo" ErasedArity.One ErasedRequirement.Required
                     leaf 1 "bar" ErasedArity.One ErasedRequirement.Required
                 ]
-                None
+                []
 
         let fake = FakeTyped.Fresh ()
 
@@ -515,7 +518,7 @@ module TestArgParserRuntime =
     [<Test>]
     let ``runParse: help wins, lazily`` () =
         let schema =
-            productSchema [ leaf 0 "foo" ErasedArity.One ErasedRequirement.Required ] None
+            productSchema [ leaf 0 "foo" ErasedArity.One ErasedRequirement.Required ] []
 
         let fake = FakeTyped.Fresh ()
 
@@ -528,7 +531,7 @@ module TestArgParserRuntime =
     [<Test>]
     let ``runParse: unknown keys are fatal where flag-like collection is not allowed`` () =
         let schema =
-            productSchema [ leaf 0 "foo" ErasedArity.One ErasedRequirement.Optional ] None
+            productSchema [ leaf 0 "foo" ErasedArity.One ErasedRequirement.Optional ] []
 
         let fake = FakeTyped.Fresh ()
 
@@ -550,7 +553,7 @@ module TestArgParserRuntime =
                     leaf 0 "foo" ErasedArity.One ErasedRequirement.Required
                     leaf 1 "flag" ErasedArity.BoolLike ErasedRequirement.Optional
                 ]
-                None
+                []
 
         let fake = FakeTyped.Fresh ()
 
@@ -569,7 +572,7 @@ module TestArgParserRuntime =
     [<Test>]
     let ``runParse: a failed first occurrence is not a duplicate of a successful second`` () =
         let schema =
-            productSchema [ leaf 0 "foo" ErasedArity.One ErasedRequirement.Required ] None
+            productSchema [ leaf 0 "foo" ErasedArity.One ErasedRequirement.Required ] []
 
         let fake = FakeTyped.Fresh ()
 
@@ -588,7 +591,7 @@ module TestArgParserRuntime =
                     leaf 0 "foo" ErasedArity.One ErasedRequirement.Required
                     leaf 1 "bar" ErasedArity.One ErasedRequirement.Required
                 ]
-                None
+                []
 
         let fake = FakeTyped.Fresh ()
 
@@ -605,7 +608,7 @@ module TestArgParserRuntime =
     [<Test>]
     let ``runParse: leftover positionals without a sink are an error`` () =
         let schema =
-            productSchema [ leaf 0 "foo" ErasedArity.One ErasedRequirement.Optional ] None
+            productSchema [ leaf 0 "foo" ErasedArity.One ErasedRequirement.Optional ] []
 
         let fake = FakeTyped.Fresh ()
 
@@ -626,7 +629,7 @@ module TestArgParserRuntime =
             }
 
         let schema =
-            productSchema [ leaf 0 "foo" ErasedArity.One ErasedRequirement.Optional ] (Some sink)
+            productSchema [ leaf 0 "foo" ErasedArity.One ErasedRequirement.Optional ] [ sink ]
 
         let fake = FakeTyped.Fresh ()
 
@@ -662,6 +665,9 @@ module TestArgParserRuntime =
     let rec private alternatives (tree : ErasedTree) : (Map<int, int> * Set<int>) list =
         match tree with
         | ErasedTree.Leaf leafId -> [ Map.empty, Set.singleton leafId ]
+        // These alternatives track named leaves only; positional resolution has its own
+        // reference semantics in TestArgParserPositionalReference.
+        | ErasedTree.PositionalLeaf _ -> [ Map.empty, Set.empty ]
         | ErasedTree.Product children ->
             ([ Map.empty, Set.empty ], children)
             ||> List.fold (fun accs child ->
@@ -814,6 +820,7 @@ module TestArgParserRuntime =
         let rec go (tree : ErasedTree) : ErasedTree =
             match tree with
             | ErasedTree.Leaf id -> ErasedTree.Leaf id
+            | ErasedTree.PositionalLeaf id -> ErasedTree.PositionalLeaf id
             | ErasedTree.Product children -> ErasedTree.Product (children |> List.map go)
             | ErasedTree.Sum (_, cases) ->
                 let id = next
@@ -832,7 +839,7 @@ module TestArgParserRuntime =
                 {
                     Leaves = leaves
                     Tree = renumberSums tree
-                    Positional = None
+                    Positionals = []
                 }
         }
 
@@ -852,6 +859,7 @@ module TestArgParserRuntime =
             let rec pickAlternative (tree : ErasedTree) : Gen<Set<int>> =
                 match tree with
                 | ErasedTree.Leaf id -> Gen.constant (Set.singleton id)
+                | ErasedTree.PositionalLeaf _ -> Gen.constant Set.empty
                 | ErasedTree.Product children ->
                     gen {
                         let! sets = children |> List.map pickAlternative |> Gen.sequenceToList
@@ -1018,7 +1026,7 @@ module TestArgParserRuntime =
     let private genToken (schema : ErasedSchema) : Gen<string> =
         let forms =
             (schema.Leaves |> List.collect (fun l -> l.Forms))
-            @ (schema.Positional |> Option.toList |> List.collect (fun p -> p.Forms))
+            @ (schema.Positionals |> List.collect (fun p -> p.Forms))
 
         let keyish =
             match forms with
@@ -1056,8 +1064,8 @@ module TestArgParserRuntime =
                 let schema =
                     if hasSink then
                         { schema with
-                            Positional =
-                                Some
+                            Positionals =
+                                [
                                     {
                                         Id = 1000
                                         Forms = [ "rest" ]
@@ -1065,6 +1073,8 @@ module TestArgParserRuntime =
                                         TypeDescription = "string"
                                         Help = None
                                     }
+                                ]
+                            Tree = ErasedTree.Product [ schema.Tree ; ErasedTree.PositionalLeaf 1000 ]
                         }
                     else
                         schema
@@ -1258,8 +1268,8 @@ module TestArgParserRuntime =
 
                 let schema =
                     { schema with
-                        Positional =
-                            Some
+                        Positionals =
+                            [
                                 {
                                     Id = 1000
                                     Forms = [ "rest" ]
@@ -1267,6 +1277,8 @@ module TestArgParserRuntime =
                                     TypeDescription = "string"
                                     Help = None
                                 }
+                            ]
+                        Tree = ErasedTree.Product [ schema.Tree ; ErasedTree.PositionalLeaf 1000 ]
                     }
 
                 // Any leaf may occur any number of times: the scanner does not enforce
@@ -1394,7 +1406,7 @@ module TestArgParserRuntime =
                         leaf 1 "FOO" ErasedArity.One ErasedRequirement.Required
                     ]
                 Tree = ErasedTree.Sum (0, [ "CaseA", ErasedTree.Leaf 0 ; "CaseB", ErasedTree.Leaf 1 ])
-                Positional = None
+                Positionals = []
             }
 
         WellFormedSchema.errors schema
@@ -1411,7 +1423,7 @@ module TestArgParserRuntime =
             }
 
         let schema =
-            productSchema [ negatable ; leaf 1 "No-Foo" ErasedArity.One ErasedRequirement.Required ] None
+            productSchema [ negatable ; leaf 1 "No-Foo" ErasedArity.One ErasedRequirement.Required ] []
 
         WellFormedSchema.errors schema
         |> shouldEqual
@@ -1425,7 +1437,7 @@ module TestArgParserRuntime =
     [<Test>]
     let ``No argument may claim the reserved help name, in any casing`` () =
         let schema =
-            productSchema [ leaf 0 "HeLp" ErasedArity.One ErasedRequirement.Required ] None
+            productSchema [ leaf 0 "HeLp" ErasedArity.One ErasedRequirement.Required ] []
 
         WellFormedSchema.errors schema
         |> shouldEqual
@@ -1445,7 +1457,7 @@ module TestArgParserRuntime =
             }
 
         let schema =
-            productSchema [ leaf 0 "rest" ErasedArity.One ErasedRequirement.Required ] (Some sink)
+            productSchema [ leaf 0 "rest" ErasedArity.One ErasedRequirement.Required ] [ sink ]
 
         WellFormedSchema.errors schema
         |> shouldEqual
@@ -1466,7 +1478,7 @@ module TestArgParserRuntime =
             }
 
         let schema =
-            productSchema [ leaf 0 "target" ErasedArity.One ErasedRequirement.Required ] (Some sink)
+            productSchema [ leaf 0 "target" ErasedArity.One ErasedRequirement.Required ] [ sink ]
 
         WellFormedSchema.errors schema
         |> shouldEqual
@@ -1484,7 +1496,7 @@ module TestArgParserRuntime =
                 Forms = [ "foo" ; "FOO" ]
             }
 
-        WellFormedSchema.errors (productSchema [ doubled ] None)
+        WellFormedSchema.errors (productSchema [ doubled ] [])
         |> shouldEqual
             [
                 SchemaError.TokenCollision ("--foo", [ "argument '--foo'" ; "argument '--FOO'" ])
@@ -1500,7 +1512,7 @@ module TestArgParserRuntime =
                         leaf 0 "b" ErasedArity.One ErasedRequirement.Required
                     ]
                 Tree = ErasedTree.Product [ ErasedTree.Leaf 0 ]
-                Positional = None
+                Positionals = []
             }
 
         WellFormedSchema.errors schema |> shouldEqual [ SchemaError.DuplicateLeafId 0 ]
@@ -1508,7 +1520,7 @@ module TestArgParserRuntime =
     [<Test>]
     let ``A leaf repeated in the tree is rejected`` () =
         let schema =
-            { productSchema [ leaf 0 "a" ErasedArity.One ErasedRequirement.Required ] None with
+            { productSchema [ leaf 0 "a" ErasedArity.One ErasedRequirement.Required ] [] with
                 Tree = ErasedTree.Product [ ErasedTree.Leaf 0 ; ErasedTree.Leaf 0 ]
             }
 
@@ -1525,7 +1537,7 @@ module TestArgParserRuntime =
                         leaf 1 "b" ErasedArity.One ErasedRequirement.Required
                     ]
                 Tree = ErasedTree.Product [ ErasedTree.Leaf 0 ; ErasedTree.Leaf 2 ]
-                Positional = None
+                Positionals = []
             }
 
         WellFormedSchema.errors schema
@@ -1546,7 +1558,7 @@ module TestArgParserRuntime =
                             ErasedTree.Sum (0, [ "A", ErasedTree.Leaf 0 ])
                             ErasedTree.Sum (0, [ "B", ErasedTree.Leaf 1 ])
                         ]
-                Positional = None
+                Positionals = []
             }
 
         WellFormedSchema.errors schema |> shouldEqual [ SchemaError.DuplicateSumId 0 ]
@@ -1558,7 +1570,7 @@ module TestArgParserRuntime =
                 AcceptsNegation = true
             }
 
-        WellFormedSchema.errors (productSchema [ bad ] None)
+        WellFormedSchema.errors (productSchema [ bad ] [])
         |> shouldEqual [ SchemaError.NegationOnNonBool 0 ]
 
     [<Test>]
@@ -1568,7 +1580,7 @@ module TestArgParserRuntime =
                 Forms = []
             }
 
-        WellFormedSchema.errors (productSchema [ bad ] None)
+        WellFormedSchema.errors (productSchema [ bad ] [])
         |> shouldEqual [ SchemaError.NoForms 0 ]
 
     [<Test>]
@@ -1581,7 +1593,7 @@ module TestArgParserRuntime =
                         leaf 1 "FOO" ErasedArity.One ErasedRequirement.Required
                     ]
                 Tree = ErasedTree.Sum (0, [ "CaseA", ErasedTree.Leaf 0 ; "CaseB", ErasedTree.Leaf 1 ])
-                Positional = None
+                Positionals = []
             }
 
         let exc =
@@ -1620,7 +1632,7 @@ module TestArgParserRuntime =
                     leaf 0 "s" ErasedArity.One ErasedRequirement.Required
                     leaf 1 "ſ" ErasedArity.One ErasedRequirement.Required
                 ]
-                None
+                []
 
         // The scanner really does distinguish them.
         scan schema [ "--s=1" ] |> shouldEqual [ occ 0 (Some "1") false "--s=1" ]
@@ -1635,7 +1647,7 @@ module TestArgParserRuntime =
                 Forms = [ "" ]
             }
 
-        WellFormedSchema.errors (productSchema [ bad ] None)
+        WellFormedSchema.errors (productSchema [ bad ] [])
         |> shouldEqual [ SchemaError.EmptyForm "argument id 0" ]
 
     [<Test>]
@@ -1647,7 +1659,7 @@ module TestArgParserRuntime =
                 Forms = [ "foo=bar" ]
             }
 
-        WellFormedSchema.errors (productSchema [ bad ] None)
+        WellFormedSchema.errors (productSchema [ bad ] [])
         |> shouldEqual [ SchemaError.FormContainsEquals ("argument id 0", "foo=bar") ]
 
         let badSink =
@@ -1659,5 +1671,227 @@ module TestArgParserRuntime =
                 Help = None
             }
 
-        WellFormedSchema.errors (productSchema [ leaf 0 "a" ErasedArity.One ErasedRequirement.Required ] (Some badSink))
-        |> shouldEqual [ SchemaError.FormContainsEquals ("the positional-args sink", "rest=stuff") ]
+        WellFormedSchema.errors (productSchema [ leaf 0 "a" ErasedArity.One ErasedRequirement.Required ] [ badSink ])
+        |> shouldEqual [ SchemaError.FormContainsEquals ("positional-args sink id 99", "rest=stuff") ]
+
+    // ----------------------------------------------------------------------------------------
+    // Well-formedness: positional sinks in the tree. The capacity rule (at most one sink per
+    // complete interpretation), the global flag-like policy, and the sink table/tree
+    // correspondence.
+
+    let private sink' (id : int) (forms : string list) (flagLike : ErasedFlagLikeBehaviour) : ErasedPositional =
+        {
+            Id = id
+            Forms = forms
+            FlagLike = flagLike
+            TypeDescription = "string"
+            Help = None
+        }
+
+    [<Test>]
+    let ``Two sinks in one product exceed positional capacity`` () =
+        let schema =
+            {
+                Leaves = []
+                Tree = ErasedTree.Product [ ErasedTree.PositionalLeaf 0 ; ErasedTree.PositionalLeaf 1 ]
+                Positionals =
+                    [
+                        sink' 0 [ "rest" ] ErasedFlagLikeBehaviour.Reject
+                        sink' 1 [ "files" ] ErasedFlagLikeBehaviour.Reject
+                    ]
+            }
+
+        WellFormedSchema.errors schema
+        |> shouldEqual [ SchemaError.PositionalCapacityExceeded 2 ]
+
+    [<Test>]
+    let ``Sinks in mutually exclusive cases are within capacity, and may share forms`` () =
+        // (A × P) + (B × Q), both sinks addressable as --rest: the sinks can never both be
+        // active, and a keyed --rest token has the same arity whichever wins, so this is fine.
+        let schema =
+            {
+                Leaves =
+                    [
+                        leaf 0 "foo" ErasedArity.One ErasedRequirement.Required
+                        leaf 1 "bar" ErasedArity.One ErasedRequirement.Required
+                    ]
+                Tree =
+                    ErasedTree.Sum (
+                        0,
+                        [
+                            "A", ErasedTree.Product [ ErasedTree.Leaf 0 ; ErasedTree.PositionalLeaf 0 ]
+                            "B", ErasedTree.Product [ ErasedTree.Leaf 1 ; ErasedTree.PositionalLeaf 1 ]
+                        ]
+                    )
+                Positionals =
+                    [
+                        sink' 0 [ "rest" ] ErasedFlagLikeBehaviour.Reject
+                        sink' 1 [ "rest" ] ErasedFlagLikeBehaviour.Reject
+                    ]
+            }
+
+        WellFormedSchema.errors schema |> shouldEqual []
+
+    [<Test>]
+    let ``A sink form colliding with a named form is still rejected, even across cases`` () =
+        let schema =
+            {
+                Leaves =
+                    [
+                        leaf 0 "foo" ErasedArity.One ErasedRequirement.Required
+                        leaf 1 "rest" ErasedArity.One ErasedRequirement.Required
+                    ]
+                Tree =
+                    ErasedTree.Sum (
+                        0,
+                        [
+                            "A", ErasedTree.Product [ ErasedTree.Leaf 0 ; ErasedTree.PositionalLeaf 0 ]
+                            "B", ErasedTree.Leaf 1
+                        ]
+                    )
+                Positionals = [ sink' 0 [ "REST" ] ErasedFlagLikeBehaviour.Reject ]
+            }
+
+        WellFormedSchema.errors schema
+        |> shouldEqual
+            [
+                SchemaError.TokenCollision ("--rest", [ "argument '--rest'" ; "the positional-args sink '--REST'" ])
+            ]
+
+    [<Test>]
+    let ``Sinks disagreeing on flag-like policy are rejected`` () =
+        let schema =
+            {
+                Leaves =
+                    [
+                        leaf 0 "foo" ErasedArity.One ErasedRequirement.Required
+                        leaf 1 "bar" ErasedArity.One ErasedRequirement.Required
+                    ]
+                Tree =
+                    ErasedTree.Sum (
+                        0,
+                        [
+                            "A", ErasedTree.Product [ ErasedTree.Leaf 0 ; ErasedTree.PositionalLeaf 0 ]
+                            "B", ErasedTree.Product [ ErasedTree.Leaf 1 ; ErasedTree.PositionalLeaf 1 ]
+                        ]
+                    )
+                Positionals =
+                    [
+                        sink' 0 [ "rest" ] ErasedFlagLikeBehaviour.Reject
+                        sink' 1 [ "files" ] ErasedFlagLikeBehaviour.Collect
+                    ]
+            }
+
+        WellFormedSchema.errors schema
+        |> shouldEqual [ SchemaError.FlagLikePolicyDisagreement ]
+
+    [<Test>]
+    let ``Sink table and tree must correspond`` () =
+        let schema =
+            {
+                Leaves = []
+                Tree = ErasedTree.Product [ ErasedTree.PositionalLeaf 0 ]
+                Positionals = [ sink' 1 [ "rest" ] ErasedFlagLikeBehaviour.Reject ]
+            }
+
+        WellFormedSchema.errors schema
+        |> shouldEqual [ SchemaError.PositionalNotInTable 0 ; SchemaError.PositionalNotInTree 1 ]
+
+    [<Test>]
+    let ``Duplicate sink ids and repeated tree references are rejected`` () =
+        let schema =
+            {
+                Leaves = []
+                Tree = ErasedTree.Product [ ErasedTree.PositionalLeaf 0 ; ErasedTree.PositionalLeaf 0 ]
+                Positionals =
+                    [
+                        sink' 0 [ "rest" ] ErasedFlagLikeBehaviour.Reject
+                        sink' 0 [ "files" ] ErasedFlagLikeBehaviour.Reject
+                    ]
+            }
+
+        WellFormedSchema.errors schema
+        |> shouldEqual
+            [
+                SchemaError.DuplicatePositionalId 0
+                SchemaError.PositionalRepeatedInTree 0
+                SchemaError.PositionalCapacityExceeded 2
+            ]
+
+    [<Test>]
+    let ``Selection reports the active sink for a sink in the selected interpretation`` () =
+        let schema =
+            {
+                Leaves =
+                    [
+                        leaf 0 "foo" ErasedArity.One ErasedRequirement.Required
+                        leaf 1 "bar" ErasedArity.One ErasedRequirement.Required
+                    ]
+                Tree =
+                    ErasedTree.Product
+                        [
+                            ErasedTree.Sum (0, [ "A", ErasedTree.Leaf 0 ; "B", ErasedTree.Leaf 1 ])
+                            ErasedTree.PositionalLeaf 7
+                        ]
+                Positionals = [ sink' 7 [ "rest" ] ErasedFlagLikeBehaviour.Reject ]
+            }
+
+        let selection = select schema (Map.ofList [ 0, "--foo=1" ])
+        selection.Errors |> shouldEqual []
+        selection.Choices |> shouldEqual (Map.ofList [ 0, 0 ])
+        selection.ActivePositional |> shouldEqual (Some 7)
+
+        // A sink inside an unselected case is not active.
+        let schema =
+            {
+                Leaves =
+                    [
+                        leaf 0 "foo" ErasedArity.One ErasedRequirement.Required
+                        leaf 1 "bar" ErasedArity.One ErasedRequirement.Required
+                    ]
+                Tree =
+                    ErasedTree.Sum (
+                        0,
+                        [
+                            "A", ErasedTree.Leaf 0
+                            "B", ErasedTree.Product [ ErasedTree.Leaf 1 ; ErasedTree.PositionalLeaf 7 ]
+                        ]
+                    )
+                Positionals = [ sink' 7 [ "rest" ] ErasedFlagLikeBehaviour.Reject ]
+            }
+
+        let selection = select schema (Map.ofList [ 0, "--foo=1" ])
+        selection.Errors |> shouldEqual []
+        selection.ActivePositional |> shouldEqual None
+
+        let selection = select schema (Map.ofList [ 1, "--bar=1" ])
+        selection.Errors |> shouldEqual []
+        selection.ActivePositional |> shouldEqual (Some 7)
+
+    // ----------------------------------------------------------------------------------------
+    // Property: the runtime's compositional positional-capacity calculation agrees with the
+    // exhaustive reference model of TestArgParserPositionalReference.
+
+    [<Test>]
+    let ``Runtime positional capacity agrees with the reference model`` () =
+        let rec convert (tree : TestArgParserPositionalReference.RefTree) : ErasedTree =
+            match tree with
+            | TestArgParserPositionalReference.RefTree.Named leaf -> ErasedTree.Leaf leaf.Id
+            | TestArgParserPositionalReference.RefTree.Positional p -> ErasedTree.PositionalLeaf p.Id
+            | TestArgParserPositionalReference.RefTree.Product children ->
+                ErasedTree.Product (children |> List.map convert)
+            | TestArgParserPositionalReference.RefTree.Sum (sumId, cases) ->
+                ErasedTree.Sum (sumId, cases |> List.map (fun (name, case) -> name, convert case))
+
+        let cases =
+            gen {
+                let! sumBias = Gen.elements [ 20 ; 50 ; 80 ]
+                return! TestArgParserPositionalReference.genTree sumBias
+            }
+
+        let property (tree : TestArgParserPositionalReference.RefTree) : unit =
+            maxPositionals (convert tree)
+            |> shouldEqual (TestArgParserPositionalReference.maxPositionals tree)
+
+        let config = Config.QuickThrowOnFailure.WithMaxTest 1000
+        Check.One (config, Prop.forAll (Arb.fromGen cases) property)

--- a/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
+++ b/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
@@ -460,17 +460,17 @@ module private ParseTree =
                 failwith
                     $"Cases %s{names} can all be satisfied without supplying any arguments, so an empty command line cannot choose between them. Make an argument in all but one of them mandatory."
 
-    /// Build the expression for the erased-schema tree mirroring this parse tree. Leaf ids are
-    /// assigned in `accumulators` order, which is exactly this walk's traversal order. `rt`
-    /// resolves a path inside the embedded runtime module; `listOf` builds a list literal (with
-    /// the empty list handled). The positional sink is not part of the erased tree, hence the
-    /// option.
+    /// Build the expression for the erased-schema tree mirroring this parse tree. Named-leaf
+    /// ids are assigned in `accumulators` order, which is exactly this walk's traversal order;
+    /// the positional sink (at most one today) has its own id space and always gets id 0. `rt`
+    /// resolves a path inside the embedded runtime module; `listOf` builds a list literal
+    /// (with the empty list handled).
     let rec toErasedTreeExpr<'a>
         (rt : string list -> SynExpr)
         (listOf : SynExpr list -> SynExpr)
         (counter : int ref)
         (tree : ParseTree<'a>)
-        : SynExpr option
+        : SynExpr
         =
         let product (children : SynExpr list) : SynExpr =
             SynExpr.applyFunction (rt [ "ErasedTree" ; "Product" ]) (SynExpr.paren (listOf children))
@@ -481,19 +481,17 @@ module private ParseTree =
             counter.Value <- counter.Value + 1
 
             SynExpr.applyFunction (rt [ "ErasedTree" ; "Leaf" ]) (SynExpr.CreateConst index)
-            |> Some
-        | ParseTree.PositionalLeaf _ -> None
+        | ParseTree.PositionalLeaf _ ->
+            SynExpr.applyFunction (rt [ "ErasedTree" ; "PositionalLeaf" ]) (SynExpr.CreateConst 0)
         | ParseTree.Branch (fields, _, _) ->
             fields
-            |> List.choose (fun (_, child) -> toErasedTreeExpr rt listOf counter child)
+            |> List.map (fun (_, child) -> toErasedTreeExpr rt listOf counter child)
             |> product
-            |> Some
         | ParseTree.Sum (sumId, cases, _, _) ->
             let caseExprs =
                 cases
                 |> List.map (fun (caseName, payload) ->
-                    let payloadExpr =
-                        toErasedTreeExpr rt listOf counter payload |> Option.defaultValue (product [])
+                    let payloadExpr = toErasedTreeExpr rt listOf counter payload
 
                     SynExpr.tuple [ SynExpr.CreateConst caseName.idText ; payloadExpr ]
                 )
@@ -501,16 +499,13 @@ module private ParseTree =
             SynExpr.applyFunction
                 (rt [ "ErasedTree" ; "Sum" ])
                 (SynExpr.paren (SynExpr.tuple [ SynExpr.CreateConst sumId ; listOf caseExprs ]))
-            |> Some
         | ParseTree.BranchPos (_, posTree, fields, _, _) ->
-            // Ordering matches `accumulators`: the sibling fields first, then any named leaves
-            // inside the positional subtree.
+            // Ordering matches `accumulators`: the sibling fields first, then the positional
+            // subtree (whose own named leaves come after the siblings').
             let siblings =
-                fields
-                |> List.choose (fun (_, child) -> toErasedTreeExpr rt listOf counter child)
+                fields |> List.map (fun (_, child) -> toErasedTreeExpr rt listOf counter child)
 
-            let fromPos = toErasedTreeExpr rt listOf counter posTree |> Option.toList
-            product (siblings @ fromPos) |> Some
+            product (siblings @ [ toErasedTreeExpr rt listOf counter posTree ])
 
     /// Build the return value. (References the `parser_selection` binding which the generated
     /// code brings into scope on the success path, to choose among Sum cases.)
@@ -1509,14 +1504,11 @@ module internal ArgParserGenerator =
                         ParseTree.toErasedTreeExpr rt listOf counter tree
                 }
                 |> spec.Apply
-                |> Option.defaultValue (
-                    SynExpr.applyFunction (rt [ "ErasedTree" ; "Product" ]) (SynExpr.paren (listOf []))
-                )
                 |> SynExpr.paren
 
-            let positional =
+            let positionals =
                 match pos with
-                | None -> SynExpr.createIdent "None"
+                | None -> []
                 | Some pf ->
                     let flagLike =
                         let includeFlagLike =
@@ -1533,26 +1525,22 @@ module internal ArgParserGenerator =
                                 (rt [ "ErasedFlagLikeBehaviour" ; "Collect" ])
                             |> SynExpr.paren
 
-
-                    // Unlike the leaf literals, this record is not in annotation-directed
-                    // position (it flows through `Some`), and its type's module is not open, so
-                    // every label must be qualified.
-                    let positionalField (name : string) (value : SynExpr) : SynLongIdent * SynExpr =
-                        SynLongIdent.create [ runtimeModule ; Ident.create "ErasedPositional" ; Ident.create name ],
-                        value
-
                     [
-                        positionalField "Id" (SynExpr.CreateConst (List.length nonPos))
-                        positionalField "Forms" (listOf pf.ArgForm)
-                        positionalField "FlagLike" flagLike
-                        positionalField "TypeDescription" (SynExpr.CreateConst "")
-                        positionalField "Help" (SynExpr.createIdent "None")
+                        [
+                            field "Id" (SynExpr.CreateConst 0)
+                            field "Forms" (listOf pf.ArgForm)
+                            field "FlagLike" flagLike
+                            field "TypeDescription" (SynExpr.CreateConst "")
+                            field "Help" (SynExpr.createIdent "None")
+                        ]
+                        |> SynExpr.createRecord None
                     ]
-                    |> SynExpr.createRecord None
-                    |> SynExpr.paren
-                    |> SynExpr.pipeThroughFunction (SynExpr.createIdent "Some")
 
-            [ field "Leaves" leaves ; field "Tree" tree ; field "Positional" positional ]
+            [
+                field "Leaves" leaves
+                field "Tree" tree
+                field "Positionals" (listOf positionals)
+            ]
             |> SynExpr.createRecord None
             |> SynBinding.basic [ schemaVar ] []
             |> SynBinding.withReturnAnnotation (rtType "ErasedSchema")

--- a/WoofWare.Myriad.Plugins/ArgParserRuntime.fs
+++ b/WoofWare.Myriad.Plugins/ArgParserRuntime.fs
@@ -69,37 +69,49 @@ module internal ArgParserRuntime =
         /// Reject the parse (`[<PositionalArgs false>]` / `[<PositionalArgs>]`).
         | Reject
 
-    /// The positional-argument sink, if the schema has one.
+    /// A positional-argument sink: a consumer of the positional-token stream.
     type ErasedPositional =
         {
-            /// Index into the typed layer's converter table.
+            /// Index into the typed layer's positional converter table. Ids live in their own
+            /// space, independent of ErasedLeaf ids.
             Id : int
             /// The forms under which the sink itself can be addressed as `--form value` /
             /// `--form=value` (the field name argified, plus any explicit long forms); the head
-            /// is used in help text.
+            /// is used in help text. Two sinks in mutually exclusive Sum cases may share a
+            /// form: all keyed positional forms have the same arity, and the capacity rule
+            /// means the sinks can never both be active.
             Forms : string list
+            /// The flag-like policy is lexical (it controls tokenization, which happens before
+            /// any case is selected), so every sink in a schema must agree on it;
+            /// WellFormedSchema enforces the agreement.
             FlagLike : ErasedFlagLikeBehaviour
             TypeDescription : string
             Help : string option
         }
 
     /// The shape of a parser: a tree of products (records), sums (discriminated unions) and
-    /// leaves (actual arguments). Leaves are referred to by id; the flat leaf table plus this
-    /// tree fully describe the schema.
+    /// leaves (actual arguments, named or positional). Leaves are referred to by id; the flat
+    /// leaf tables plus this tree fully describe the schema.
     [<RequireQualifiedAccess>]
     type ErasedTree =
         | Leaf of leafId : int
+        /// A positional-stream consumer. At most one may appear in any complete
+        /// interpretation of the tree (one case chosen for every reachable Sum): argv holds a
+        /// single positional stream, and two unbounded consumers would admit no canonical
+        /// partition of it. WellFormedSchema enforces this capacity rule.
+        | PositionalLeaf of positionalId : int
         | Product of children : ErasedTree list
         /// Cases are in declaration order; the string is the case name, for messages.
         | Sum of sumId : int * cases : (string * ErasedTree) list
 
     type ErasedSchema =
         {
-            /// All leaves reachable in the tree, in field declaration order (the order in which
-            /// "missing required argument" errors are reported).
+            /// All named leaves reachable in the tree, in field declaration order (the order
+            /// in which "missing required argument" errors are reported).
             Leaves : ErasedLeaf list
             Tree : ErasedTree
-            Positional : ErasedPositional option
+            /// All positional sinks reachable in the tree, in declaration order.
+            Positionals : ErasedPositional list
         }
 
     /// One observed occurrence of a named argument.
@@ -220,20 +232,25 @@ module internal ArgParserRuntime =
     /// - Any other token in key position is positional.
     let scan (schema : ErasedSchema) (args : string list) : ScanEvent list =
         let collectFlagLike =
-            match schema.Positional with
-            | Some p ->
-                match p.FlagLike with
-                | ErasedFlagLikeBehaviour.Collect -> true
-                | ErasedFlagLikeBehaviour.Reject -> false
-            | None -> false
+            // The policy is lexical, so all sinks must agree on it (WellFormedSchema enforces
+            // this); Collect is honoured only when every sink asks for it.
+            match schema.Positionals with
+            | [] -> false
+            | positionals ->
+                positionals
+                |> List.forall (fun p ->
+                    match p.FlagLike with
+                    | ErasedFlagLikeBehaviour.Collect -> true
+                    | ErasedFlagLikeBehaviour.Reject -> false
+                )
 
-        /// Does this full `--key` token (value part already split off) name the positional sink?
+        /// Does this full `--key` token (value part already split off) name a positional sink?
         let isPositionalKey (key : string) : bool =
-            match schema.Positional with
-            | None -> false
-            | Some p ->
+            schema.Positionals
+            |> List.exists (fun p ->
                 p.Forms
                 |> List.exists (fun form -> String.Equals (key, "--" + form, StringComparison.OrdinalIgnoreCase))
+            )
 
         /// Resolve a pending key which will receive no value (end of input, or `--` next).
         let resolvePending (state : ScanState) : ScanEvent list =
@@ -381,13 +398,17 @@ module internal ArgParserRuntime =
     type Selection =
         {
             Choices : Map<int, int>
-            /// Ids of leaves which are part of the selected interpretation.
+            /// Ids of named leaves which are part of the selected interpretation.
             ActiveLeaves : Set<int>
+            /// The positional sink which is part of the selected interpretation, if any. The
+            /// capacity rule (enforced by WellFormedSchema) guarantees there is at most one.
+            ActivePositional : int option
             Errors : SelectionError list
         }
 
-    /// Can this subtree be satisfied with zero occurrences? A leaf can iff it is not required; a
-    /// product can iff all its children can; a sum can iff some case can.
+    /// Can this subtree be satisfied with zero occurrences? A named leaf can iff it is not
+    /// required; a positional leaf always can (an empty stream is fine); a product can iff all
+    /// its children can; a sum can iff some case can.
     let rec private emptyOk (leaves : Map<int, ErasedLeaf>) (tree : ErasedTree) : bool =
         match tree with
         | ErasedTree.Leaf leafId ->
@@ -395,15 +416,38 @@ module internal ArgParserRuntime =
             | ErasedRequirement.Required -> false
             | ErasedRequirement.Optional
             | ErasedRequirement.HasDefault -> true
+        | ErasedTree.PositionalLeaf _ -> true
         | ErasedTree.Product children -> children |> List.forall (emptyOk leaves)
         | ErasedTree.Sum (_, cases) -> cases |> List.exists (fun (_, case) -> emptyOk leaves case)
 
-    /// All leaf ids under a subtree, in declaration order.
+    /// All named-leaf ids under a subtree, in declaration order.
     let rec leafIds (tree : ErasedTree) : int list =
         match tree with
         | ErasedTree.Leaf leafId -> [ leafId ]
+        | ErasedTree.PositionalLeaf _ -> []
         | ErasedTree.Product children -> children |> List.collect leafIds
         | ErasedTree.Sum (_, cases) -> cases |> List.collect (fun (_, case) -> leafIds case)
+
+    /// All positional-sink ids under a subtree, in declaration order.
+    let rec positionalIds (tree : ErasedTree) : int list =
+        match tree with
+        | ErasedTree.Leaf _ -> []
+        | ErasedTree.PositionalLeaf positionalId -> [ positionalId ]
+        | ErasedTree.Product children -> children |> List.collect positionalIds
+        | ErasedTree.Sum (_, cases) -> cases |> List.collect (fun (_, case) -> positionalIds case)
+
+    /// The maximum number of positional sinks any complete interpretation of the tree can
+    /// contain: a product's interpretations combine its children's, a sum's take the maximum
+    /// over its cases.
+    let rec maxPositionals (tree : ErasedTree) : int =
+        match tree with
+        | ErasedTree.Leaf _ -> 0
+        | ErasedTree.PositionalLeaf _ -> 1
+        | ErasedTree.Product children -> children |> List.sumBy maxPositionals
+        | ErasedTree.Sum (_, cases) ->
+            match cases with
+            | [] -> 0
+            | cases -> cases |> List.map (fun (_, case) -> maxPositionals case) |> List.max
 
     /// Select a case for every Sum node reachable in the selected interpretation, given a witness
     /// (an example source token) for every leaf which received an occurrence.
@@ -415,17 +459,18 @@ module internal ArgParserRuntime =
     let select (schema : ErasedSchema) (observed : Map<int, string>) : Selection =
         let leavesById = schema.Leaves |> List.map (fun leaf -> leaf.Id, leaf) |> Map.ofList
 
-        let rec go (tree : ErasedTree) : Map<int, int> * Set<int> * SelectionError list =
+        let rec go (tree : ErasedTree) : Map<int, int> * Set<int> * Set<int> * SelectionError list =
             match tree with
-            | ErasedTree.Leaf leafId -> Map.empty, Set.singleton leafId, []
+            | ErasedTree.Leaf leafId -> Map.empty, Set.singleton leafId, Set.empty, []
+            | ErasedTree.PositionalLeaf positionalId -> Map.empty, Set.empty, Set.singleton positionalId, []
             | ErasedTree.Product children ->
-                ((Map.empty, Set.empty, []), children)
-                ||> List.fold (fun (choices, active, errors) child ->
-                    let childChoices, childActive, childErrors = go child
+                ((Map.empty, Set.empty, Set.empty, []), children)
+                ||> List.fold (fun (choices, active, activePos, errors) child ->
+                    let childChoices, childActive, childActivePos, childErrors = go child
 
                     let choices = (choices, childChoices) ||> Map.fold (fun m k v -> Map.add k v m)
 
-                    choices, Set.union active childActive, errors @ childErrors
+                    choices, Set.union active childActive, Set.union activePos childActivePos, errors @ childErrors
                 )
             | ErasedTree.Sum (sumId, cases) ->
                 let touched =
@@ -443,8 +488,8 @@ module internal ArgParserRuntime =
                 match touched with
                 | [ (index, _, _) ] ->
                     let _, case = List.item index cases
-                    let childChoices, childActive, childErrors = go case
-                    Map.add sumId index childChoices, childActive, childErrors
+                    let childChoices, childActive, childActivePos, childErrors = go case
+                    Map.add sumId index childChoices, childActive, childActivePos, childErrors
                 | [] ->
                     let satisfiable =
                         cases
@@ -453,23 +498,31 @@ module internal ArgParserRuntime =
 
                     match satisfiable with
                     | [ (index, (_, case)) ] ->
-                        let childChoices, childActive, childErrors = go case
-                        Map.add sumId index childChoices, childActive, childErrors
+                        let childChoices, childActive, childActivePos, childErrors = go case
+                        Map.add sumId index childChoices, childActive, childActivePos, childErrors
                     | [] ->
                         let names = cases |> List.map fst
-                        Map.empty, Set.empty, [ SelectionError.NoCaseSelected (sumId, names) ]
+                        Map.empty, Set.empty, Set.empty, [ SelectionError.NoCaseSelected (sumId, names) ]
                     | multiple ->
                         let names = multiple |> List.map (fun (_, (name, _)) -> name)
-                        Map.empty, Set.empty, [ SelectionError.AmbiguousEmptyCases (sumId, names) ]
+                        Map.empty, Set.empty, Set.empty, [ SelectionError.AmbiguousEmptyCases (sumId, names) ]
                 | multiple ->
                     let witnesses = multiple |> List.map (fun (_, name, source) -> name, source)
-                    Map.empty, Set.empty, [ SelectionError.ConflictingCases (sumId, witnesses) ]
+                    Map.empty, Set.empty, Set.empty, [ SelectionError.ConflictingCases (sumId, witnesses) ]
 
-        let choices, active, errors = go schema.Tree
+        let choices, active, activePos, errors = go schema.Tree
 
         {
             Choices = choices
             ActiveLeaves = active
+            ActivePositional =
+                // The capacity rule makes two active sinks impossible on a well-formed schema.
+                match Set.toList activePos with
+                | [] -> None
+                | [ p ] -> Some p
+                | _ ->
+                    failwith
+                        "WoofWare.Myriad internal error: two positional sinks were active at once; the schema was not validated"
             Errors = errors
         }
 
@@ -552,9 +605,9 @@ module internal ArgParserRuntime =
             )
 
         let noSink =
-            match schema.Positional with
-            | Some _ -> []
-            | None ->
+            match schema.Positionals with
+            | _ :: _ -> []
+            | [] ->
                 let tokens =
                     events
                     |> List.choose (fun event ->
@@ -618,8 +671,26 @@ module internal ArgParserRuntime =
         /// case-insensitive matching (so e.g. forms `foo` and `FOO` collide, as do a literal
         /// form `no-foo` and the negated variant of a negatable `foo`). The token is reported
         /// in the first claimant's spelling; the claimant descriptions are human-readable, in
-        /// declaration order.
+        /// declaration order. Positional sinks *may* share forms with each other (a keyed
+        /// positional form always has the same meaning whichever sink wins), so a collision
+        /// is only reported when at least one claimant is not a sink.
         | TokenCollision of token : string * claimants : string list
+        /// Two positional sinks in the table share an id.
+        | DuplicatePositionalId of positionalId : int
+        /// The tree refers to this positional sink more than once.
+        | PositionalRepeatedInTree of positionalId : int
+        /// The tree refers to a positional-sink id which is not in the table.
+        | PositionalNotInTable of positionalId : int
+        /// A positional sink in the table is not reachable in the tree.
+        | PositionalNotInTree of positionalId : int
+        /// Some complete interpretation of the tree contains more than one positional sink.
+        /// argv holds a single positional stream, and two unbounded consumers would admit no
+        /// canonical partition of it: `P × Q` is malformed, while `(A × P) + (B × Q)` is fine.
+        | PositionalCapacityExceeded of maximum : int
+        /// Positional sinks disagree on the treatment of unrecognised flag-like tokens. The
+        /// policy is lexical — it controls tokenization, which happens before any case is
+        /// selected — so it must be schema-global.
+        | FlagLikePolicyDisagreement
 
     [<RequireQualifiedAccess>]
     module SchemaError =
@@ -649,6 +720,20 @@ module internal ArgParserRuntime =
                     "the token '%s' is claimed by: %s (argument names are matched case-insensitively)"
                     token
                     (String.concat "; " claimants)
+            | SchemaError.DuplicatePositionalId positionalId ->
+                sprintf "two positional-args sinks share the id %i" positionalId
+            | SchemaError.PositionalRepeatedInTree positionalId ->
+                sprintf "the schema tree refers to positional-args sink id %i more than once" positionalId
+            | SchemaError.PositionalNotInTable positionalId ->
+                sprintf "the schema tree refers to positional-args sink id %i, which does not exist" positionalId
+            | SchemaError.PositionalNotInTree positionalId ->
+                sprintf "positional-args sink id %i is not reachable in the schema tree" positionalId
+            | SchemaError.PositionalCapacityExceeded maximum ->
+                sprintf
+                    "some alternative of the schema contains %i positional-args sinks; at most one may be active, because argv holds a single stream of positional args"
+                    maximum
+            | SchemaError.FlagLikePolicyDisagreement ->
+                "positional-args sinks disagree on whether to collect unrecognised flag-like tokens; that choice affects tokenization, which happens before alternatives are chosen between, so all sinks must agree"
 
     /// An ErasedSchema which has passed the structural checks in WellFormedSchema.check.
     ///
@@ -692,10 +777,63 @@ module internal ArgParserRuntime =
                 |> List.filter (fun leafId -> not (Set.contains leafId treeIdSet))
                 |> List.map SchemaError.LeafNotInTree
 
+            let positionalTreeIds = positionalIds schema.Tree
+            let positionalTableIds = schema.Positionals |> List.map (fun p -> p.Id)
+            let positionalTreeIdSet = Set.ofList positionalTreeIds
+            let positionalTableIdSet = Set.ofList positionalTableIds
+
+            let duplicatePositionalIds =
+                positionalTableIds
+                |> List.countBy (fun positionalId -> positionalId)
+                |> List.filter (fun (_, count) -> count > 1)
+                |> List.map (fun (positionalId, _) -> SchemaError.DuplicatePositionalId positionalId)
+
+            let positionalRepeatedInTree =
+                positionalTreeIds
+                |> List.countBy (fun positionalId -> positionalId)
+                |> List.filter (fun (_, count) -> count > 1)
+                |> List.map (fun (positionalId, _) -> SchemaError.PositionalRepeatedInTree positionalId)
+
+            let positionalNotInTable =
+                positionalTreeIds
+                |> List.distinct
+                |> List.filter (fun positionalId -> not (Set.contains positionalId positionalTableIdSet))
+                |> List.map SchemaError.PositionalNotInTable
+
+            let positionalNotInTree =
+                positionalTableIds
+                |> List.distinct
+                |> List.filter (fun positionalId -> not (Set.contains positionalId positionalTreeIdSet))
+                |> List.map SchemaError.PositionalNotInTree
+
+            let capacityExceeded =
+                let maximum = maxPositionals schema.Tree
+
+                if maximum > 1 then
+                    [ SchemaError.PositionalCapacityExceeded maximum ]
+                else
+                    []
+
+            let policyDisagreement =
+                let policies =
+                    schema.Positionals
+                    |> List.map (fun p ->
+                        match p.FlagLike with
+                        | ErasedFlagLikeBehaviour.Collect -> true
+                        | ErasedFlagLikeBehaviour.Reject -> false
+                    )
+                    |> List.distinct
+
+                match policies with
+                | []
+                | [ _ ] -> []
+                | _ -> [ SchemaError.FlagLikePolicyDisagreement ]
+
             let duplicateSumIds =
                 let rec sumIds (tree : ErasedTree) : int list =
                     match tree with
                     | ErasedTree.Leaf _ -> []
+                    | ErasedTree.PositionalLeaf _ -> []
                     | ErasedTree.Product children -> children |> List.collect sumIds
                     | ErasedTree.Sum (sumId, cases) -> sumId :: (cases |> List.collect (fun (_, case) -> sumIds case))
 
@@ -725,29 +863,33 @@ module internal ArgParserRuntime =
             // of its claimant, in declaration order. matchLeaf, the positional-sink match and
             // the `--help` match are all case-insensitive, so claims are grouped under a
             // case-normalised key (ToUpperInvariant, the equality OrdinalIgnoreCase uses).
+            // The boolean records whether the claimant is a positional sink: sinks may share
+            // tokens with each other (whichever sink is active, a keyed positional token
+            // means the same thing), but not with anything else.
             let claims =
                 (schema.Leaves
                  |> List.collect (fun leaf ->
                      let plain =
-                         leaf.Forms |> List.map (fun form -> "--" + form, sprintf "argument '--%s'" form)
+                         leaf.Forms
+                         |> List.map (fun form -> "--" + form, sprintf "argument '--%s'" form, false)
 
                      let negated =
                          if leaf.AcceptsNegation then
                              leaf.Forms
-                             |> List.map (fun form -> "--no-" + form, sprintf "the --no- form of argument '--%s'" form)
+                             |> List.map (fun form ->
+                                 "--no-" + form, sprintf "the --no- form of argument '--%s'" form, false
+                             )
                          else
                              []
 
                      plain @ negated
                  ))
-                @ (
-                    match schema.Positional with
-                    | None -> []
-                    | Some positional ->
-                        positional.Forms
-                        |> List.map (fun form -> "--" + form, sprintf "the positional-args sink '--%s'" form)
-                )
-                @ [ "--help", "the built-in help flag" ]
+                @ (schema.Positionals
+                   |> List.collect (fun positional ->
+                       positional.Forms
+                       |> List.map (fun form -> "--" + form, sprintf "the positional-args sink '--%s'" form, true)
+                   ))
+                @ [ "--help", "the built-in help flag", false ]
 
             // Group under the scanner's own equality (OrdinalIgnoreCase), preserving
             // declaration order. This is deliberately not ToUpperInvariant keying, which is a
@@ -757,24 +899,32 @@ module internal ArgParserRuntime =
                 let indexOf =
                     System.Collections.Generic.Dictionary<string, int> (StringComparer.OrdinalIgnoreCase)
 
-                let buckets = ResizeArray<ResizeArray<string * string>> ()
+                let buckets = ResizeArray<ResizeArray<string * string * bool>> ()
 
-                for token, claimant in claims do
+                for token, claimant, isSink in claims do
                     match indexOf.TryGetValue token with
-                    | true, index -> buckets.[index].Add ((token, claimant))
+                    | true, index -> buckets.[index].Add ((token, claimant, isSink))
                     | false, _ ->
                         indexOf.[token] <- buckets.Count
                         let bucket = ResizeArray ()
-                        bucket.Add ((token, claimant))
+                        bucket.Add ((token, claimant, isSink))
                         buckets.Add bucket
 
                 buckets
                 |> Seq.choose (fun bucket ->
-                    if bucket.Count < 2 then
+                    let allSinks = bucket |> Seq.forall (fun (_, _, isSink) -> isSink)
+
+                    if bucket.Count < 2 || allSinks then
                         None
                     else
-                        let token, _ = bucket.[0]
-                        Some (SchemaError.TokenCollision (token, bucket |> Seq.map snd |> List.ofSeq))
+                        let token, _, _ = bucket.[0]
+
+                        Some (
+                            SchemaError.TokenCollision (
+                                token,
+                                bucket |> Seq.map (fun (_, claimant, _) -> claimant) |> List.ofSeq
+                            )
+                        )
                 )
                 |> List.ofSeq
 
@@ -794,27 +944,31 @@ module internal ArgParserRuntime =
                              []
                      )
                  ))
-                @ (
-                    match schema.Positional with
-                    | None -> []
-                    | Some positional ->
-                        let claimant = "the positional-args sink"
+                @ (schema.Positionals
+                   |> List.collect (fun positional ->
+                       let claimant = sprintf "positional-args sink id %i" positional.Id
 
-                        positional.Forms
-                        |> List.collect (fun form ->
-                            if form = "" then
-                                [ SchemaError.EmptyForm claimant ]
-                            elif form.Contains "=" then
-                                [ SchemaError.FormContainsEquals (claimant, form) ]
-                            else
-                                []
-                        )
-                )
+                       positional.Forms
+                       |> List.collect (fun form ->
+                           if form = "" then
+                               [ SchemaError.EmptyForm claimant ]
+                           elif form.Contains "=" then
+                               [ SchemaError.FormContainsEquals (claimant, form) ]
+                           else
+                               []
+                       )
+                   ))
 
             duplicateLeafIds
             @ repeatedInTree
             @ notInTable
             @ notInTree
+            @ duplicatePositionalIds
+            @ positionalRepeatedInTree
+            @ positionalNotInTable
+            @ positionalNotInTree
+            @ capacityExceeded
+            @ policyDisagreement
             @ duplicateSumIds
             @ noForms
             @ negationOnNonBool
@@ -956,11 +1110,11 @@ module internal ArgParserRuntime =
 
                 consume rest
             | ScanEvent.Positional (value, afterSeparator, _) ->
-                match schema.Positional with
-                | None ->
+                match schema.Positionals with
+                | [] ->
                     // No sink: the tokens are reported wholesale by validation below.
                     consume rest
-                | Some _ ->
+                | _ :: _ ->
                     match callbacks.StorePositional value afterSeparator with
                     | Some error -> errors.Add error
                     | None -> ()


### PR DESCRIPTION
Stage 3 of the positional-args-with-unions stack (3/8). Stacked on #575.

Extends the erased runtime kernel so positional sinks are nodes in the parser tree rather than a single out-of-band slot:

- `ErasedTree` gains `PositionalLeaf of positionalId : int`; `ErasedSchema`'s single `Positional option` becomes a `Positionals : ErasedPositional list` table.
- `Selection` gains `ActivePositional : int option` — which sink (if any) the winning interpretation routes positional tokens to.
- `WellFormedSchema` enforces the new structural invariants as `SchemaError`s: sink ids are unique, in both table and tree, referenced exactly once; **capacity** — no complete interpretation contains more than one positional sink (`P × Q` is malformed, `(A×P) + (B×Q)` is fine); **global flag-like policy** — because collect-vs-reject is a lexical property of scanning, every sink in a schema must agree on it.
- Named-form collision buckets are tagged with whether each claimant is a sink; buckets consisting entirely of sinks are permitted (mutually exclusive cases may share a keyed form), mixed or all-named buckets remain errors.

No behaviour change for existing generated parsers: the generator still emits at most one sink, and a one-element table with the sink at the tree root reproduces the old semantics exactly. Property tests check the new invariants agree with the Stage 2 reference model's capacity rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
