### PR TITLE
Scan positional tokens into candidate-bearing events

### DIFF
--- a/ConsumePlugin/GeneratedArgParserNegationTests.fs
+++ b/ConsumePlugin/GeneratedArgParserNegationTests.fs
@@ -146,14 +146,32 @@ module private ArgParserRuntime_BoolNegation =
         /// `--rest value`; the key text is recorded as spelled.
         | KeySpaced of key : string
 
+    /// One value belonging to the positional stream. Scanning does not decide which sink
+    /// receives it: the token's spelling determines only the *candidate* sinks, and the actual
+    /// consumer is resolved after case selection. (For today's schemas, with at most one sink,
+    /// the candidate set is that sink alone.)
+    type PositionalEvent =
+        {
+            Value : string
+            /// True for tokens which appeared after the `--` separator.
+            AfterSeparator : bool
+            /// How the value was spelled; preserved exactly, for diagnostics and lossless
+            /// reconstruction of argv.
+            Form : PositionalForm
+            /// The sinks which could consume this token: every sink for a bare token
+            /// (including everything after `--`, and flag-like tokens collected in Collect
+            /// mode), the claimants of the key for a keyed one.
+            Candidates : Set<int>
+        }
+
     /// The scan phase emits an ordered log of these; the typed layer folds over the log in order,
     /// so that e.g. conversion errors interleave with structural errors in argv order.
     [<RequireQualifiedAccess>]
     type ScanEvent =
         | Occurrence of ErasedOccurrence
-        /// A value routed to the positional sink (or to the leftover-args accumulator, for a
-        /// schema with no sink). `afterSeparator` is true for tokens which appeared after `--`.
-        | Positional of value : string * afterSeparator : bool * form : PositionalForm
+        /// A value belonging to the positional stream (or to the leftover-args accumulator,
+        /// for a schema with no sink).
+        | Positional of PositionalEvent
         | Error of ScanError
         /// A `--help`-shaped token was seen in key position; the token itself is recorded (the
         /// match is case-insensitive, so it may be e.g. "--HELP").
@@ -178,9 +196,10 @@ module private ArgParserRuntime_BoolNegation =
     type private ScanState =
         | AwaitingKey
         | AwaitingValue of leaf : (ErasedLeaf * bool) option * source : string
-        /// The positional sink's own key (`--rest`) was seen; the next token is its value,
-        /// consumed greedily (keyed positionals always take exactly one value).
-        | AwaitingPositionalValue of source : string
+        /// A positional sink's own key (`--rest`) was seen; the next token is its value,
+        /// consumed greedily (keyed positionals always take exactly one value). `candidates`
+        /// are the sinks claiming the key.
+        | AwaitingPositionalValue of candidates : Set<int> * source : string
 
     /// Match a full `--key` token (value part already split off) against the leaf table.
     /// Returns the leaf and whether the match was via the negated `--no-` form.
@@ -236,13 +255,29 @@ module private ArgParserRuntime_BoolNegation =
                     | ErasedFlagLikeBehaviour.Reject -> false
                 )
 
-        /// Does this full `--key` token (value part already split off) name a positional sink?
-        let isPositionalKey (key : string) : bool =
+        /// Every sink: the candidate set of a bare positional token.
+        let allSinks : Set<int> =
+            schema.Positionals |> List.map (fun p -> p.Id) |> Set.ofList
+
+        /// The sinks claiming this full `--key` token (value part already split off); empty
+        /// when the token does not name a positional sink at all.
+        let positionalClaimants (key : string) : Set<int> =
             schema.Positionals
-            |> List.exists (fun p ->
+            |> List.filter (fun p ->
                 p.Forms
                 |> List.exists (fun form -> String.Equals (key, "--" + form, StringComparison.OrdinalIgnoreCase))
             )
+            |> List.map (fun p -> p.Id)
+            |> Set.ofList
+
+        let bareToken (value : string) (afterSeparator : bool) : ScanEvent =
+            ScanEvent.Positional
+                {
+                    Value = value
+                    AfterSeparator = afterSeparator
+                    Form = PositionalForm.Bare
+                    Candidates = allSinks
+                }
 
         /// Resolve a pending key which will receive no value (end of input, or `--` next).
         let resolvePending (state : ScanState) : ScanEvent list =
@@ -262,22 +297,19 @@ module private ArgParserRuntime_BoolNegation =
                     ]
                 | ErasedArity.One -> [ ScanEvent.Error (ScanError.TrailingKeyNoValue source) ]
             | ScanState.AwaitingValue (None, source) -> [ ScanEvent.Error (ScanError.TrailingKeyNoValue source) ]
-            | ScanState.AwaitingPositionalValue source -> [ ScanEvent.Error (ScanError.TrailingKeyNoValue source) ]
+            | ScanState.AwaitingPositionalValue (_, source) -> [ ScanEvent.Error (ScanError.TrailingKeyNoValue source) ]
 
         let rec go (state : ScanState) (acc : ScanEvent list) (args : string list) : ScanEvent list =
             match args with
             | [] -> List.rev acc @ resolvePending state
             | "--" :: rest ->
-                let positionals =
-                    rest
-                    |> List.map (fun token -> ScanEvent.Positional (token, true, PositionalForm.Bare))
-
+                let positionals = rest |> List.map (fun token -> bareToken token true)
                 List.rev acc @ resolvePending state @ (ScanEvent.Separator :: positionals)
             | arg :: rest ->
                 match state with
                 | ScanState.AwaitingKey ->
                     if not (arg.StartsWith ("--", StringComparison.Ordinal)) then
-                        go ScanState.AwaitingKey (ScanEvent.Positional (arg, false, PositionalForm.Bare) :: acc) rest
+                        go ScanState.AwaitingKey (bareToken arg false :: acc) rest
                     elif String.Equals (arg, "--help", StringComparison.OrdinalIgnoreCase) then
                         go ScanState.AwaitingKey (ScanEvent.Help arg :: acc) rest
                     else
@@ -299,16 +331,21 @@ module private ArgParserRuntime_BoolNegation =
 
                                 go ScanState.AwaitingKey (ScanEvent.Occurrence occurrence :: acc) rest
                             | None ->
-                                if isPositionalKey key then
-                                    go
-                                        ScanState.AwaitingKey
-                                        (ScanEvent.Positional (value, false, PositionalForm.KeyEquals key) :: acc)
-                                        rest
+                                let claimants = positionalClaimants key
+
+                                if not (Set.isEmpty claimants) then
+                                    let event =
+                                        ScanEvent.Positional
+                                            {
+                                                Value = value
+                                                AfterSeparator = false
+                                                Form = PositionalForm.KeyEquals key
+                                                Candidates = claimants
+                                            }
+
+                                    go ScanState.AwaitingKey (event :: acc) rest
                                 elif collectFlagLike then
-                                    go
-                                        ScanState.AwaitingKey
-                                        (ScanEvent.Positional (arg, false, PositionalForm.Bare) :: acc)
-                                        rest
+                                    go ScanState.AwaitingKey (bareToken arg false :: acc) rest
                                 else
                                     go
                                         ScanState.AwaitingKey
@@ -318,8 +355,10 @@ module private ArgParserRuntime_BoolNegation =
                             match matchLeaf schema.Leaves arg with
                             | Some matched -> go (ScanState.AwaitingValue (Some matched, arg)) acc rest
                             | None ->
-                                if isPositionalKey arg then
-                                    go (ScanState.AwaitingPositionalValue arg) acc rest
+                                let claimants = positionalClaimants arg
+
+                                if not (Set.isEmpty claimants) then
+                                    go (ScanState.AwaitingPositionalValue (claimants, arg)) acc rest
                                 else
                                     go (ScanState.AwaitingValue (None, arg)) acc rest
                 | ScanState.AwaitingValue (Some (leaf, negated), source) ->
@@ -349,17 +388,20 @@ module private ArgParserRuntime_BoolNegation =
                             go ScanState.AwaitingKey (ScanEvent.Occurrence occurrence :: acc) (arg :: rest)
                 | ScanState.AwaitingValue (None, source) ->
                     if collectFlagLike then
-                        go
-                            ScanState.AwaitingKey
-                            (ScanEvent.Positional (source, false, PositionalForm.Bare) :: acc)
-                            (arg :: rest)
+                        go ScanState.AwaitingKey (bareToken source false :: acc) (arg :: rest)
                     else
                         go ScanState.AwaitingKey (ScanEvent.Error (ScanError.UnknownKey source) :: acc) (arg :: rest)
-                | ScanState.AwaitingPositionalValue source ->
-                    go
-                        ScanState.AwaitingKey
-                        (ScanEvent.Positional (arg, false, PositionalForm.KeySpaced source) :: acc)
-                        rest
+                | ScanState.AwaitingPositionalValue (candidates, source) ->
+                    let event =
+                        ScanEvent.Positional
+                            {
+                                Value = arg
+                                AfterSeparator = false
+                                Form = PositionalForm.KeySpaced source
+                                Candidates = candidates
+                            }
+
+                    go ScanState.AwaitingKey (event :: acc) rest
 
         go ScanState.AwaitingKey [] args
 
@@ -594,7 +636,7 @@ module private ArgParserRuntime_BoolNegation =
                     events
                     |> List.choose (fun event ->
                         match event with
-                        | ScanEvent.Positional (value, _, _) -> Some value
+                        | ScanEvent.Positional positional -> Some positional.Value
                         | _ -> None
                     )
 
@@ -1083,11 +1125,11 @@ module private ArgParserRuntime_BoolNegation =
                         | None -> stored.Add occurrence.LeafId |> ignore<bool>
 
                     consume rest
-                | ScanEvent.Positional (value, afterSeparator, _) ->
+                | ScanEvent.Positional positional ->
                     match schema.Positionals with
                     | [] -> consume rest
                     | _ :: _ ->
-                        match callbacks.StorePositional value afterSeparator with
+                        match callbacks.StorePositional positional.Value positional.AfterSeparator with
                         | Some error -> errors.Add error
                         | None -> ()
 

--- a/ConsumePlugin/GeneratedArgs.fs
+++ b/ConsumePlugin/GeneratedArgs.fs
@@ -146,14 +146,32 @@ module private ArgParserRuntime_BasicNoPositionals =
         /// `--rest value`; the key text is recorded as spelled.
         | KeySpaced of key : string
 
+    /// One value belonging to the positional stream. Scanning does not decide which sink
+    /// receives it: the token's spelling determines only the *candidate* sinks, and the actual
+    /// consumer is resolved after case selection. (For today's schemas, with at most one sink,
+    /// the candidate set is that sink alone.)
+    type PositionalEvent =
+        {
+            Value : string
+            /// True for tokens which appeared after the `--` separator.
+            AfterSeparator : bool
+            /// How the value was spelled; preserved exactly, for diagnostics and lossless
+            /// reconstruction of argv.
+            Form : PositionalForm
+            /// The sinks which could consume this token: every sink for a bare token
+            /// (including everything after `--`, and flag-like tokens collected in Collect
+            /// mode), the claimants of the key for a keyed one.
+            Candidates : Set<int>
+        }
+
     /// The scan phase emits an ordered log of these; the typed layer folds over the log in order,
     /// so that e.g. conversion errors interleave with structural errors in argv order.
     [<RequireQualifiedAccess>]
     type ScanEvent =
         | Occurrence of ErasedOccurrence
-        /// A value routed to the positional sink (or to the leftover-args accumulator, for a
-        /// schema with no sink). `afterSeparator` is true for tokens which appeared after `--`.
-        | Positional of value : string * afterSeparator : bool * form : PositionalForm
+        /// A value belonging to the positional stream (or to the leftover-args accumulator,
+        /// for a schema with no sink).
+        | Positional of PositionalEvent
         | Error of ScanError
         /// A `--help`-shaped token was seen in key position; the token itself is recorded (the
         /// match is case-insensitive, so it may be e.g. "--HELP").
@@ -178,9 +196,10 @@ module private ArgParserRuntime_BasicNoPositionals =
     type private ScanState =
         | AwaitingKey
         | AwaitingValue of leaf : (ErasedLeaf * bool) option * source : string
-        /// The positional sink's own key (`--rest`) was seen; the next token is its value,
-        /// consumed greedily (keyed positionals always take exactly one value).
-        | AwaitingPositionalValue of source : string
+        /// A positional sink's own key (`--rest`) was seen; the next token is its value,
+        /// consumed greedily (keyed positionals always take exactly one value). `candidates`
+        /// are the sinks claiming the key.
+        | AwaitingPositionalValue of candidates : Set<int> * source : string
 
     /// Match a full `--key` token (value part already split off) against the leaf table.
     /// Returns the leaf and whether the match was via the negated `--no-` form.
@@ -236,13 +255,29 @@ module private ArgParserRuntime_BasicNoPositionals =
                     | ErasedFlagLikeBehaviour.Reject -> false
                 )
 
-        /// Does this full `--key` token (value part already split off) name a positional sink?
-        let isPositionalKey (key : string) : bool =
+        /// Every sink: the candidate set of a bare positional token.
+        let allSinks : Set<int> =
+            schema.Positionals |> List.map (fun p -> p.Id) |> Set.ofList
+
+        /// The sinks claiming this full `--key` token (value part already split off); empty
+        /// when the token does not name a positional sink at all.
+        let positionalClaimants (key : string) : Set<int> =
             schema.Positionals
-            |> List.exists (fun p ->
+            |> List.filter (fun p ->
                 p.Forms
                 |> List.exists (fun form -> String.Equals (key, "--" + form, StringComparison.OrdinalIgnoreCase))
             )
+            |> List.map (fun p -> p.Id)
+            |> Set.ofList
+
+        let bareToken (value : string) (afterSeparator : bool) : ScanEvent =
+            ScanEvent.Positional
+                {
+                    Value = value
+                    AfterSeparator = afterSeparator
+                    Form = PositionalForm.Bare
+                    Candidates = allSinks
+                }
 
         /// Resolve a pending key which will receive no value (end of input, or `--` next).
         let resolvePending (state : ScanState) : ScanEvent list =
@@ -262,22 +297,19 @@ module private ArgParserRuntime_BasicNoPositionals =
                     ]
                 | ErasedArity.One -> [ ScanEvent.Error (ScanError.TrailingKeyNoValue source) ]
             | ScanState.AwaitingValue (None, source) -> [ ScanEvent.Error (ScanError.TrailingKeyNoValue source) ]
-            | ScanState.AwaitingPositionalValue source -> [ ScanEvent.Error (ScanError.TrailingKeyNoValue source) ]
+            | ScanState.AwaitingPositionalValue (_, source) -> [ ScanEvent.Error (ScanError.TrailingKeyNoValue source) ]
 
         let rec go (state : ScanState) (acc : ScanEvent list) (args : string list) : ScanEvent list =
             match args with
             | [] -> List.rev acc @ resolvePending state
             | "--" :: rest ->
-                let positionals =
-                    rest
-                    |> List.map (fun token -> ScanEvent.Positional (token, true, PositionalForm.Bare))
-
+                let positionals = rest |> List.map (fun token -> bareToken token true)
                 List.rev acc @ resolvePending state @ (ScanEvent.Separator :: positionals)
             | arg :: rest ->
                 match state with
                 | ScanState.AwaitingKey ->
                     if not (arg.StartsWith ("--", StringComparison.Ordinal)) then
-                        go ScanState.AwaitingKey (ScanEvent.Positional (arg, false, PositionalForm.Bare) :: acc) rest
+                        go ScanState.AwaitingKey (bareToken arg false :: acc) rest
                     elif String.Equals (arg, "--help", StringComparison.OrdinalIgnoreCase) then
                         go ScanState.AwaitingKey (ScanEvent.Help arg :: acc) rest
                     else
@@ -299,16 +331,21 @@ module private ArgParserRuntime_BasicNoPositionals =
 
                                 go ScanState.AwaitingKey (ScanEvent.Occurrence occurrence :: acc) rest
                             | None ->
-                                if isPositionalKey key then
-                                    go
-                                        ScanState.AwaitingKey
-                                        (ScanEvent.Positional (value, false, PositionalForm.KeyEquals key) :: acc)
-                                        rest
+                                let claimants = positionalClaimants key
+
+                                if not (Set.isEmpty claimants) then
+                                    let event =
+                                        ScanEvent.Positional
+                                            {
+                                                Value = value
+                                                AfterSeparator = false
+                                                Form = PositionalForm.KeyEquals key
+                                                Candidates = claimants
+                                            }
+
+                                    go ScanState.AwaitingKey (event :: acc) rest
                                 elif collectFlagLike then
-                                    go
-                                        ScanState.AwaitingKey
-                                        (ScanEvent.Positional (arg, false, PositionalForm.Bare) :: acc)
-                                        rest
+                                    go ScanState.AwaitingKey (bareToken arg false :: acc) rest
                                 else
                                     go
                                         ScanState.AwaitingKey
@@ -318,8 +355,10 @@ module private ArgParserRuntime_BasicNoPositionals =
                             match matchLeaf schema.Leaves arg with
                             | Some matched -> go (ScanState.AwaitingValue (Some matched, arg)) acc rest
                             | None ->
-                                if isPositionalKey arg then
-                                    go (ScanState.AwaitingPositionalValue arg) acc rest
+                                let claimants = positionalClaimants arg
+
+                                if not (Set.isEmpty claimants) then
+                                    go (ScanState.AwaitingPositionalValue (claimants, arg)) acc rest
                                 else
                                     go (ScanState.AwaitingValue (None, arg)) acc rest
                 | ScanState.AwaitingValue (Some (leaf, negated), source) ->
@@ -349,17 +388,20 @@ module private ArgParserRuntime_BasicNoPositionals =
                             go ScanState.AwaitingKey (ScanEvent.Occurrence occurrence :: acc) (arg :: rest)
                 | ScanState.AwaitingValue (None, source) ->
                     if collectFlagLike then
-                        go
-                            ScanState.AwaitingKey
-                            (ScanEvent.Positional (source, false, PositionalForm.Bare) :: acc)
-                            (arg :: rest)
+                        go ScanState.AwaitingKey (bareToken source false :: acc) (arg :: rest)
                     else
                         go ScanState.AwaitingKey (ScanEvent.Error (ScanError.UnknownKey source) :: acc) (arg :: rest)
-                | ScanState.AwaitingPositionalValue source ->
-                    go
-                        ScanState.AwaitingKey
-                        (ScanEvent.Positional (arg, false, PositionalForm.KeySpaced source) :: acc)
-                        rest
+                | ScanState.AwaitingPositionalValue (candidates, source) ->
+                    let event =
+                        ScanEvent.Positional
+                            {
+                                Value = arg
+                                AfterSeparator = false
+                                Form = PositionalForm.KeySpaced source
+                                Candidates = candidates
+                            }
+
+                    go ScanState.AwaitingKey (event :: acc) rest
 
         go ScanState.AwaitingKey [] args
 
@@ -594,7 +636,7 @@ module private ArgParserRuntime_BasicNoPositionals =
                     events
                     |> List.choose (fun event ->
                         match event with
-                        | ScanEvent.Positional (value, _, _) -> Some value
+                        | ScanEvent.Positional positional -> Some positional.Value
                         | _ -> None
                     )
 
@@ -1083,11 +1125,11 @@ module private ArgParserRuntime_BasicNoPositionals =
                         | None -> stored.Add occurrence.LeafId |> ignore<bool>
 
                     consume rest
-                | ScanEvent.Positional (value, afterSeparator, _) ->
+                | ScanEvent.Positional positional ->
                     match schema.Positionals with
                     | [] -> consume rest
                     | _ :: _ ->
-                        match callbacks.StorePositional value afterSeparator with
+                        match callbacks.StorePositional positional.Value positional.AfterSeparator with
                         | Some error -> errors.Add error
                         | None -> ()
 

--- a/ConsumePlugin/GeneratedDuArgs.fs
+++ b/ConsumePlugin/GeneratedDuArgs.fs
@@ -146,14 +146,32 @@ module private ArgParserRuntime_DuArgs =
         /// `--rest value`; the key text is recorded as spelled.
         | KeySpaced of key : string
 
+    /// One value belonging to the positional stream. Scanning does not decide which sink
+    /// receives it: the token's spelling determines only the *candidate* sinks, and the actual
+    /// consumer is resolved after case selection. (For today's schemas, with at most one sink,
+    /// the candidate set is that sink alone.)
+    type PositionalEvent =
+        {
+            Value : string
+            /// True for tokens which appeared after the `--` separator.
+            AfterSeparator : bool
+            /// How the value was spelled; preserved exactly, for diagnostics and lossless
+            /// reconstruction of argv.
+            Form : PositionalForm
+            /// The sinks which could consume this token: every sink for a bare token
+            /// (including everything after `--`, and flag-like tokens collected in Collect
+            /// mode), the claimants of the key for a keyed one.
+            Candidates : Set<int>
+        }
+
     /// The scan phase emits an ordered log of these; the typed layer folds over the log in order,
     /// so that e.g. conversion errors interleave with structural errors in argv order.
     [<RequireQualifiedAccess>]
     type ScanEvent =
         | Occurrence of ErasedOccurrence
-        /// A value routed to the positional sink (or to the leftover-args accumulator, for a
-        /// schema with no sink). `afterSeparator` is true for tokens which appeared after `--`.
-        | Positional of value : string * afterSeparator : bool * form : PositionalForm
+        /// A value belonging to the positional stream (or to the leftover-args accumulator,
+        /// for a schema with no sink).
+        | Positional of PositionalEvent
         | Error of ScanError
         /// A `--help`-shaped token was seen in key position; the token itself is recorded (the
         /// match is case-insensitive, so it may be e.g. "--HELP").
@@ -178,9 +196,10 @@ module private ArgParserRuntime_DuArgs =
     type private ScanState =
         | AwaitingKey
         | AwaitingValue of leaf : (ErasedLeaf * bool) option * source : string
-        /// The positional sink's own key (`--rest`) was seen; the next token is its value,
-        /// consumed greedily (keyed positionals always take exactly one value).
-        | AwaitingPositionalValue of source : string
+        /// A positional sink's own key (`--rest`) was seen; the next token is its value,
+        /// consumed greedily (keyed positionals always take exactly one value). `candidates`
+        /// are the sinks claiming the key.
+        | AwaitingPositionalValue of candidates : Set<int> * source : string
 
     /// Match a full `--key` token (value part already split off) against the leaf table.
     /// Returns the leaf and whether the match was via the negated `--no-` form.
@@ -236,13 +255,29 @@ module private ArgParserRuntime_DuArgs =
                     | ErasedFlagLikeBehaviour.Reject -> false
                 )
 
-        /// Does this full `--key` token (value part already split off) name a positional sink?
-        let isPositionalKey (key : string) : bool =
+        /// Every sink: the candidate set of a bare positional token.
+        let allSinks : Set<int> =
+            schema.Positionals |> List.map (fun p -> p.Id) |> Set.ofList
+
+        /// The sinks claiming this full `--key` token (value part already split off); empty
+        /// when the token does not name a positional sink at all.
+        let positionalClaimants (key : string) : Set<int> =
             schema.Positionals
-            |> List.exists (fun p ->
+            |> List.filter (fun p ->
                 p.Forms
                 |> List.exists (fun form -> String.Equals (key, "--" + form, StringComparison.OrdinalIgnoreCase))
             )
+            |> List.map (fun p -> p.Id)
+            |> Set.ofList
+
+        let bareToken (value : string) (afterSeparator : bool) : ScanEvent =
+            ScanEvent.Positional
+                {
+                    Value = value
+                    AfterSeparator = afterSeparator
+                    Form = PositionalForm.Bare
+                    Candidates = allSinks
+                }
 
         /// Resolve a pending key which will receive no value (end of input, or `--` next).
         let resolvePending (state : ScanState) : ScanEvent list =
@@ -262,22 +297,19 @@ module private ArgParserRuntime_DuArgs =
                     ]
                 | ErasedArity.One -> [ ScanEvent.Error (ScanError.TrailingKeyNoValue source) ]
             | ScanState.AwaitingValue (None, source) -> [ ScanEvent.Error (ScanError.TrailingKeyNoValue source) ]
-            | ScanState.AwaitingPositionalValue source -> [ ScanEvent.Error (ScanError.TrailingKeyNoValue source) ]
+            | ScanState.AwaitingPositionalValue (_, source) -> [ ScanEvent.Error (ScanError.TrailingKeyNoValue source) ]
 
         let rec go (state : ScanState) (acc : ScanEvent list) (args : string list) : ScanEvent list =
             match args with
             | [] -> List.rev acc @ resolvePending state
             | "--" :: rest ->
-                let positionals =
-                    rest
-                    |> List.map (fun token -> ScanEvent.Positional (token, true, PositionalForm.Bare))
-
+                let positionals = rest |> List.map (fun token -> bareToken token true)
                 List.rev acc @ resolvePending state @ (ScanEvent.Separator :: positionals)
             | arg :: rest ->
                 match state with
                 | ScanState.AwaitingKey ->
                     if not (arg.StartsWith ("--", StringComparison.Ordinal)) then
-                        go ScanState.AwaitingKey (ScanEvent.Positional (arg, false, PositionalForm.Bare) :: acc) rest
+                        go ScanState.AwaitingKey (bareToken arg false :: acc) rest
                     elif String.Equals (arg, "--help", StringComparison.OrdinalIgnoreCase) then
                         go ScanState.AwaitingKey (ScanEvent.Help arg :: acc) rest
                     else
@@ -299,16 +331,21 @@ module private ArgParserRuntime_DuArgs =
 
                                 go ScanState.AwaitingKey (ScanEvent.Occurrence occurrence :: acc) rest
                             | None ->
-                                if isPositionalKey key then
-                                    go
-                                        ScanState.AwaitingKey
-                                        (ScanEvent.Positional (value, false, PositionalForm.KeyEquals key) :: acc)
-                                        rest
+                                let claimants = positionalClaimants key
+
+                                if not (Set.isEmpty claimants) then
+                                    let event =
+                                        ScanEvent.Positional
+                                            {
+                                                Value = value
+                                                AfterSeparator = false
+                                                Form = PositionalForm.KeyEquals key
+                                                Candidates = claimants
+                                            }
+
+                                    go ScanState.AwaitingKey (event :: acc) rest
                                 elif collectFlagLike then
-                                    go
-                                        ScanState.AwaitingKey
-                                        (ScanEvent.Positional (arg, false, PositionalForm.Bare) :: acc)
-                                        rest
+                                    go ScanState.AwaitingKey (bareToken arg false :: acc) rest
                                 else
                                     go
                                         ScanState.AwaitingKey
@@ -318,8 +355,10 @@ module private ArgParserRuntime_DuArgs =
                             match matchLeaf schema.Leaves arg with
                             | Some matched -> go (ScanState.AwaitingValue (Some matched, arg)) acc rest
                             | None ->
-                                if isPositionalKey arg then
-                                    go (ScanState.AwaitingPositionalValue arg) acc rest
+                                let claimants = positionalClaimants arg
+
+                                if not (Set.isEmpty claimants) then
+                                    go (ScanState.AwaitingPositionalValue (claimants, arg)) acc rest
                                 else
                                     go (ScanState.AwaitingValue (None, arg)) acc rest
                 | ScanState.AwaitingValue (Some (leaf, negated), source) ->
@@ -349,17 +388,20 @@ module private ArgParserRuntime_DuArgs =
                             go ScanState.AwaitingKey (ScanEvent.Occurrence occurrence :: acc) (arg :: rest)
                 | ScanState.AwaitingValue (None, source) ->
                     if collectFlagLike then
-                        go
-                            ScanState.AwaitingKey
-                            (ScanEvent.Positional (source, false, PositionalForm.Bare) :: acc)
-                            (arg :: rest)
+                        go ScanState.AwaitingKey (bareToken source false :: acc) (arg :: rest)
                     else
                         go ScanState.AwaitingKey (ScanEvent.Error (ScanError.UnknownKey source) :: acc) (arg :: rest)
-                | ScanState.AwaitingPositionalValue source ->
-                    go
-                        ScanState.AwaitingKey
-                        (ScanEvent.Positional (arg, false, PositionalForm.KeySpaced source) :: acc)
-                        rest
+                | ScanState.AwaitingPositionalValue (candidates, source) ->
+                    let event =
+                        ScanEvent.Positional
+                            {
+                                Value = arg
+                                AfterSeparator = false
+                                Form = PositionalForm.KeySpaced source
+                                Candidates = candidates
+                            }
+
+                    go ScanState.AwaitingKey (event :: acc) rest
 
         go ScanState.AwaitingKey [] args
 
@@ -594,7 +636,7 @@ module private ArgParserRuntime_DuArgs =
                     events
                     |> List.choose (fun event ->
                         match event with
-                        | ScanEvent.Positional (value, _, _) -> Some value
+                        | ScanEvent.Positional positional -> Some positional.Value
                         | _ -> None
                     )
 
@@ -1083,11 +1125,11 @@ module private ArgParserRuntime_DuArgs =
                         | None -> stored.Add occurrence.LeafId |> ignore<bool>
 
                     consume rest
-                | ScanEvent.Positional (value, afterSeparator, _) ->
+                | ScanEvent.Positional positional ->
                     match schema.Positionals with
                     | [] -> consume rest
                     | _ :: _ ->
-                        match callbacks.StorePositional value afterSeparator with
+                        match callbacks.StorePositional positional.Value positional.AfterSeparator with
                         | Some error -> errors.Add error
                         | None -> ()
 

--- a/ConsumePlugin/GeneratedOpensLeakRegression.fs
+++ b/ConsumePlugin/GeneratedOpensLeakRegression.fs
@@ -146,14 +146,32 @@ module private ArgParserRuntime_LeakArgs =
         /// `--rest value`; the key text is recorded as spelled.
         | KeySpaced of key : string
 
+    /// One value belonging to the positional stream. Scanning does not decide which sink
+    /// receives it: the token's spelling determines only the *candidate* sinks, and the actual
+    /// consumer is resolved after case selection. (For today's schemas, with at most one sink,
+    /// the candidate set is that sink alone.)
+    type PositionalEvent =
+        {
+            Value : string
+            /// True for tokens which appeared after the `--` separator.
+            AfterSeparator : bool
+            /// How the value was spelled; preserved exactly, for diagnostics and lossless
+            /// reconstruction of argv.
+            Form : PositionalForm
+            /// The sinks which could consume this token: every sink for a bare token
+            /// (including everything after `--`, and flag-like tokens collected in Collect
+            /// mode), the claimants of the key for a keyed one.
+            Candidates : Set<int>
+        }
+
     /// The scan phase emits an ordered log of these; the typed layer folds over the log in order,
     /// so that e.g. conversion errors interleave with structural errors in argv order.
     [<RequireQualifiedAccess>]
     type ScanEvent =
         | Occurrence of ErasedOccurrence
-        /// A value routed to the positional sink (or to the leftover-args accumulator, for a
-        /// schema with no sink). `afterSeparator` is true for tokens which appeared after `--`.
-        | Positional of value : string * afterSeparator : bool * form : PositionalForm
+        /// A value belonging to the positional stream (or to the leftover-args accumulator,
+        /// for a schema with no sink).
+        | Positional of PositionalEvent
         | Error of ScanError
         /// A `--help`-shaped token was seen in key position; the token itself is recorded (the
         /// match is case-insensitive, so it may be e.g. "--HELP").
@@ -178,9 +196,10 @@ module private ArgParserRuntime_LeakArgs =
     type private ScanState =
         | AwaitingKey
         | AwaitingValue of leaf : (ErasedLeaf * bool) option * source : string
-        /// The positional sink's own key (`--rest`) was seen; the next token is its value,
-        /// consumed greedily (keyed positionals always take exactly one value).
-        | AwaitingPositionalValue of source : string
+        /// A positional sink's own key (`--rest`) was seen; the next token is its value,
+        /// consumed greedily (keyed positionals always take exactly one value). `candidates`
+        /// are the sinks claiming the key.
+        | AwaitingPositionalValue of candidates : Set<int> * source : string
 
     /// Match a full `--key` token (value part already split off) against the leaf table.
     /// Returns the leaf and whether the match was via the negated `--no-` form.
@@ -236,13 +255,29 @@ module private ArgParserRuntime_LeakArgs =
                     | ErasedFlagLikeBehaviour.Reject -> false
                 )
 
-        /// Does this full `--key` token (value part already split off) name a positional sink?
-        let isPositionalKey (key : string) : bool =
+        /// Every sink: the candidate set of a bare positional token.
+        let allSinks : Set<int> =
+            schema.Positionals |> List.map (fun p -> p.Id) |> Set.ofList
+
+        /// The sinks claiming this full `--key` token (value part already split off); empty
+        /// when the token does not name a positional sink at all.
+        let positionalClaimants (key : string) : Set<int> =
             schema.Positionals
-            |> List.exists (fun p ->
+            |> List.filter (fun p ->
                 p.Forms
                 |> List.exists (fun form -> String.Equals (key, "--" + form, StringComparison.OrdinalIgnoreCase))
             )
+            |> List.map (fun p -> p.Id)
+            |> Set.ofList
+
+        let bareToken (value : string) (afterSeparator : bool) : ScanEvent =
+            ScanEvent.Positional
+                {
+                    Value = value
+                    AfterSeparator = afterSeparator
+                    Form = PositionalForm.Bare
+                    Candidates = allSinks
+                }
 
         /// Resolve a pending key which will receive no value (end of input, or `--` next).
         let resolvePending (state : ScanState) : ScanEvent list =
@@ -262,22 +297,19 @@ module private ArgParserRuntime_LeakArgs =
                     ]
                 | ErasedArity.One -> [ ScanEvent.Error (ScanError.TrailingKeyNoValue source) ]
             | ScanState.AwaitingValue (None, source) -> [ ScanEvent.Error (ScanError.TrailingKeyNoValue source) ]
-            | ScanState.AwaitingPositionalValue source -> [ ScanEvent.Error (ScanError.TrailingKeyNoValue source) ]
+            | ScanState.AwaitingPositionalValue (_, source) -> [ ScanEvent.Error (ScanError.TrailingKeyNoValue source) ]
 
         let rec go (state : ScanState) (acc : ScanEvent list) (args : string list) : ScanEvent list =
             match args with
             | [] -> List.rev acc @ resolvePending state
             | "--" :: rest ->
-                let positionals =
-                    rest
-                    |> List.map (fun token -> ScanEvent.Positional (token, true, PositionalForm.Bare))
-
+                let positionals = rest |> List.map (fun token -> bareToken token true)
                 List.rev acc @ resolvePending state @ (ScanEvent.Separator :: positionals)
             | arg :: rest ->
                 match state with
                 | ScanState.AwaitingKey ->
                     if not (arg.StartsWith ("--", StringComparison.Ordinal)) then
-                        go ScanState.AwaitingKey (ScanEvent.Positional (arg, false, PositionalForm.Bare) :: acc) rest
+                        go ScanState.AwaitingKey (bareToken arg false :: acc) rest
                     elif String.Equals (arg, "--help", StringComparison.OrdinalIgnoreCase) then
                         go ScanState.AwaitingKey (ScanEvent.Help arg :: acc) rest
                     else
@@ -299,16 +331,21 @@ module private ArgParserRuntime_LeakArgs =
 
                                 go ScanState.AwaitingKey (ScanEvent.Occurrence occurrence :: acc) rest
                             | None ->
-                                if isPositionalKey key then
-                                    go
-                                        ScanState.AwaitingKey
-                                        (ScanEvent.Positional (value, false, PositionalForm.KeyEquals key) :: acc)
-                                        rest
+                                let claimants = positionalClaimants key
+
+                                if not (Set.isEmpty claimants) then
+                                    let event =
+                                        ScanEvent.Positional
+                                            {
+                                                Value = value
+                                                AfterSeparator = false
+                                                Form = PositionalForm.KeyEquals key
+                                                Candidates = claimants
+                                            }
+
+                                    go ScanState.AwaitingKey (event :: acc) rest
                                 elif collectFlagLike then
-                                    go
-                                        ScanState.AwaitingKey
-                                        (ScanEvent.Positional (arg, false, PositionalForm.Bare) :: acc)
-                                        rest
+                                    go ScanState.AwaitingKey (bareToken arg false :: acc) rest
                                 else
                                     go
                                         ScanState.AwaitingKey
@@ -318,8 +355,10 @@ module private ArgParserRuntime_LeakArgs =
                             match matchLeaf schema.Leaves arg with
                             | Some matched -> go (ScanState.AwaitingValue (Some matched, arg)) acc rest
                             | None ->
-                                if isPositionalKey arg then
-                                    go (ScanState.AwaitingPositionalValue arg) acc rest
+                                let claimants = positionalClaimants arg
+
+                                if not (Set.isEmpty claimants) then
+                                    go (ScanState.AwaitingPositionalValue (claimants, arg)) acc rest
                                 else
                                     go (ScanState.AwaitingValue (None, arg)) acc rest
                 | ScanState.AwaitingValue (Some (leaf, negated), source) ->
@@ -349,17 +388,20 @@ module private ArgParserRuntime_LeakArgs =
                             go ScanState.AwaitingKey (ScanEvent.Occurrence occurrence :: acc) (arg :: rest)
                 | ScanState.AwaitingValue (None, source) ->
                     if collectFlagLike then
-                        go
-                            ScanState.AwaitingKey
-                            (ScanEvent.Positional (source, false, PositionalForm.Bare) :: acc)
-                            (arg :: rest)
+                        go ScanState.AwaitingKey (bareToken source false :: acc) (arg :: rest)
                     else
                         go ScanState.AwaitingKey (ScanEvent.Error (ScanError.UnknownKey source) :: acc) (arg :: rest)
-                | ScanState.AwaitingPositionalValue source ->
-                    go
-                        ScanState.AwaitingKey
-                        (ScanEvent.Positional (arg, false, PositionalForm.KeySpaced source) :: acc)
-                        rest
+                | ScanState.AwaitingPositionalValue (candidates, source) ->
+                    let event =
+                        ScanEvent.Positional
+                            {
+                                Value = arg
+                                AfterSeparator = false
+                                Form = PositionalForm.KeySpaced source
+                                Candidates = candidates
+                            }
+
+                    go ScanState.AwaitingKey (event :: acc) rest
 
         go ScanState.AwaitingKey [] args
 
@@ -594,7 +636,7 @@ module private ArgParserRuntime_LeakArgs =
                     events
                     |> List.choose (fun event ->
                         match event with
-                        | ScanEvent.Positional (value, _, _) -> Some value
+                        | ScanEvent.Positional positional -> Some positional.Value
                         | _ -> None
                     )
 
@@ -1083,11 +1125,11 @@ module private ArgParserRuntime_LeakArgs =
                         | None -> stored.Add occurrence.LeafId |> ignore<bool>
 
                     consume rest
-                | ScanEvent.Positional (value, afterSeparator, _) ->
+                | ScanEvent.Positional positional ->
                     match schema.Positionals with
                     | [] -> consume rest
                     | _ :: _ ->
-                        match callbacks.StorePositional value afterSeparator with
+                        match callbacks.StorePositional positional.Value positional.AfterSeparator with
                         | Some error -> errors.Add error
                         | None -> ()
 

--- a/ConsumePlugin/Nested/GeneratedArgs.fs
+++ b/ConsumePlugin/Nested/GeneratedArgs.fs
@@ -146,14 +146,32 @@ module private ArgParserRuntime_SameBaseNameArgs =
         /// `--rest value`; the key text is recorded as spelled.
         | KeySpaced of key : string
 
+    /// One value belonging to the positional stream. Scanning does not decide which sink
+    /// receives it: the token's spelling determines only the *candidate* sinks, and the actual
+    /// consumer is resolved after case selection. (For today's schemas, with at most one sink,
+    /// the candidate set is that sink alone.)
+    type PositionalEvent =
+        {
+            Value : string
+            /// True for tokens which appeared after the `--` separator.
+            AfterSeparator : bool
+            /// How the value was spelled; preserved exactly, for diagnostics and lossless
+            /// reconstruction of argv.
+            Form : PositionalForm
+            /// The sinks which could consume this token: every sink for a bare token
+            /// (including everything after `--`, and flag-like tokens collected in Collect
+            /// mode), the claimants of the key for a keyed one.
+            Candidates : Set<int>
+        }
+
     /// The scan phase emits an ordered log of these; the typed layer folds over the log in order,
     /// so that e.g. conversion errors interleave with structural errors in argv order.
     [<RequireQualifiedAccess>]
     type ScanEvent =
         | Occurrence of ErasedOccurrence
-        /// A value routed to the positional sink (or to the leftover-args accumulator, for a
-        /// schema with no sink). `afterSeparator` is true for tokens which appeared after `--`.
-        | Positional of value : string * afterSeparator : bool * form : PositionalForm
+        /// A value belonging to the positional stream (or to the leftover-args accumulator,
+        /// for a schema with no sink).
+        | Positional of PositionalEvent
         | Error of ScanError
         /// A `--help`-shaped token was seen in key position; the token itself is recorded (the
         /// match is case-insensitive, so it may be e.g. "--HELP").
@@ -178,9 +196,10 @@ module private ArgParserRuntime_SameBaseNameArgs =
     type private ScanState =
         | AwaitingKey
         | AwaitingValue of leaf : (ErasedLeaf * bool) option * source : string
-        /// The positional sink's own key (`--rest`) was seen; the next token is its value,
-        /// consumed greedily (keyed positionals always take exactly one value).
-        | AwaitingPositionalValue of source : string
+        /// A positional sink's own key (`--rest`) was seen; the next token is its value,
+        /// consumed greedily (keyed positionals always take exactly one value). `candidates`
+        /// are the sinks claiming the key.
+        | AwaitingPositionalValue of candidates : Set<int> * source : string
 
     /// Match a full `--key` token (value part already split off) against the leaf table.
     /// Returns the leaf and whether the match was via the negated `--no-` form.
@@ -236,13 +255,29 @@ module private ArgParserRuntime_SameBaseNameArgs =
                     | ErasedFlagLikeBehaviour.Reject -> false
                 )
 
-        /// Does this full `--key` token (value part already split off) name a positional sink?
-        let isPositionalKey (key : string) : bool =
+        /// Every sink: the candidate set of a bare positional token.
+        let allSinks : Set<int> =
+            schema.Positionals |> List.map (fun p -> p.Id) |> Set.ofList
+
+        /// The sinks claiming this full `--key` token (value part already split off); empty
+        /// when the token does not name a positional sink at all.
+        let positionalClaimants (key : string) : Set<int> =
             schema.Positionals
-            |> List.exists (fun p ->
+            |> List.filter (fun p ->
                 p.Forms
                 |> List.exists (fun form -> String.Equals (key, "--" + form, StringComparison.OrdinalIgnoreCase))
             )
+            |> List.map (fun p -> p.Id)
+            |> Set.ofList
+
+        let bareToken (value : string) (afterSeparator : bool) : ScanEvent =
+            ScanEvent.Positional
+                {
+                    Value = value
+                    AfterSeparator = afterSeparator
+                    Form = PositionalForm.Bare
+                    Candidates = allSinks
+                }
 
         /// Resolve a pending key which will receive no value (end of input, or `--` next).
         let resolvePending (state : ScanState) : ScanEvent list =
@@ -262,22 +297,19 @@ module private ArgParserRuntime_SameBaseNameArgs =
                     ]
                 | ErasedArity.One -> [ ScanEvent.Error (ScanError.TrailingKeyNoValue source) ]
             | ScanState.AwaitingValue (None, source) -> [ ScanEvent.Error (ScanError.TrailingKeyNoValue source) ]
-            | ScanState.AwaitingPositionalValue source -> [ ScanEvent.Error (ScanError.TrailingKeyNoValue source) ]
+            | ScanState.AwaitingPositionalValue (_, source) -> [ ScanEvent.Error (ScanError.TrailingKeyNoValue source) ]
 
         let rec go (state : ScanState) (acc : ScanEvent list) (args : string list) : ScanEvent list =
             match args with
             | [] -> List.rev acc @ resolvePending state
             | "--" :: rest ->
-                let positionals =
-                    rest
-                    |> List.map (fun token -> ScanEvent.Positional (token, true, PositionalForm.Bare))
-
+                let positionals = rest |> List.map (fun token -> bareToken token true)
                 List.rev acc @ resolvePending state @ (ScanEvent.Separator :: positionals)
             | arg :: rest ->
                 match state with
                 | ScanState.AwaitingKey ->
                     if not (arg.StartsWith ("--", StringComparison.Ordinal)) then
-                        go ScanState.AwaitingKey (ScanEvent.Positional (arg, false, PositionalForm.Bare) :: acc) rest
+                        go ScanState.AwaitingKey (bareToken arg false :: acc) rest
                     elif String.Equals (arg, "--help", StringComparison.OrdinalIgnoreCase) then
                         go ScanState.AwaitingKey (ScanEvent.Help arg :: acc) rest
                     else
@@ -299,16 +331,21 @@ module private ArgParserRuntime_SameBaseNameArgs =
 
                                 go ScanState.AwaitingKey (ScanEvent.Occurrence occurrence :: acc) rest
                             | None ->
-                                if isPositionalKey key then
-                                    go
-                                        ScanState.AwaitingKey
-                                        (ScanEvent.Positional (value, false, PositionalForm.KeyEquals key) :: acc)
-                                        rest
+                                let claimants = positionalClaimants key
+
+                                if not (Set.isEmpty claimants) then
+                                    let event =
+                                        ScanEvent.Positional
+                                            {
+                                                Value = value
+                                                AfterSeparator = false
+                                                Form = PositionalForm.KeyEquals key
+                                                Candidates = claimants
+                                            }
+
+                                    go ScanState.AwaitingKey (event :: acc) rest
                                 elif collectFlagLike then
-                                    go
-                                        ScanState.AwaitingKey
-                                        (ScanEvent.Positional (arg, false, PositionalForm.Bare) :: acc)
-                                        rest
+                                    go ScanState.AwaitingKey (bareToken arg false :: acc) rest
                                 else
                                     go
                                         ScanState.AwaitingKey
@@ -318,8 +355,10 @@ module private ArgParserRuntime_SameBaseNameArgs =
                             match matchLeaf schema.Leaves arg with
                             | Some matched -> go (ScanState.AwaitingValue (Some matched, arg)) acc rest
                             | None ->
-                                if isPositionalKey arg then
-                                    go (ScanState.AwaitingPositionalValue arg) acc rest
+                                let claimants = positionalClaimants arg
+
+                                if not (Set.isEmpty claimants) then
+                                    go (ScanState.AwaitingPositionalValue (claimants, arg)) acc rest
                                 else
                                     go (ScanState.AwaitingValue (None, arg)) acc rest
                 | ScanState.AwaitingValue (Some (leaf, negated), source) ->
@@ -349,17 +388,20 @@ module private ArgParserRuntime_SameBaseNameArgs =
                             go ScanState.AwaitingKey (ScanEvent.Occurrence occurrence :: acc) (arg :: rest)
                 | ScanState.AwaitingValue (None, source) ->
                     if collectFlagLike then
-                        go
-                            ScanState.AwaitingKey
-                            (ScanEvent.Positional (source, false, PositionalForm.Bare) :: acc)
-                            (arg :: rest)
+                        go ScanState.AwaitingKey (bareToken source false :: acc) (arg :: rest)
                     else
                         go ScanState.AwaitingKey (ScanEvent.Error (ScanError.UnknownKey source) :: acc) (arg :: rest)
-                | ScanState.AwaitingPositionalValue source ->
-                    go
-                        ScanState.AwaitingKey
-                        (ScanEvent.Positional (arg, false, PositionalForm.KeySpaced source) :: acc)
-                        rest
+                | ScanState.AwaitingPositionalValue (candidates, source) ->
+                    let event =
+                        ScanEvent.Positional
+                            {
+                                Value = arg
+                                AfterSeparator = false
+                                Form = PositionalForm.KeySpaced source
+                                Candidates = candidates
+                            }
+
+                    go ScanState.AwaitingKey (event :: acc) rest
 
         go ScanState.AwaitingKey [] args
 
@@ -594,7 +636,7 @@ module private ArgParserRuntime_SameBaseNameArgs =
                     events
                     |> List.choose (fun event ->
                         match event with
-                        | ScanEvent.Positional (value, _, _) -> Some value
+                        | ScanEvent.Positional positional -> Some positional.Value
                         | _ -> None
                     )
 
@@ -1083,11 +1125,11 @@ module private ArgParserRuntime_SameBaseNameArgs =
                         | None -> stored.Add occurrence.LeafId |> ignore<bool>
 
                     consume rest
-                | ScanEvent.Positional (value, afterSeparator, _) ->
+                | ScanEvent.Positional positional ->
                     match schema.Positionals with
                     | [] -> consume rest
                     | _ :: _ ->
-                        match callbacks.StorePositional value afterSeparator with
+                        match callbacks.StorePositional positional.Value positional.AfterSeparator with
                         | Some error -> errors.Add error
                         | None -> ()
 

--- a/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParserRuntime.fs
+++ b/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParserRuntime.fs
@@ -51,6 +51,15 @@ module TestArgParserRuntime =
                 Source = source
             }
 
+    let private posEv (value : string) (afterSep : bool) (form : PositionalForm) (candidates : int list) : ScanEvent =
+        ScanEvent.Positional
+            {
+                Value = value
+                AfterSeparator = afterSep
+                Form = form
+                Candidates = Set.ofList candidates
+            }
+
     // ----------------------------------------------------------------------------------------
     // Unit tests: the token grammar.
 
@@ -162,8 +171,8 @@ module TestArgParserRuntime =
         scan schema [ "--unknown" ; "foo" ]
         |> shouldEqual
             [
-                ScanEvent.Positional ("--unknown", false, PositionalForm.Bare)
-                ScanEvent.Positional ("foo", false, PositionalForm.Bare)
+                posEv "--unknown" false PositionalForm.Bare [ 99 ]
+                posEv "foo" false PositionalForm.Bare [ 99 ]
             ]
 
         scan schema [ "--unknown" ]
@@ -172,8 +181,8 @@ module TestArgParserRuntime =
         scan schema [ "--unknown=3" ; "foo" ]
         |> shouldEqual
             [
-                ScanEvent.Positional ("--unknown=3", false, PositionalForm.Bare)
-                ScanEvent.Positional ("foo", false, PositionalForm.Bare)
+                posEv "--unknown=3" false PositionalForm.Bare [ 99 ]
+                posEv "foo" false PositionalForm.Bare [ 99 ]
             ]
 
     [<Test>]
@@ -193,18 +202,18 @@ module TestArgParserRuntime =
         scan schema [ "--rest=5" ; "--rest" ; "6" ; "plain" ]
         |> shouldEqual
             [
-                ScanEvent.Positional ("5", false, PositionalForm.KeyEquals "--rest")
-                ScanEvent.Positional ("6", false, PositionalForm.KeySpaced "--rest")
-                ScanEvent.Positional ("plain", false, PositionalForm.Bare)
+                posEv "5" false (PositionalForm.KeyEquals "--rest") [ 99 ]
+                posEv "6" false (PositionalForm.KeySpaced "--rest") [ 99 ]
+                posEv "plain" false PositionalForm.Bare [ 99 ]
             ]
 
         // Case-insensitive, like every other key.
         scan schema [ "--REST=5" ]
-        |> shouldEqual [ ScanEvent.Positional ("5", false, PositionalForm.KeyEquals "--REST") ]
+        |> shouldEqual [ posEv "5" false (PositionalForm.KeyEquals "--REST") [ 99 ] ]
 
         // The keyed form always consumes exactly one value, greedily.
         scan schema [ "--rest" ; "--rest" ]
-        |> shouldEqual [ ScanEvent.Positional ("--rest", false, PositionalForm.KeySpaced "--rest") ]
+        |> shouldEqual [ posEv "--rest" false (PositionalForm.KeySpaced "--rest") [ 99 ] ]
 
         // Trailing key with no value: same error as any other arity-one key.
         scan schema [ "--rest" ]
@@ -229,12 +238,12 @@ module TestArgParserRuntime =
         scan schema [ "--remainder=5" ; "--REMAINDER" ; "6" ]
         |> shouldEqual
             [
-                ScanEvent.Positional ("5", false, PositionalForm.KeyEquals "--remainder")
-                ScanEvent.Positional ("6", false, PositionalForm.KeySpaced "--REMAINDER")
+                posEv "5" false (PositionalForm.KeyEquals "--remainder") [ 99 ]
+                posEv "6" false (PositionalForm.KeySpaced "--REMAINDER") [ 99 ]
             ]
 
         scan schema [ "--rest=7" ]
-        |> shouldEqual [ ScanEvent.Positional ("7", false, PositionalForm.KeyEquals "--rest") ]
+        |> shouldEqual [ posEv "7" false (PositionalForm.KeyEquals "--rest") [ 99 ] ]
 
     [<Test>]
     let ``An unknown key is an error where flag-like collection is not allowed`` () =
@@ -248,7 +257,7 @@ module TestArgParserRuntime =
         |> shouldEqual
             [
                 ScanEvent.Error (ScanError.UnknownKey "--unknown")
-                ScanEvent.Positional ("x", false, PositionalForm.Bare)
+                posEv "x" false PositionalForm.Bare []
             ]
 
     // ----------------------------------------------------------------------------------------
@@ -1009,11 +1018,11 @@ module TestArgParserRuntime =
                         [ occurrence.Source ]
                     else
                         [ occurrence.Source ; value ]
-            | ScanEvent.Positional (value, _, form) ->
-                match form with
-                | PositionalForm.Bare -> [ value ]
-                | PositionalForm.KeyEquals key -> [ key + "=" + value ]
-                | PositionalForm.KeySpaced key -> [ key ; value ]
+            | ScanEvent.Positional positional ->
+                match positional.Form with
+                | PositionalForm.Bare -> [ positional.Value ]
+                | PositionalForm.KeyEquals key -> [ key + "=" + positional.Value ]
+                | PositionalForm.KeySpaced key -> [ key ; positional.Value ]
             | ScanEvent.Error (ScanError.TrailingKeyNoValue source) -> [ source ]
             | ScanEvent.Error (ScanError.UnknownKey source) -> [ source ]
             | ScanEvent.Error (ScanError.UnknownKeyEqualsValue (key, value)) -> [ key + "=" + value ]
@@ -1241,7 +1250,7 @@ module TestArgParserRuntime =
             return
                 {
                     Tokens = [ value ]
-                    Expected = [ ScanEvent.Positional (value, false, PositionalForm.Bare) ]
+                    Expected = [ posEv value false PositionalForm.Bare [ 1000 ] ]
                 }
         }
 
@@ -1366,8 +1375,7 @@ module TestArgParserRuntime =
                 (fixedUnits |> List.collect (fun u -> u.Expected))
                 @ (if withSeparator then
                        ScanEvent.Separator
-                       :: (postSep
-                           |> List.map (fun t -> ScanEvent.Positional (t, true, PositionalForm.Bare)))
+                       :: (postSep |> List.map (fun t -> posEv t true PositionalForm.Bare [ 1000 ]))
                    else
                        [])
 
@@ -1895,3 +1903,86 @@ module TestArgParserRuntime =
 
         let config = Config.QuickThrowOnFailure.WithMaxTest 1000
         Check.One (config, Prop.forAll (Arb.fromGen cases) property)
+
+    // ----------------------------------------------------------------------------------------
+    // Candidate sets: the spelling of a positional token determines which sinks could consume
+    // it, and nothing else does — scanning stays independent of the eventual case selection.
+
+    [<Test>]
+    let ``Positional events carry the claimant sets of their spelling`` () =
+        // Two sinks in mutually exclusive cases, sharing the form "rest"; only sink 11 also
+        // answers to "files".
+        let schema =
+            {
+                Leaves =
+                    [
+                        leaf 0 "foo" ErasedArity.One ErasedRequirement.Required
+                        leaf 1 "bar" ErasedArity.One ErasedRequirement.Required
+                    ]
+                Tree =
+                    ErasedTree.Sum (
+                        0,
+                        [
+                            "A", ErasedTree.Product [ ErasedTree.Leaf 0 ; ErasedTree.PositionalLeaf 10 ]
+                            "B", ErasedTree.Product [ ErasedTree.Leaf 1 ; ErasedTree.PositionalLeaf 11 ]
+                        ]
+                    )
+                Positionals =
+                    [
+                        sink' 10 [ "rest" ] ErasedFlagLikeBehaviour.Reject
+                        sink' 11 [ "rest" ; "files" ] ErasedFlagLikeBehaviour.Reject
+                    ]
+            }
+
+        // A shared keyed form yields the union of its claimants.
+        scan schema [ "--rest=1" ]
+        |> shouldEqual [ posEv "1" false (PositionalForm.KeyEquals "--rest") [ 10 ; 11 ] ]
+
+        // A form claimed by one sink yields that sink alone, case-insensitively.
+        scan schema [ "--FILES" ; "2" ]
+        |> shouldEqual [ posEv "2" false (PositionalForm.KeySpaced "--FILES") [ 11 ] ]
+
+        // Bare tokens, and everything after the separator, name every sink.
+        scan schema [ "bare" ]
+        |> shouldEqual [ posEv "bare" false PositionalForm.Bare [ 10 ; 11 ] ]
+
+        scan schema [ "--" ; "tail" ]
+        |> shouldEqual [ ScanEvent.Separator ; posEv "tail" true PositionalForm.Bare [ 10 ; 11 ] ]
+
+    [<Test>]
+    let ``Every positional event of a one-sink schema names exactly that sink`` () =
+        // The legacy-projection property: for the schemas the generator emits today (at most
+        // one sink), the candidate metadata is fully determined, so erasing it recovers the
+        // historical event log.
+        let mutable positionalEvents = 0
+
+        let cases =
+            gen {
+                let! sumBias = Gen.elements [ 0 ; 50 ]
+                let! schema = genSchema sumBias
+
+                let! flagLike = Gen.elements [ ErasedFlagLikeBehaviour.Collect ; ErasedFlagLikeBehaviour.Reject ]
+
+                let schema =
+                    { schema with
+                        Positionals = [ sink' 1000 [ "rest" ] flagLike ]
+                        Tree = ErasedTree.Product [ schema.Tree ; ErasedTree.PositionalLeaf 1000 ]
+                    }
+
+                let! count = Gen.choose (0, 15)
+                let! tokens = Gen.listOfLength count (genToken schema)
+                return schema, tokens
+            }
+
+        let property (schema : ErasedSchema, tokens : string list) : unit =
+            for event in scan schema tokens do
+                match event with
+                | ScanEvent.Positional positional ->
+                    positionalEvents <- positionalEvents + 1
+                    positional.Candidates |> shouldEqual (Set.singleton 1000)
+                | _ -> ()
+
+        let config = Config.QuickThrowOnFailure.WithMaxTest 1000
+        Check.One (config, Prop.forAll (Arb.fromGen cases) property)
+
+        positionalEvents |> shouldBeGreaterThan 1000

--- a/WoofWare.Myriad.Plugins/ArgParserRuntime.fs
+++ b/WoofWare.Myriad.Plugins/ArgParserRuntime.fs
@@ -152,14 +152,32 @@ module internal ArgParserRuntime =
         /// `--rest value`; the key text is recorded as spelled.
         | KeySpaced of key : string
 
+    /// One value belonging to the positional stream. Scanning does not decide which sink
+    /// receives it: the token's spelling determines only the *candidate* sinks, and the actual
+    /// consumer is resolved after case selection. (For today's schemas, with at most one sink,
+    /// the candidate set is that sink alone.)
+    type PositionalEvent =
+        {
+            Value : string
+            /// True for tokens which appeared after the `--` separator.
+            AfterSeparator : bool
+            /// How the value was spelled; preserved exactly, for diagnostics and lossless
+            /// reconstruction of argv.
+            Form : PositionalForm
+            /// The sinks which could consume this token: every sink for a bare token
+            /// (including everything after `--`, and flag-like tokens collected in Collect
+            /// mode), the claimants of the key for a keyed one.
+            Candidates : Set<int>
+        }
+
     /// The scan phase emits an ordered log of these; the typed layer folds over the log in order,
     /// so that e.g. conversion errors interleave with structural errors in argv order.
     [<RequireQualifiedAccess>]
     type ScanEvent =
         | Occurrence of ErasedOccurrence
-        /// A value routed to the positional sink (or to the leftover-args accumulator, for a
-        /// schema with no sink). `afterSeparator` is true for tokens which appeared after `--`.
-        | Positional of value : string * afterSeparator : bool * form : PositionalForm
+        /// A value belonging to the positional stream (or to the leftover-args accumulator,
+        /// for a schema with no sink).
+        | Positional of PositionalEvent
         | Error of ScanError
         /// A `--help`-shaped token was seen in key position; the token itself is recorded (the
         /// match is case-insensitive, so it may be e.g. "--HELP").
@@ -184,9 +202,10 @@ module internal ArgParserRuntime =
     type private ScanState =
         | AwaitingKey
         | AwaitingValue of leaf : (ErasedLeaf * bool) option * source : string
-        /// The positional sink's own key (`--rest`) was seen; the next token is its value,
-        /// consumed greedily (keyed positionals always take exactly one value).
-        | AwaitingPositionalValue of source : string
+        /// A positional sink's own key (`--rest`) was seen; the next token is its value,
+        /// consumed greedily (keyed positionals always take exactly one value). `candidates`
+        /// are the sinks claiming the key.
+        | AwaitingPositionalValue of candidates : Set<int> * source : string
 
     /// Match a full `--key` token (value part already split off) against the leaf table.
     /// Returns the leaf and whether the match was via the negated `--no-` form.
@@ -244,13 +263,29 @@ module internal ArgParserRuntime =
                     | ErasedFlagLikeBehaviour.Reject -> false
                 )
 
-        /// Does this full `--key` token (value part already split off) name a positional sink?
-        let isPositionalKey (key : string) : bool =
+        /// Every sink: the candidate set of a bare positional token.
+        let allSinks : Set<int> =
+            schema.Positionals |> List.map (fun p -> p.Id) |> Set.ofList
+
+        /// The sinks claiming this full `--key` token (value part already split off); empty
+        /// when the token does not name a positional sink at all.
+        let positionalClaimants (key : string) : Set<int> =
             schema.Positionals
-            |> List.exists (fun p ->
+            |> List.filter (fun p ->
                 p.Forms
                 |> List.exists (fun form -> String.Equals (key, "--" + form, StringComparison.OrdinalIgnoreCase))
             )
+            |> List.map (fun p -> p.Id)
+            |> Set.ofList
+
+        let bareToken (value : string) (afterSeparator : bool) : ScanEvent =
+            ScanEvent.Positional
+                {
+                    Value = value
+                    AfterSeparator = afterSeparator
+                    Form = PositionalForm.Bare
+                    Candidates = allSinks
+                }
 
         /// Resolve a pending key which will receive no value (end of input, or `--` next).
         let resolvePending (state : ScanState) : ScanEvent list =
@@ -270,15 +305,13 @@ module internal ArgParserRuntime =
                     ]
                 | ErasedArity.One -> [ ScanEvent.Error (ScanError.TrailingKeyNoValue source) ]
             | ScanState.AwaitingValue (None, source) -> [ ScanEvent.Error (ScanError.TrailingKeyNoValue source) ]
-            | ScanState.AwaitingPositionalValue source -> [ ScanEvent.Error (ScanError.TrailingKeyNoValue source) ]
+            | ScanState.AwaitingPositionalValue (_, source) -> [ ScanEvent.Error (ScanError.TrailingKeyNoValue source) ]
 
         let rec go (state : ScanState) (acc : ScanEvent list) (args : string list) : ScanEvent list =
             match args with
             | [] -> List.rev acc @ resolvePending state
             | "--" :: rest ->
-                let positionals =
-                    rest
-                    |> List.map (fun token -> ScanEvent.Positional (token, true, PositionalForm.Bare))
+                let positionals = rest |> List.map (fun token -> bareToken token true)
 
                 List.rev acc @ resolvePending state @ (ScanEvent.Separator :: positionals)
             | arg :: rest ->
@@ -286,7 +319,7 @@ module internal ArgParserRuntime =
             match state with
             | ScanState.AwaitingKey ->
                 if not (arg.StartsWith ("--", StringComparison.Ordinal)) then
-                    go ScanState.AwaitingKey (ScanEvent.Positional (arg, false, PositionalForm.Bare) :: acc) rest
+                    go ScanState.AwaitingKey (bareToken arg false :: acc) rest
                 elif String.Equals (arg, "--help", StringComparison.OrdinalIgnoreCase) then
                     go ScanState.AwaitingKey (ScanEvent.Help arg :: acc) rest
                 else
@@ -310,16 +343,21 @@ module internal ArgParserRuntime =
 
                             go ScanState.AwaitingKey (ScanEvent.Occurrence occurrence :: acc) rest
                         | None ->
-                            if isPositionalKey key then
-                                go
-                                    ScanState.AwaitingKey
-                                    (ScanEvent.Positional (value, false, PositionalForm.KeyEquals key) :: acc)
-                                    rest
+                            let claimants = positionalClaimants key
+
+                            if not (Set.isEmpty claimants) then
+                                let event =
+                                    ScanEvent.Positional
+                                        {
+                                            Value = value
+                                            AfterSeparator = false
+                                            Form = PositionalForm.KeyEquals key
+                                            Candidates = claimants
+                                        }
+
+                                go ScanState.AwaitingKey (event :: acc) rest
                             elif collectFlagLike then
-                                go
-                                    ScanState.AwaitingKey
-                                    (ScanEvent.Positional (arg, false, PositionalForm.Bare) :: acc)
-                                    rest
+                                go ScanState.AwaitingKey (bareToken arg false :: acc) rest
                             else
                                 go
                                     ScanState.AwaitingKey
@@ -330,8 +368,10 @@ module internal ArgParserRuntime =
                         match matchLeaf schema.Leaves arg with
                         | Some matched -> go (ScanState.AwaitingValue (Some matched, arg)) acc rest
                         | None ->
-                            if isPositionalKey arg then
-                                go (ScanState.AwaitingPositionalValue arg) acc rest
+                            let claimants = positionalClaimants arg
+
+                            if not (Set.isEmpty claimants) then
+                                go (ScanState.AwaitingPositionalValue (claimants, arg)) acc rest
                             else
                                 go (ScanState.AwaitingValue (None, arg)) acc rest
             | ScanState.AwaitingValue (Some (leaf, negated), source) ->
@@ -363,18 +403,21 @@ module internal ArgParserRuntime =
             | ScanState.AwaitingValue (None, source) ->
                 // A pending unrecognised key, now known not to be trailing.
                 if collectFlagLike then
-                    go
-                        ScanState.AwaitingKey
-                        (ScanEvent.Positional (source, false, PositionalForm.Bare) :: acc)
-                        (arg :: rest)
+                    go ScanState.AwaitingKey (bareToken source false :: acc) (arg :: rest)
                 else
                     go ScanState.AwaitingKey (ScanEvent.Error (ScanError.UnknownKey source) :: acc) (arg :: rest)
-            | ScanState.AwaitingPositionalValue source ->
+            | ScanState.AwaitingPositionalValue (candidates, source) ->
                 // The sink's own key consumes the next token greedily, like any arity-one key.
-                go
-                    ScanState.AwaitingKey
-                    (ScanEvent.Positional (arg, false, PositionalForm.KeySpaced source) :: acc)
-                    rest
+                let event =
+                    ScanEvent.Positional
+                        {
+                            Value = arg
+                            AfterSeparator = false
+                            Form = PositionalForm.KeySpaced source
+                            Candidates = candidates
+                        }
+
+                go ScanState.AwaitingKey (event :: acc) rest
 
         go ScanState.AwaitingKey [] args
 
@@ -612,7 +655,7 @@ module internal ArgParserRuntime =
                     events
                     |> List.choose (fun event ->
                         match event with
-                        | ScanEvent.Positional (value, _, _) -> Some value
+                        | ScanEvent.Positional positional -> Some positional.Value
                         | _ -> None
                     )
 
@@ -1109,13 +1152,13 @@ module internal ArgParserRuntime =
                     | None -> stored.Add occurrence.LeafId |> ignore<bool>
 
                 consume rest
-            | ScanEvent.Positional (value, afterSeparator, _) ->
+            | ScanEvent.Positional positional ->
                 match schema.Positionals with
                 | [] ->
                     // No sink: the tokens are reported wholesale by validation below.
                     consume rest
                 | _ :: _ ->
-                    match callbacks.StorePositional value afterSeparator with
+                    match callbacks.StorePositional positional.Value positional.AfterSeparator with
                     | Some error -> errors.Add error
                     | None -> ()
 


### PR DESCRIPTION
Stage 4 of the positional-args-with-unions stack (4/8). Stacked on #576.

The scanner now records *where a positional token could go* instead of assuming a single destination. Each positional occurrence becomes a `PositionalEvent { Value; AfterSeparator; Form; Candidates }`:

- a bare token's candidate set is **every** sink in the schema (any complete interpretation could claim it);
- a keyed occurrence (`--rest=value`, or `--rest` followed by a value) names exactly the sinks whose form matches, case-insensitively;
- `AwaitingPositionalValue` carries the candidate set and source spelling through the two-token form.

Routing is *not* decided here — events stay unresolved until the Stage 5 resolver runs, after structural case selection. That's the phase-separation invariant: scanning is purely lexical.

A determinism property pins backward compatibility: for any schema with exactly one sink, projecting the new events onto the old single-destination scan reproduces the previous behaviour exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
