### PR TITLE
Add the structural resolver: case selection plus positional routing

### DIFF
--- a/ConsumePlugin/GeneratedArgParserNegationTests.fs
+++ b/ConsumePlugin/GeneratedArgParserNegationTests.fs
@@ -405,7 +405,7 @@ module private ArgParserRuntime_BoolNegation =
 
         go ScanState.AwaitingKey [] args
 
-    /// A failure to choose a unique case for a Sum node.
+    /// A failure to choose a unique case for a Sum node, or to route the positional stream.
     [<RequireQualifiedAccess>]
     type SelectionError =
         /// Occurrences were seen for leaves belonging to two (or more) different cases of one
@@ -417,6 +417,16 @@ module private ArgParserRuntime_BoolNegation =
         /// arguments, so the choice is ambiguous. (A generation-time check normally rejects
         /// schemas where this can happen; this is the runtime safety net.)
         | AmbiguousEmptyCases of sumId : int * caseNames : string list
+        /// Positional tokens were seen, but no positional sink consistent with the named
+        /// arguments can consume them all. `source` is the first positional token, as spelled.
+        | UnroutablePositional of source : string
+        /// The positional stream could be consumed by more than one sink, and nothing else
+        /// distinguishes their alternatives. `source` is the first positional token, as
+        /// spelled; `sinkIds` are the competing sinks. (A generation-time check normally
+        /// rejects schemas where this can happen with bare tokens; this is the runtime safety
+        /// net, and it can also fire for a keyed form shared between otherwise-undistinguished
+        /// alternatives.)
+        | AmbiguousPositionalRouting of source : string * sinkIds : int list
 
     /// The result of case selection: which case index was chosen for each Sum node reachable in
     /// the selected interpretation, and which leaves are *active* (belong to selected cases).
@@ -483,7 +493,16 @@ module private ArgParserRuntime_BoolNegation =
     /// "touched" if any leaf beneath it received an occurrence. Exactly one touched case means
     /// that case is selected; two or more touched cases is a conflict; zero touched cases falls
     /// back to the unique case satisfiable with no arguments.
-    let select (schema : ErasedSchema) (observed : Map<int, string>) : Selection =
+    /// Like `select` below, but a positional-stream hypothesis may be supplied: the sink with
+    /// the given id is treated as one additional observed (optional) leaf, its witness being
+    /// the given source text. This is how the resolver asks "which case would be selected if
+    /// sink p consumed the positional stream?".
+    let private selectWith
+        (schema : ErasedSchema)
+        (observed : Map<int, string>)
+        (positionalWitness : (int * string) option)
+        : Selection
+        =
         let leavesById = schema.Leaves |> List.map (fun leaf -> leaf.Id, leaf) |> Map.ofList
 
         let rec go (tree : ErasedTree) : Map<int, int> * Set<int> * Set<int> * SelectionError list =
@@ -504,6 +523,15 @@ module private ArgParserRuntime_BoolNegation =
                     |> List.choose (fun (i, (name, case)) ->
                         let witness =
                             leafIds case |> List.tryPick (fun leafId -> Map.tryFind leafId observed)
+
+                        let witness =
+                            match witness with
+                            | Some source -> Some source
+                            | None ->
+                                match positionalWitness with
+                                | Some (positionalId, source) when positionalIds case |> List.contains positionalId ->
+                                    Some source
+                                | _ -> None
 
                         match witness with
                         | Some source -> Some (i, name, source)
@@ -549,6 +577,146 @@ module private ArgParserRuntime_BoolNegation =
                         "WoofWare.Myriad internal error: two positional sinks were active at once; the schema was not validated"
             Errors = errors
         }
+
+    let select (schema : ErasedSchema) (observed : Map<int, string>) : Selection = selectWith schema observed None
+
+    /// A positional event's original spelling, for error messages.
+    let describePositionalEvent (event : PositionalEvent) : string =
+        match event.Form with
+        | PositionalForm.Bare -> event.Value
+        | PositionalForm.KeyEquals key -> key + "=" + event.Value
+        | PositionalForm.KeySpaced key -> key + " " + event.Value
+
+    /// Structural resolution: select a case for every Sum *and* route the positional stream,
+    /// given the named observations and the scanned positional events. Pure, and independent
+    /// of conversion by construction: it sees only which named leaves were observed and how
+    /// the positional tokens were spelled.
+    ///
+    /// The rule (mirroring the exhaustive reference semantics): a complete interpretation
+    /// accepts the input iff it contains every observed named leaf, all its required leaves
+    /// were observed, and — when positional tokens exist — it contains a sink which is a
+    /// candidate of every positional event. The parse succeeds exactly when one
+    /// interpretation accepts. Efficiently: intersect the events' candidate sets, and run the
+    /// compositional selector once per candidate sink, with that sink treated as one
+    /// additional observed leaf.
+    ///
+    /// Error reporting prefers the friendliest diagnosis: an interpretation which is unique
+    /// up to missing required arguments is still selected (the missing arguments are reported
+    /// downstream, as for a purely named parse), so positional routing only surfaces in
+    /// errors when it is genuinely the obstacle.
+    let resolve
+        (schema : ErasedSchema)
+        (observed : Map<int, string>)
+        (positionalEvents : PositionalEvent list)
+        : Selection
+        =
+        match positionalEvents, schema.Positionals with
+        | [], _
+        | _, [] -> select schema observed
+        | events, _ ->
+            let candidates =
+                events |> List.map (fun event -> event.Candidates) |> Set.intersectMany
+
+            /// Are all the required named leaves active under this selection observed?
+            let requiredComplete (selection : Selection) : bool =
+                schema.Leaves
+                |> List.forall (fun leaf ->
+                    match leaf.Requirement with
+                    | ErasedRequirement.Required ->
+                        not (Set.contains leaf.Id selection.ActiveLeaves)
+                        || Map.containsKey leaf.Id observed
+                    | ErasedRequirement.Optional
+                    | ErasedRequirement.HasDefault -> true
+                )
+
+            let firstSource = describePositionalEvent (List.head events)
+
+            let hypotheses =
+                schema.Positionals
+                |> List.filter (fun p -> Set.contains p.Id candidates)
+                |> List.map (fun p ->
+                    let witness =
+                        events
+                        |> List.tryFind (fun event -> Set.contains p.Id event.Candidates)
+                        |> Option.map describePositionalEvent
+                        |> Option.defaultValue firstSource
+
+                    p.Id, selectWith schema observed (Some (p.Id, witness))
+                )
+
+            let clean =
+                hypotheses
+                |> List.filter (fun (p, selection) ->
+                    List.isEmpty selection.Errors
+                    && (
+                        match selection.ActivePositional with
+                        | Some active -> active = p
+                        | None -> false
+                    )
+                )
+
+            let fullyValid =
+                clean |> List.filter (fun (_, selection) -> requiredComplete selection)
+
+            let innerAmbiguous =
+                hypotheses
+                |> List.filter (fun (p, selection) ->
+                    not (List.isEmpty selection.Errors)
+                    && (selection.Errors
+                        |> List.forall (fun error ->
+                            match error with
+                            | SelectionError.AmbiguousEmptyCases _ -> true
+                            | _ -> false
+                        ))
+                    && (
+                        match selection.ActivePositional with
+                        | Some active -> active = p
+                        | None -> false
+                    )
+                    && requiredComplete selection
+                )
+
+            let ambiguous (competing : (int * Selection) list) : Selection =
+                {
+                    Choices = Map.empty
+                    ActiveLeaves = Set.empty
+                    ActivePositional = None
+                    Errors =
+                        [
+                            SelectionError.AmbiguousPositionalRouting (
+                                firstSource,
+                                competing |> List.map (fun (p, _) -> p)
+                            )
+                        ]
+                }
+
+            match fullyValid, innerAmbiguous with
+            | [ (_, selection) ], [] -> selection
+            | [], [ (_, selection) ] -> selection
+            | [], [] ->
+                match clean with
+                | [ (_, selection) ] -> selection
+                | clean ->
+                    let selection = select schema observed
+
+                    let unroutable =
+                        { selection with
+                            Errors = selection.Errors @ [ SelectionError.UnroutablePositional firstSource ]
+                        }
+
+                    if Set.isEmpty candidates then
+                        unroutable
+                    elif not (List.isEmpty selection.Errors) then
+                        selection
+                    else
+                        match selection.ActivePositional with
+                        | Some active when events |> List.forall (fun event -> Set.contains active event.Candidates) ->
+                            selection
+                        | _ ->
+                            match clean with
+                            | _ :: _ :: _ -> ambiguous clean
+                            | _ -> unroutable
+            | fullyValid, innerAmbiguous -> ambiguous (fullyValid @ innerAmbiguous)
 
     /// A structural error found after scanning and selection.
     [<RequireQualifiedAccess>]
@@ -1170,6 +1338,27 @@ module private ArgParserRuntime_BoolNegation =
                     sprintf
                         "Arguments do not determine which of these alternatives was intended: %s"
                         (String.concat ", " caseNames)
+                    |> errors.Add
+                | SelectionError.UnroutablePositional source ->
+                    sprintf
+                        "Positional argument '%s' does not belong to any single alternative consistent with the other arguments"
+                        source
+                    |> errors.Add
+                | SelectionError.AmbiguousPositionalRouting (source, sinkIds) ->
+                    let describeSink (sinkId : int) : string =
+                        let sink = schema.Positionals |> List.tryFind (fun p -> p.Id = sinkId)
+
+                        match sink with
+                        | Some sink ->
+                            match sink.Forms with
+                            | form :: _ -> "--" + form
+                            | [] -> sprintf "sink %i" sinkId
+                        | None -> sprintf "sink %i" sinkId
+
+                    sprintf
+                        "Positional args (e.g. '%s') could belong to more than one alternative (%s); supply an argument which distinguishes them"
+                        source
+                        (sinkIds |> List.map describeSink |> String.concat ", ")
                     |> errors.Add
 
             for validationError in validationErrors do

--- a/ConsumePlugin/GeneratedArgs.fs
+++ b/ConsumePlugin/GeneratedArgs.fs
@@ -405,7 +405,7 @@ module private ArgParserRuntime_BasicNoPositionals =
 
         go ScanState.AwaitingKey [] args
 
-    /// A failure to choose a unique case for a Sum node.
+    /// A failure to choose a unique case for a Sum node, or to route the positional stream.
     [<RequireQualifiedAccess>]
     type SelectionError =
         /// Occurrences were seen for leaves belonging to two (or more) different cases of one
@@ -417,6 +417,16 @@ module private ArgParserRuntime_BasicNoPositionals =
         /// arguments, so the choice is ambiguous. (A generation-time check normally rejects
         /// schemas where this can happen; this is the runtime safety net.)
         | AmbiguousEmptyCases of sumId : int * caseNames : string list
+        /// Positional tokens were seen, but no positional sink consistent with the named
+        /// arguments can consume them all. `source` is the first positional token, as spelled.
+        | UnroutablePositional of source : string
+        /// The positional stream could be consumed by more than one sink, and nothing else
+        /// distinguishes their alternatives. `source` is the first positional token, as
+        /// spelled; `sinkIds` are the competing sinks. (A generation-time check normally
+        /// rejects schemas where this can happen with bare tokens; this is the runtime safety
+        /// net, and it can also fire for a keyed form shared between otherwise-undistinguished
+        /// alternatives.)
+        | AmbiguousPositionalRouting of source : string * sinkIds : int list
 
     /// The result of case selection: which case index was chosen for each Sum node reachable in
     /// the selected interpretation, and which leaves are *active* (belong to selected cases).
@@ -483,7 +493,16 @@ module private ArgParserRuntime_BasicNoPositionals =
     /// "touched" if any leaf beneath it received an occurrence. Exactly one touched case means
     /// that case is selected; two or more touched cases is a conflict; zero touched cases falls
     /// back to the unique case satisfiable with no arguments.
-    let select (schema : ErasedSchema) (observed : Map<int, string>) : Selection =
+    /// Like `select` below, but a positional-stream hypothesis may be supplied: the sink with
+    /// the given id is treated as one additional observed (optional) leaf, its witness being
+    /// the given source text. This is how the resolver asks "which case would be selected if
+    /// sink p consumed the positional stream?".
+    let private selectWith
+        (schema : ErasedSchema)
+        (observed : Map<int, string>)
+        (positionalWitness : (int * string) option)
+        : Selection
+        =
         let leavesById = schema.Leaves |> List.map (fun leaf -> leaf.Id, leaf) |> Map.ofList
 
         let rec go (tree : ErasedTree) : Map<int, int> * Set<int> * Set<int> * SelectionError list =
@@ -504,6 +523,15 @@ module private ArgParserRuntime_BasicNoPositionals =
                     |> List.choose (fun (i, (name, case)) ->
                         let witness =
                             leafIds case |> List.tryPick (fun leafId -> Map.tryFind leafId observed)
+
+                        let witness =
+                            match witness with
+                            | Some source -> Some source
+                            | None ->
+                                match positionalWitness with
+                                | Some (positionalId, source) when positionalIds case |> List.contains positionalId ->
+                                    Some source
+                                | _ -> None
 
                         match witness with
                         | Some source -> Some (i, name, source)
@@ -549,6 +577,146 @@ module private ArgParserRuntime_BasicNoPositionals =
                         "WoofWare.Myriad internal error: two positional sinks were active at once; the schema was not validated"
             Errors = errors
         }
+
+    let select (schema : ErasedSchema) (observed : Map<int, string>) : Selection = selectWith schema observed None
+
+    /// A positional event's original spelling, for error messages.
+    let describePositionalEvent (event : PositionalEvent) : string =
+        match event.Form with
+        | PositionalForm.Bare -> event.Value
+        | PositionalForm.KeyEquals key -> key + "=" + event.Value
+        | PositionalForm.KeySpaced key -> key + " " + event.Value
+
+    /// Structural resolution: select a case for every Sum *and* route the positional stream,
+    /// given the named observations and the scanned positional events. Pure, and independent
+    /// of conversion by construction: it sees only which named leaves were observed and how
+    /// the positional tokens were spelled.
+    ///
+    /// The rule (mirroring the exhaustive reference semantics): a complete interpretation
+    /// accepts the input iff it contains every observed named leaf, all its required leaves
+    /// were observed, and — when positional tokens exist — it contains a sink which is a
+    /// candidate of every positional event. The parse succeeds exactly when one
+    /// interpretation accepts. Efficiently: intersect the events' candidate sets, and run the
+    /// compositional selector once per candidate sink, with that sink treated as one
+    /// additional observed leaf.
+    ///
+    /// Error reporting prefers the friendliest diagnosis: an interpretation which is unique
+    /// up to missing required arguments is still selected (the missing arguments are reported
+    /// downstream, as for a purely named parse), so positional routing only surfaces in
+    /// errors when it is genuinely the obstacle.
+    let resolve
+        (schema : ErasedSchema)
+        (observed : Map<int, string>)
+        (positionalEvents : PositionalEvent list)
+        : Selection
+        =
+        match positionalEvents, schema.Positionals with
+        | [], _
+        | _, [] -> select schema observed
+        | events, _ ->
+            let candidates =
+                events |> List.map (fun event -> event.Candidates) |> Set.intersectMany
+
+            /// Are all the required named leaves active under this selection observed?
+            let requiredComplete (selection : Selection) : bool =
+                schema.Leaves
+                |> List.forall (fun leaf ->
+                    match leaf.Requirement with
+                    | ErasedRequirement.Required ->
+                        not (Set.contains leaf.Id selection.ActiveLeaves)
+                        || Map.containsKey leaf.Id observed
+                    | ErasedRequirement.Optional
+                    | ErasedRequirement.HasDefault -> true
+                )
+
+            let firstSource = describePositionalEvent (List.head events)
+
+            let hypotheses =
+                schema.Positionals
+                |> List.filter (fun p -> Set.contains p.Id candidates)
+                |> List.map (fun p ->
+                    let witness =
+                        events
+                        |> List.tryFind (fun event -> Set.contains p.Id event.Candidates)
+                        |> Option.map describePositionalEvent
+                        |> Option.defaultValue firstSource
+
+                    p.Id, selectWith schema observed (Some (p.Id, witness))
+                )
+
+            let clean =
+                hypotheses
+                |> List.filter (fun (p, selection) ->
+                    List.isEmpty selection.Errors
+                    && (
+                        match selection.ActivePositional with
+                        | Some active -> active = p
+                        | None -> false
+                    )
+                )
+
+            let fullyValid =
+                clean |> List.filter (fun (_, selection) -> requiredComplete selection)
+
+            let innerAmbiguous =
+                hypotheses
+                |> List.filter (fun (p, selection) ->
+                    not (List.isEmpty selection.Errors)
+                    && (selection.Errors
+                        |> List.forall (fun error ->
+                            match error with
+                            | SelectionError.AmbiguousEmptyCases _ -> true
+                            | _ -> false
+                        ))
+                    && (
+                        match selection.ActivePositional with
+                        | Some active -> active = p
+                        | None -> false
+                    )
+                    && requiredComplete selection
+                )
+
+            let ambiguous (competing : (int * Selection) list) : Selection =
+                {
+                    Choices = Map.empty
+                    ActiveLeaves = Set.empty
+                    ActivePositional = None
+                    Errors =
+                        [
+                            SelectionError.AmbiguousPositionalRouting (
+                                firstSource,
+                                competing |> List.map (fun (p, _) -> p)
+                            )
+                        ]
+                }
+
+            match fullyValid, innerAmbiguous with
+            | [ (_, selection) ], [] -> selection
+            | [], [ (_, selection) ] -> selection
+            | [], [] ->
+                match clean with
+                | [ (_, selection) ] -> selection
+                | clean ->
+                    let selection = select schema observed
+
+                    let unroutable =
+                        { selection with
+                            Errors = selection.Errors @ [ SelectionError.UnroutablePositional firstSource ]
+                        }
+
+                    if Set.isEmpty candidates then
+                        unroutable
+                    elif not (List.isEmpty selection.Errors) then
+                        selection
+                    else
+                        match selection.ActivePositional with
+                        | Some active when events |> List.forall (fun event -> Set.contains active event.Candidates) ->
+                            selection
+                        | _ ->
+                            match clean with
+                            | _ :: _ :: _ -> ambiguous clean
+                            | _ -> unroutable
+            | fullyValid, innerAmbiguous -> ambiguous (fullyValid @ innerAmbiguous)
 
     /// A structural error found after scanning and selection.
     [<RequireQualifiedAccess>]
@@ -1170,6 +1338,27 @@ module private ArgParserRuntime_BasicNoPositionals =
                     sprintf
                         "Arguments do not determine which of these alternatives was intended: %s"
                         (String.concat ", " caseNames)
+                    |> errors.Add
+                | SelectionError.UnroutablePositional source ->
+                    sprintf
+                        "Positional argument '%s' does not belong to any single alternative consistent with the other arguments"
+                        source
+                    |> errors.Add
+                | SelectionError.AmbiguousPositionalRouting (source, sinkIds) ->
+                    let describeSink (sinkId : int) : string =
+                        let sink = schema.Positionals |> List.tryFind (fun p -> p.Id = sinkId)
+
+                        match sink with
+                        | Some sink ->
+                            match sink.Forms with
+                            | form :: _ -> "--" + form
+                            | [] -> sprintf "sink %i" sinkId
+                        | None -> sprintf "sink %i" sinkId
+
+                    sprintf
+                        "Positional args (e.g. '%s') could belong to more than one alternative (%s); supply an argument which distinguishes them"
+                        source
+                        (sinkIds |> List.map describeSink |> String.concat ", ")
                     |> errors.Add
 
             for validationError in validationErrors do

--- a/ConsumePlugin/GeneratedDuArgs.fs
+++ b/ConsumePlugin/GeneratedDuArgs.fs
@@ -405,7 +405,7 @@ module private ArgParserRuntime_DuArgs =
 
         go ScanState.AwaitingKey [] args
 
-    /// A failure to choose a unique case for a Sum node.
+    /// A failure to choose a unique case for a Sum node, or to route the positional stream.
     [<RequireQualifiedAccess>]
     type SelectionError =
         /// Occurrences were seen for leaves belonging to two (or more) different cases of one
@@ -417,6 +417,16 @@ module private ArgParserRuntime_DuArgs =
         /// arguments, so the choice is ambiguous. (A generation-time check normally rejects
         /// schemas where this can happen; this is the runtime safety net.)
         | AmbiguousEmptyCases of sumId : int * caseNames : string list
+        /// Positional tokens were seen, but no positional sink consistent with the named
+        /// arguments can consume them all. `source` is the first positional token, as spelled.
+        | UnroutablePositional of source : string
+        /// The positional stream could be consumed by more than one sink, and nothing else
+        /// distinguishes their alternatives. `source` is the first positional token, as
+        /// spelled; `sinkIds` are the competing sinks. (A generation-time check normally
+        /// rejects schemas where this can happen with bare tokens; this is the runtime safety
+        /// net, and it can also fire for a keyed form shared between otherwise-undistinguished
+        /// alternatives.)
+        | AmbiguousPositionalRouting of source : string * sinkIds : int list
 
     /// The result of case selection: which case index was chosen for each Sum node reachable in
     /// the selected interpretation, and which leaves are *active* (belong to selected cases).
@@ -483,7 +493,16 @@ module private ArgParserRuntime_DuArgs =
     /// "touched" if any leaf beneath it received an occurrence. Exactly one touched case means
     /// that case is selected; two or more touched cases is a conflict; zero touched cases falls
     /// back to the unique case satisfiable with no arguments.
-    let select (schema : ErasedSchema) (observed : Map<int, string>) : Selection =
+    /// Like `select` below, but a positional-stream hypothesis may be supplied: the sink with
+    /// the given id is treated as one additional observed (optional) leaf, its witness being
+    /// the given source text. This is how the resolver asks "which case would be selected if
+    /// sink p consumed the positional stream?".
+    let private selectWith
+        (schema : ErasedSchema)
+        (observed : Map<int, string>)
+        (positionalWitness : (int * string) option)
+        : Selection
+        =
         let leavesById = schema.Leaves |> List.map (fun leaf -> leaf.Id, leaf) |> Map.ofList
 
         let rec go (tree : ErasedTree) : Map<int, int> * Set<int> * Set<int> * SelectionError list =
@@ -504,6 +523,15 @@ module private ArgParserRuntime_DuArgs =
                     |> List.choose (fun (i, (name, case)) ->
                         let witness =
                             leafIds case |> List.tryPick (fun leafId -> Map.tryFind leafId observed)
+
+                        let witness =
+                            match witness with
+                            | Some source -> Some source
+                            | None ->
+                                match positionalWitness with
+                                | Some (positionalId, source) when positionalIds case |> List.contains positionalId ->
+                                    Some source
+                                | _ -> None
 
                         match witness with
                         | Some source -> Some (i, name, source)
@@ -549,6 +577,146 @@ module private ArgParserRuntime_DuArgs =
                         "WoofWare.Myriad internal error: two positional sinks were active at once; the schema was not validated"
             Errors = errors
         }
+
+    let select (schema : ErasedSchema) (observed : Map<int, string>) : Selection = selectWith schema observed None
+
+    /// A positional event's original spelling, for error messages.
+    let describePositionalEvent (event : PositionalEvent) : string =
+        match event.Form with
+        | PositionalForm.Bare -> event.Value
+        | PositionalForm.KeyEquals key -> key + "=" + event.Value
+        | PositionalForm.KeySpaced key -> key + " " + event.Value
+
+    /// Structural resolution: select a case for every Sum *and* route the positional stream,
+    /// given the named observations and the scanned positional events. Pure, and independent
+    /// of conversion by construction: it sees only which named leaves were observed and how
+    /// the positional tokens were spelled.
+    ///
+    /// The rule (mirroring the exhaustive reference semantics): a complete interpretation
+    /// accepts the input iff it contains every observed named leaf, all its required leaves
+    /// were observed, and — when positional tokens exist — it contains a sink which is a
+    /// candidate of every positional event. The parse succeeds exactly when one
+    /// interpretation accepts. Efficiently: intersect the events' candidate sets, and run the
+    /// compositional selector once per candidate sink, with that sink treated as one
+    /// additional observed leaf.
+    ///
+    /// Error reporting prefers the friendliest diagnosis: an interpretation which is unique
+    /// up to missing required arguments is still selected (the missing arguments are reported
+    /// downstream, as for a purely named parse), so positional routing only surfaces in
+    /// errors when it is genuinely the obstacle.
+    let resolve
+        (schema : ErasedSchema)
+        (observed : Map<int, string>)
+        (positionalEvents : PositionalEvent list)
+        : Selection
+        =
+        match positionalEvents, schema.Positionals with
+        | [], _
+        | _, [] -> select schema observed
+        | events, _ ->
+            let candidates =
+                events |> List.map (fun event -> event.Candidates) |> Set.intersectMany
+
+            /// Are all the required named leaves active under this selection observed?
+            let requiredComplete (selection : Selection) : bool =
+                schema.Leaves
+                |> List.forall (fun leaf ->
+                    match leaf.Requirement with
+                    | ErasedRequirement.Required ->
+                        not (Set.contains leaf.Id selection.ActiveLeaves)
+                        || Map.containsKey leaf.Id observed
+                    | ErasedRequirement.Optional
+                    | ErasedRequirement.HasDefault -> true
+                )
+
+            let firstSource = describePositionalEvent (List.head events)
+
+            let hypotheses =
+                schema.Positionals
+                |> List.filter (fun p -> Set.contains p.Id candidates)
+                |> List.map (fun p ->
+                    let witness =
+                        events
+                        |> List.tryFind (fun event -> Set.contains p.Id event.Candidates)
+                        |> Option.map describePositionalEvent
+                        |> Option.defaultValue firstSource
+
+                    p.Id, selectWith schema observed (Some (p.Id, witness))
+                )
+
+            let clean =
+                hypotheses
+                |> List.filter (fun (p, selection) ->
+                    List.isEmpty selection.Errors
+                    && (
+                        match selection.ActivePositional with
+                        | Some active -> active = p
+                        | None -> false
+                    )
+                )
+
+            let fullyValid =
+                clean |> List.filter (fun (_, selection) -> requiredComplete selection)
+
+            let innerAmbiguous =
+                hypotheses
+                |> List.filter (fun (p, selection) ->
+                    not (List.isEmpty selection.Errors)
+                    && (selection.Errors
+                        |> List.forall (fun error ->
+                            match error with
+                            | SelectionError.AmbiguousEmptyCases _ -> true
+                            | _ -> false
+                        ))
+                    && (
+                        match selection.ActivePositional with
+                        | Some active -> active = p
+                        | None -> false
+                    )
+                    && requiredComplete selection
+                )
+
+            let ambiguous (competing : (int * Selection) list) : Selection =
+                {
+                    Choices = Map.empty
+                    ActiveLeaves = Set.empty
+                    ActivePositional = None
+                    Errors =
+                        [
+                            SelectionError.AmbiguousPositionalRouting (
+                                firstSource,
+                                competing |> List.map (fun (p, _) -> p)
+                            )
+                        ]
+                }
+
+            match fullyValid, innerAmbiguous with
+            | [ (_, selection) ], [] -> selection
+            | [], [ (_, selection) ] -> selection
+            | [], [] ->
+                match clean with
+                | [ (_, selection) ] -> selection
+                | clean ->
+                    let selection = select schema observed
+
+                    let unroutable =
+                        { selection with
+                            Errors = selection.Errors @ [ SelectionError.UnroutablePositional firstSource ]
+                        }
+
+                    if Set.isEmpty candidates then
+                        unroutable
+                    elif not (List.isEmpty selection.Errors) then
+                        selection
+                    else
+                        match selection.ActivePositional with
+                        | Some active when events |> List.forall (fun event -> Set.contains active event.Candidates) ->
+                            selection
+                        | _ ->
+                            match clean with
+                            | _ :: _ :: _ -> ambiguous clean
+                            | _ -> unroutable
+            | fullyValid, innerAmbiguous -> ambiguous (fullyValid @ innerAmbiguous)
 
     /// A structural error found after scanning and selection.
     [<RequireQualifiedAccess>]
@@ -1170,6 +1338,27 @@ module private ArgParserRuntime_DuArgs =
                     sprintf
                         "Arguments do not determine which of these alternatives was intended: %s"
                         (String.concat ", " caseNames)
+                    |> errors.Add
+                | SelectionError.UnroutablePositional source ->
+                    sprintf
+                        "Positional argument '%s' does not belong to any single alternative consistent with the other arguments"
+                        source
+                    |> errors.Add
+                | SelectionError.AmbiguousPositionalRouting (source, sinkIds) ->
+                    let describeSink (sinkId : int) : string =
+                        let sink = schema.Positionals |> List.tryFind (fun p -> p.Id = sinkId)
+
+                        match sink with
+                        | Some sink ->
+                            match sink.Forms with
+                            | form :: _ -> "--" + form
+                            | [] -> sprintf "sink %i" sinkId
+                        | None -> sprintf "sink %i" sinkId
+
+                    sprintf
+                        "Positional args (e.g. '%s') could belong to more than one alternative (%s); supply an argument which distinguishes them"
+                        source
+                        (sinkIds |> List.map describeSink |> String.concat ", ")
                     |> errors.Add
 
             for validationError in validationErrors do

--- a/ConsumePlugin/GeneratedOpensLeakRegression.fs
+++ b/ConsumePlugin/GeneratedOpensLeakRegression.fs
@@ -405,7 +405,7 @@ module private ArgParserRuntime_LeakArgs =
 
         go ScanState.AwaitingKey [] args
 
-    /// A failure to choose a unique case for a Sum node.
+    /// A failure to choose a unique case for a Sum node, or to route the positional stream.
     [<RequireQualifiedAccess>]
     type SelectionError =
         /// Occurrences were seen for leaves belonging to two (or more) different cases of one
@@ -417,6 +417,16 @@ module private ArgParserRuntime_LeakArgs =
         /// arguments, so the choice is ambiguous. (A generation-time check normally rejects
         /// schemas where this can happen; this is the runtime safety net.)
         | AmbiguousEmptyCases of sumId : int * caseNames : string list
+        /// Positional tokens were seen, but no positional sink consistent with the named
+        /// arguments can consume them all. `source` is the first positional token, as spelled.
+        | UnroutablePositional of source : string
+        /// The positional stream could be consumed by more than one sink, and nothing else
+        /// distinguishes their alternatives. `source` is the first positional token, as
+        /// spelled; `sinkIds` are the competing sinks. (A generation-time check normally
+        /// rejects schemas where this can happen with bare tokens; this is the runtime safety
+        /// net, and it can also fire for a keyed form shared between otherwise-undistinguished
+        /// alternatives.)
+        | AmbiguousPositionalRouting of source : string * sinkIds : int list
 
     /// The result of case selection: which case index was chosen for each Sum node reachable in
     /// the selected interpretation, and which leaves are *active* (belong to selected cases).
@@ -483,7 +493,16 @@ module private ArgParserRuntime_LeakArgs =
     /// "touched" if any leaf beneath it received an occurrence. Exactly one touched case means
     /// that case is selected; two or more touched cases is a conflict; zero touched cases falls
     /// back to the unique case satisfiable with no arguments.
-    let select (schema : ErasedSchema) (observed : Map<int, string>) : Selection =
+    /// Like `select` below, but a positional-stream hypothesis may be supplied: the sink with
+    /// the given id is treated as one additional observed (optional) leaf, its witness being
+    /// the given source text. This is how the resolver asks "which case would be selected if
+    /// sink p consumed the positional stream?".
+    let private selectWith
+        (schema : ErasedSchema)
+        (observed : Map<int, string>)
+        (positionalWitness : (int * string) option)
+        : Selection
+        =
         let leavesById = schema.Leaves |> List.map (fun leaf -> leaf.Id, leaf) |> Map.ofList
 
         let rec go (tree : ErasedTree) : Map<int, int> * Set<int> * Set<int> * SelectionError list =
@@ -504,6 +523,15 @@ module private ArgParserRuntime_LeakArgs =
                     |> List.choose (fun (i, (name, case)) ->
                         let witness =
                             leafIds case |> List.tryPick (fun leafId -> Map.tryFind leafId observed)
+
+                        let witness =
+                            match witness with
+                            | Some source -> Some source
+                            | None ->
+                                match positionalWitness with
+                                | Some (positionalId, source) when positionalIds case |> List.contains positionalId ->
+                                    Some source
+                                | _ -> None
 
                         match witness with
                         | Some source -> Some (i, name, source)
@@ -549,6 +577,146 @@ module private ArgParserRuntime_LeakArgs =
                         "WoofWare.Myriad internal error: two positional sinks were active at once; the schema was not validated"
             Errors = errors
         }
+
+    let select (schema : ErasedSchema) (observed : Map<int, string>) : Selection = selectWith schema observed None
+
+    /// A positional event's original spelling, for error messages.
+    let describePositionalEvent (event : PositionalEvent) : string =
+        match event.Form with
+        | PositionalForm.Bare -> event.Value
+        | PositionalForm.KeyEquals key -> key + "=" + event.Value
+        | PositionalForm.KeySpaced key -> key + " " + event.Value
+
+    /// Structural resolution: select a case for every Sum *and* route the positional stream,
+    /// given the named observations and the scanned positional events. Pure, and independent
+    /// of conversion by construction: it sees only which named leaves were observed and how
+    /// the positional tokens were spelled.
+    ///
+    /// The rule (mirroring the exhaustive reference semantics): a complete interpretation
+    /// accepts the input iff it contains every observed named leaf, all its required leaves
+    /// were observed, and — when positional tokens exist — it contains a sink which is a
+    /// candidate of every positional event. The parse succeeds exactly when one
+    /// interpretation accepts. Efficiently: intersect the events' candidate sets, and run the
+    /// compositional selector once per candidate sink, with that sink treated as one
+    /// additional observed leaf.
+    ///
+    /// Error reporting prefers the friendliest diagnosis: an interpretation which is unique
+    /// up to missing required arguments is still selected (the missing arguments are reported
+    /// downstream, as for a purely named parse), so positional routing only surfaces in
+    /// errors when it is genuinely the obstacle.
+    let resolve
+        (schema : ErasedSchema)
+        (observed : Map<int, string>)
+        (positionalEvents : PositionalEvent list)
+        : Selection
+        =
+        match positionalEvents, schema.Positionals with
+        | [], _
+        | _, [] -> select schema observed
+        | events, _ ->
+            let candidates =
+                events |> List.map (fun event -> event.Candidates) |> Set.intersectMany
+
+            /// Are all the required named leaves active under this selection observed?
+            let requiredComplete (selection : Selection) : bool =
+                schema.Leaves
+                |> List.forall (fun leaf ->
+                    match leaf.Requirement with
+                    | ErasedRequirement.Required ->
+                        not (Set.contains leaf.Id selection.ActiveLeaves)
+                        || Map.containsKey leaf.Id observed
+                    | ErasedRequirement.Optional
+                    | ErasedRequirement.HasDefault -> true
+                )
+
+            let firstSource = describePositionalEvent (List.head events)
+
+            let hypotheses =
+                schema.Positionals
+                |> List.filter (fun p -> Set.contains p.Id candidates)
+                |> List.map (fun p ->
+                    let witness =
+                        events
+                        |> List.tryFind (fun event -> Set.contains p.Id event.Candidates)
+                        |> Option.map describePositionalEvent
+                        |> Option.defaultValue firstSource
+
+                    p.Id, selectWith schema observed (Some (p.Id, witness))
+                )
+
+            let clean =
+                hypotheses
+                |> List.filter (fun (p, selection) ->
+                    List.isEmpty selection.Errors
+                    && (
+                        match selection.ActivePositional with
+                        | Some active -> active = p
+                        | None -> false
+                    )
+                )
+
+            let fullyValid =
+                clean |> List.filter (fun (_, selection) -> requiredComplete selection)
+
+            let innerAmbiguous =
+                hypotheses
+                |> List.filter (fun (p, selection) ->
+                    not (List.isEmpty selection.Errors)
+                    && (selection.Errors
+                        |> List.forall (fun error ->
+                            match error with
+                            | SelectionError.AmbiguousEmptyCases _ -> true
+                            | _ -> false
+                        ))
+                    && (
+                        match selection.ActivePositional with
+                        | Some active -> active = p
+                        | None -> false
+                    )
+                    && requiredComplete selection
+                )
+
+            let ambiguous (competing : (int * Selection) list) : Selection =
+                {
+                    Choices = Map.empty
+                    ActiveLeaves = Set.empty
+                    ActivePositional = None
+                    Errors =
+                        [
+                            SelectionError.AmbiguousPositionalRouting (
+                                firstSource,
+                                competing |> List.map (fun (p, _) -> p)
+                            )
+                        ]
+                }
+
+            match fullyValid, innerAmbiguous with
+            | [ (_, selection) ], [] -> selection
+            | [], [ (_, selection) ] -> selection
+            | [], [] ->
+                match clean with
+                | [ (_, selection) ] -> selection
+                | clean ->
+                    let selection = select schema observed
+
+                    let unroutable =
+                        { selection with
+                            Errors = selection.Errors @ [ SelectionError.UnroutablePositional firstSource ]
+                        }
+
+                    if Set.isEmpty candidates then
+                        unroutable
+                    elif not (List.isEmpty selection.Errors) then
+                        selection
+                    else
+                        match selection.ActivePositional with
+                        | Some active when events |> List.forall (fun event -> Set.contains active event.Candidates) ->
+                            selection
+                        | _ ->
+                            match clean with
+                            | _ :: _ :: _ -> ambiguous clean
+                            | _ -> unroutable
+            | fullyValid, innerAmbiguous -> ambiguous (fullyValid @ innerAmbiguous)
 
     /// A structural error found after scanning and selection.
     [<RequireQualifiedAccess>]
@@ -1170,6 +1338,27 @@ module private ArgParserRuntime_LeakArgs =
                     sprintf
                         "Arguments do not determine which of these alternatives was intended: %s"
                         (String.concat ", " caseNames)
+                    |> errors.Add
+                | SelectionError.UnroutablePositional source ->
+                    sprintf
+                        "Positional argument '%s' does not belong to any single alternative consistent with the other arguments"
+                        source
+                    |> errors.Add
+                | SelectionError.AmbiguousPositionalRouting (source, sinkIds) ->
+                    let describeSink (sinkId : int) : string =
+                        let sink = schema.Positionals |> List.tryFind (fun p -> p.Id = sinkId)
+
+                        match sink with
+                        | Some sink ->
+                            match sink.Forms with
+                            | form :: _ -> "--" + form
+                            | [] -> sprintf "sink %i" sinkId
+                        | None -> sprintf "sink %i" sinkId
+
+                    sprintf
+                        "Positional args (e.g. '%s') could belong to more than one alternative (%s); supply an argument which distinguishes them"
+                        source
+                        (sinkIds |> List.map describeSink |> String.concat ", ")
                     |> errors.Add
 
             for validationError in validationErrors do

--- a/ConsumePlugin/Nested/GeneratedArgs.fs
+++ b/ConsumePlugin/Nested/GeneratedArgs.fs
@@ -405,7 +405,7 @@ module private ArgParserRuntime_SameBaseNameArgs =
 
         go ScanState.AwaitingKey [] args
 
-    /// A failure to choose a unique case for a Sum node.
+    /// A failure to choose a unique case for a Sum node, or to route the positional stream.
     [<RequireQualifiedAccess>]
     type SelectionError =
         /// Occurrences were seen for leaves belonging to two (or more) different cases of one
@@ -417,6 +417,16 @@ module private ArgParserRuntime_SameBaseNameArgs =
         /// arguments, so the choice is ambiguous. (A generation-time check normally rejects
         /// schemas where this can happen; this is the runtime safety net.)
         | AmbiguousEmptyCases of sumId : int * caseNames : string list
+        /// Positional tokens were seen, but no positional sink consistent with the named
+        /// arguments can consume them all. `source` is the first positional token, as spelled.
+        | UnroutablePositional of source : string
+        /// The positional stream could be consumed by more than one sink, and nothing else
+        /// distinguishes their alternatives. `source` is the first positional token, as
+        /// spelled; `sinkIds` are the competing sinks. (A generation-time check normally
+        /// rejects schemas where this can happen with bare tokens; this is the runtime safety
+        /// net, and it can also fire for a keyed form shared between otherwise-undistinguished
+        /// alternatives.)
+        | AmbiguousPositionalRouting of source : string * sinkIds : int list
 
     /// The result of case selection: which case index was chosen for each Sum node reachable in
     /// the selected interpretation, and which leaves are *active* (belong to selected cases).
@@ -483,7 +493,16 @@ module private ArgParserRuntime_SameBaseNameArgs =
     /// "touched" if any leaf beneath it received an occurrence. Exactly one touched case means
     /// that case is selected; two or more touched cases is a conflict; zero touched cases falls
     /// back to the unique case satisfiable with no arguments.
-    let select (schema : ErasedSchema) (observed : Map<int, string>) : Selection =
+    /// Like `select` below, but a positional-stream hypothesis may be supplied: the sink with
+    /// the given id is treated as one additional observed (optional) leaf, its witness being
+    /// the given source text. This is how the resolver asks "which case would be selected if
+    /// sink p consumed the positional stream?".
+    let private selectWith
+        (schema : ErasedSchema)
+        (observed : Map<int, string>)
+        (positionalWitness : (int * string) option)
+        : Selection
+        =
         let leavesById = schema.Leaves |> List.map (fun leaf -> leaf.Id, leaf) |> Map.ofList
 
         let rec go (tree : ErasedTree) : Map<int, int> * Set<int> * Set<int> * SelectionError list =
@@ -504,6 +523,15 @@ module private ArgParserRuntime_SameBaseNameArgs =
                     |> List.choose (fun (i, (name, case)) ->
                         let witness =
                             leafIds case |> List.tryPick (fun leafId -> Map.tryFind leafId observed)
+
+                        let witness =
+                            match witness with
+                            | Some source -> Some source
+                            | None ->
+                                match positionalWitness with
+                                | Some (positionalId, source) when positionalIds case |> List.contains positionalId ->
+                                    Some source
+                                | _ -> None
 
                         match witness with
                         | Some source -> Some (i, name, source)
@@ -549,6 +577,146 @@ module private ArgParserRuntime_SameBaseNameArgs =
                         "WoofWare.Myriad internal error: two positional sinks were active at once; the schema was not validated"
             Errors = errors
         }
+
+    let select (schema : ErasedSchema) (observed : Map<int, string>) : Selection = selectWith schema observed None
+
+    /// A positional event's original spelling, for error messages.
+    let describePositionalEvent (event : PositionalEvent) : string =
+        match event.Form with
+        | PositionalForm.Bare -> event.Value
+        | PositionalForm.KeyEquals key -> key + "=" + event.Value
+        | PositionalForm.KeySpaced key -> key + " " + event.Value
+
+    /// Structural resolution: select a case for every Sum *and* route the positional stream,
+    /// given the named observations and the scanned positional events. Pure, and independent
+    /// of conversion by construction: it sees only which named leaves were observed and how
+    /// the positional tokens were spelled.
+    ///
+    /// The rule (mirroring the exhaustive reference semantics): a complete interpretation
+    /// accepts the input iff it contains every observed named leaf, all its required leaves
+    /// were observed, and — when positional tokens exist — it contains a sink which is a
+    /// candidate of every positional event. The parse succeeds exactly when one
+    /// interpretation accepts. Efficiently: intersect the events' candidate sets, and run the
+    /// compositional selector once per candidate sink, with that sink treated as one
+    /// additional observed leaf.
+    ///
+    /// Error reporting prefers the friendliest diagnosis: an interpretation which is unique
+    /// up to missing required arguments is still selected (the missing arguments are reported
+    /// downstream, as for a purely named parse), so positional routing only surfaces in
+    /// errors when it is genuinely the obstacle.
+    let resolve
+        (schema : ErasedSchema)
+        (observed : Map<int, string>)
+        (positionalEvents : PositionalEvent list)
+        : Selection
+        =
+        match positionalEvents, schema.Positionals with
+        | [], _
+        | _, [] -> select schema observed
+        | events, _ ->
+            let candidates =
+                events |> List.map (fun event -> event.Candidates) |> Set.intersectMany
+
+            /// Are all the required named leaves active under this selection observed?
+            let requiredComplete (selection : Selection) : bool =
+                schema.Leaves
+                |> List.forall (fun leaf ->
+                    match leaf.Requirement with
+                    | ErasedRequirement.Required ->
+                        not (Set.contains leaf.Id selection.ActiveLeaves)
+                        || Map.containsKey leaf.Id observed
+                    | ErasedRequirement.Optional
+                    | ErasedRequirement.HasDefault -> true
+                )
+
+            let firstSource = describePositionalEvent (List.head events)
+
+            let hypotheses =
+                schema.Positionals
+                |> List.filter (fun p -> Set.contains p.Id candidates)
+                |> List.map (fun p ->
+                    let witness =
+                        events
+                        |> List.tryFind (fun event -> Set.contains p.Id event.Candidates)
+                        |> Option.map describePositionalEvent
+                        |> Option.defaultValue firstSource
+
+                    p.Id, selectWith schema observed (Some (p.Id, witness))
+                )
+
+            let clean =
+                hypotheses
+                |> List.filter (fun (p, selection) ->
+                    List.isEmpty selection.Errors
+                    && (
+                        match selection.ActivePositional with
+                        | Some active -> active = p
+                        | None -> false
+                    )
+                )
+
+            let fullyValid =
+                clean |> List.filter (fun (_, selection) -> requiredComplete selection)
+
+            let innerAmbiguous =
+                hypotheses
+                |> List.filter (fun (p, selection) ->
+                    not (List.isEmpty selection.Errors)
+                    && (selection.Errors
+                        |> List.forall (fun error ->
+                            match error with
+                            | SelectionError.AmbiguousEmptyCases _ -> true
+                            | _ -> false
+                        ))
+                    && (
+                        match selection.ActivePositional with
+                        | Some active -> active = p
+                        | None -> false
+                    )
+                    && requiredComplete selection
+                )
+
+            let ambiguous (competing : (int * Selection) list) : Selection =
+                {
+                    Choices = Map.empty
+                    ActiveLeaves = Set.empty
+                    ActivePositional = None
+                    Errors =
+                        [
+                            SelectionError.AmbiguousPositionalRouting (
+                                firstSource,
+                                competing |> List.map (fun (p, _) -> p)
+                            )
+                        ]
+                }
+
+            match fullyValid, innerAmbiguous with
+            | [ (_, selection) ], [] -> selection
+            | [], [ (_, selection) ] -> selection
+            | [], [] ->
+                match clean with
+                | [ (_, selection) ] -> selection
+                | clean ->
+                    let selection = select schema observed
+
+                    let unroutable =
+                        { selection with
+                            Errors = selection.Errors @ [ SelectionError.UnroutablePositional firstSource ]
+                        }
+
+                    if Set.isEmpty candidates then
+                        unroutable
+                    elif not (List.isEmpty selection.Errors) then
+                        selection
+                    else
+                        match selection.ActivePositional with
+                        | Some active when events |> List.forall (fun event -> Set.contains active event.Candidates) ->
+                            selection
+                        | _ ->
+                            match clean with
+                            | _ :: _ :: _ -> ambiguous clean
+                            | _ -> unroutable
+            | fullyValid, innerAmbiguous -> ambiguous (fullyValid @ innerAmbiguous)
 
     /// A structural error found after scanning and selection.
     [<RequireQualifiedAccess>]
@@ -1170,6 +1338,27 @@ module private ArgParserRuntime_SameBaseNameArgs =
                     sprintf
                         "Arguments do not determine which of these alternatives was intended: %s"
                         (String.concat ", " caseNames)
+                    |> errors.Add
+                | SelectionError.UnroutablePositional source ->
+                    sprintf
+                        "Positional argument '%s' does not belong to any single alternative consistent with the other arguments"
+                        source
+                    |> errors.Add
+                | SelectionError.AmbiguousPositionalRouting (source, sinkIds) ->
+                    let describeSink (sinkId : int) : string =
+                        let sink = schema.Positionals |> List.tryFind (fun p -> p.Id = sinkId)
+
+                        match sink with
+                        | Some sink ->
+                            match sink.Forms with
+                            | form :: _ -> "--" + form
+                            | [] -> sprintf "sink %i" sinkId
+                        | None -> sprintf "sink %i" sinkId
+
+                    sprintf
+                        "Positional args (e.g. '%s') could belong to more than one alternative (%s); supply an argument which distinguishes them"
+                        source
+                        (sinkIds |> List.map describeSink |> String.concat ", ")
                     |> errors.Add
 
             for validationError in validationErrors do

--- a/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParserRuntime.fs
+++ b/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParserRuntime.fs
@@ -1986,3 +1986,283 @@ module TestArgParserRuntime =
         Check.One (config, Prop.forAll (Arb.fromGen cases) property)
 
         positionalEvents |> shouldBeGreaterThan 1000
+
+    // ----------------------------------------------------------------------------------------
+    // The resolver: structural resolution of named observations *and* positional routing.
+    // Its definition is the exhaustive reference semantics; the property at the end pins the
+    // equivalence.
+
+    module Ref = TestArgParserPositionalReference
+
+    let rec private refToErasedTree (tree : Ref.RefTree) : ErasedTree =
+        match tree with
+        | Ref.RefTree.Named leaf -> ErasedTree.Leaf leaf.Id
+        | Ref.RefTree.Positional p -> ErasedTree.PositionalLeaf p.Id
+        | Ref.RefTree.Product children -> ErasedTree.Product (children |> List.map refToErasedTree)
+        | Ref.RefTree.Sum (sumId, cases) ->
+            ErasedTree.Sum (sumId, cases |> List.map (fun (name, case) -> name, refToErasedTree case))
+
+    let rec private refNamedLeaves (tree : Ref.RefTree) : Ref.RefNamedLeaf list =
+        match tree with
+        | Ref.RefTree.Named leaf -> [ leaf ]
+        | Ref.RefTree.Positional _ -> []
+        | Ref.RefTree.Product children -> children |> List.collect refNamedLeaves
+        | Ref.RefTree.Sum (_, cases) -> cases |> List.collect (fun (_, case) -> refNamedLeaves case)
+
+    let private toErasedSchema (tree : Ref.RefTree) : ErasedSchema =
+        {
+            Leaves =
+                refNamedLeaves tree
+                |> List.map (fun namedLeaf ->
+                    { leaf namedLeaf.Id (sprintf "arg%i" namedLeaf.Id) ErasedArity.One ErasedRequirement.Required with
+                        Requirement =
+                            match namedLeaf.Requirement with
+                            | Ref.RefRequirement.Required -> ErasedRequirement.Required
+                            | Ref.RefRequirement.Optional -> ErasedRequirement.Optional
+                    }
+                )
+            Tree = refToErasedTree tree
+            Positionals =
+                Ref.positionalLeaves tree
+                |> List.map (fun p -> sink' p.Id p.Forms ErasedFlagLikeBehaviour.Reject)
+        }
+
+    let private toPositionalEvent (sinks : Ref.RefPositionalLeaf list) (spelling : Ref.RefSpelling) : PositionalEvent =
+        {
+            Value = "v"
+            AfterSeparator = false
+            Form =
+                match spelling with
+                | Ref.RefSpelling.Bare -> PositionalForm.Bare
+                | Ref.RefSpelling.Keyed form -> PositionalForm.KeyEquals ("--" + form)
+            Candidates = Ref.candidates sinks spelling
+        }
+
+    /// Scan real argv and feed the resolver, as the orchestrator will.
+    let private resolveArgs (schema : ErasedSchema) (args : string list) : Selection =
+        let events = scan schema args
+
+        let observed =
+            (Map.empty, events)
+            ||> List.fold (fun observed event ->
+                match event with
+                | ScanEvent.Occurrence occurrence ->
+                    if Map.containsKey occurrence.LeafId observed then
+                        observed
+                    else
+                        Map.add occurrence.LeafId occurrence.Source observed
+                | _ -> observed
+            )
+
+        let positionals =
+            events
+            |> List.choose (fun event ->
+                match event with
+                | ScanEvent.Positional positional -> Some positional
+                | _ -> None
+            )
+
+        resolve schema observed positionals
+
+    /// (A × P) + (B × Q): the canonical per-case-sink schema.
+    let private perCaseSinks
+        (aReq : ErasedRequirement)
+        (bReq : ErasedRequirement)
+        (pForms : string list)
+        (qForms : string list)
+        : ErasedSchema
+        =
+        {
+            Leaves = [ leaf 0 "foo" ErasedArity.One aReq ; leaf 1 "bar" ErasedArity.One bReq ]
+            Tree =
+                ErasedTree.Sum (
+                    0,
+                    [
+                        "A", ErasedTree.Product [ ErasedTree.Leaf 0 ; ErasedTree.PositionalLeaf 10 ]
+                        "B", ErasedTree.Product [ ErasedTree.Leaf 1 ; ErasedTree.PositionalLeaf 11 ]
+                    ]
+                )
+            Positionals =
+                [
+                    sink' 10 pForms ErasedFlagLikeBehaviour.Reject
+                    sink' 11 qForms ErasedFlagLikeBehaviour.Reject
+                ]
+        }
+
+    [<Test>]
+    let ``Resolver: a named discriminator routes the stream to its case's sink`` () =
+        let schema =
+            perCaseSinks ErasedRequirement.Required ErasedRequirement.Required [ "rest" ] [ "rest" ]
+
+        let selection = resolveArgs schema [ "--foo=1" ; "2" ; "3" ]
+        selection.Errors |> shouldEqual []
+        selection.Choices |> shouldEqual (Map.ofList [ 0, 0 ])
+        selection.ActivePositional |> shouldEqual (Some 10)
+
+        let selection = resolveArgs schema [ "--bar=1" ; "--rest=2" ]
+        selection.Errors |> shouldEqual []
+        selection.Choices |> shouldEqual (Map.ofList [ 0, 1 ])
+        selection.ActivePositional |> shouldEqual (Some 11)
+
+    [<Test>]
+    let ``Resolver: bare tokens alone fall back to the named-only diagnosis`` () =
+        // The plan's example: `2 3` selects nothing, in the friendliest vocabulary available.
+        let schema =
+            perCaseSinks ErasedRequirement.Required ErasedRequirement.Required [ "rest" ] [ "rest" ]
+
+        let selection = resolveArgs schema [ "2" ; "3" ]
+
+        selection.Errors
+        |> shouldEqual [ SelectionError.NoCaseSelected (0, [ "A" ; "B" ]) ]
+
+    [<Test>]
+    let ``Resolver: a keyed form unique to one alternative is a structural discriminator`` () =
+        let schema =
+            perCaseSinks ErasedRequirement.Optional ErasedRequirement.Required [ "files" ] [ "nums" ]
+
+        let selection = resolveArgs schema [ "--files=x" ]
+        selection.Errors |> shouldEqual []
+        selection.Choices |> shouldEqual (Map.ofList [ 0, 0 ])
+        selection.ActivePositional |> shouldEqual (Some 10)
+
+    [<Test>]
+    let ``Resolver: a keyed form of an unselected alternative is unroutable`` () =
+        let schema =
+            perCaseSinks ErasedRequirement.Required ErasedRequirement.Required [ "files" ] [ "nums" ]
+
+        let selection = resolveArgs schema [ "--foo=1" ; "--nums=4" ]
+
+        selection.Errors
+        |> shouldEqual [ SelectionError.UnroutablePositional "--nums=4" ]
+
+        // Two keyed forms which no single sink claims are likewise unroutable; the routing
+        // contradiction is reported alongside the named-only diagnosis.
+        let selection = resolveArgs schema [ "--files=3" ; "--nums=4" ]
+
+        selection.Errors
+        |> shouldEqual
+            [
+                SelectionError.NoCaseSelected (0, [ "A" ; "B" ])
+                SelectionError.UnroutablePositional "--files=3"
+            ]
+
+    [<Test>]
+    let ``Resolver: a shared keyed form between indistinguishable alternatives is ambiguous`` () =
+        // Both cases are satisfiable with no arguments, so this schema would already be
+        // rejected at generation time; the resolver's runtime safety net still reports the
+        // ambiguity rather than picking a case silently.
+        let schema =
+            perCaseSinks ErasedRequirement.Optional ErasedRequirement.Optional [ "rest" ] [ "rest" ]
+
+        let selection = resolveArgs schema [ "--rest=4" ]
+
+        selection.Errors
+        |> shouldEqual [ SelectionError.AmbiguousPositionalRouting ("--rest=4", [ 10 ; 11 ]) ]
+
+    [<Test>]
+    let ``Resolver: missing required arguments do not disturb unique routing`` () =
+        // B is pinned by its keyed form; its missing required argument is reported through
+        // the ordinary channel (validation), not as a routing failure.
+        let schema =
+            perCaseSinks ErasedRequirement.Required ErasedRequirement.Required [ "files" ] [ "nums" ]
+
+        let selection = resolveArgs schema [ "--nums=4" ]
+        selection.Errors |> shouldEqual []
+        selection.Choices |> shouldEqual (Map.ofList [ 0, 1 ])
+        selection.ActivePositional |> shouldEqual (Some 11)
+
+    [<Test>]
+    let ``The resolver is equivalent to the exhaustive reference semantics`` () =
+        let mutable uniqueCount = 0
+        let mutable rejectedCount = 0
+        let mutable ambiguousCount = 0
+        let mutable withEvents = 0
+
+        let cases =
+            gen {
+                let! sumBias = Gen.elements [ 20 ; 50 ; 80 ]
+                let! tree = Ref.genTree sumBias
+                let! dropPct = Gen.elements [ 0 ; 0 ; 20 ]
+                let! optionalPct = Gen.elements [ 0 ; 50 ; 100 ]
+                let! noisePct = Gen.elements [ 0 ; 10 ; 40 ]
+                let! input = Ref.genInput dropPct optionalPct noisePct tree
+                return tree, input
+            }
+
+        let property (tree : Ref.RefTree, input : Ref.RefInput) : unit =
+            let schema = toErasedSchema tree
+            let sinks = Ref.positionalLeaves tree
+
+            let observed =
+                input.ObservedNamed
+                |> Set.toList
+                |> List.map (fun id -> id, sprintf "--arg%i" id)
+                |> Map.ofList
+
+            let events = input.PositionalEvents |> List.map (toPositionalEvent sinks)
+
+            if not (List.isEmpty events) then
+                withEvents <- withEvents + 1
+
+            let selection = resolve schema observed events
+
+            // Feed the selection through validation with a synthetic event log (one
+            // occurrence per observed leaf, plus the positional events), to surface
+            // missing-required and no-sink errors exactly as the orchestrator will.
+            let syntheticEvents =
+                (observed
+                 |> Map.toList
+                 |> List.map (fun (id, source) ->
+                     ScanEvent.Occurrence
+                         {
+                             LeafId = id
+                             Value = Some "v"
+                             Negated = false
+                             Source = source
+                         }
+                 ))
+                @ (events |> List.map ScanEvent.Positional)
+
+            let validationErrors, _ = validate schema selection syntheticEvents
+
+            let accepts = List.isEmpty selection.Errors && List.isEmpty validationErrors
+
+            match Ref.exhaustiveSelect tree input with
+            | Ref.RefOutcome.Unique interp ->
+                uniqueCount <- uniqueCount + 1
+                accepts |> shouldEqual true
+                selection.Choices |> shouldEqual interp.Choices
+                selection.ActiveLeaves |> shouldEqual interp.Named
+
+                selection.ActivePositional
+                |> shouldEqual (
+                    match Set.toList interp.Positionals with
+                    | [] -> None
+                    | [ p ] -> Some p
+                    | _ -> failwith "reference interpretation held two sinks"
+                )
+            | Ref.RefOutcome.NoInterpretation ->
+                rejectedCount <- rejectedCount + 1
+                accepts |> shouldEqual false
+            | Ref.RefOutcome.Ambiguous _ ->
+                ambiguousCount <- ambiguousCount + 1
+                accepts |> shouldEqual false
+
+                // Ambiguity must be reported as such, through one channel or the other.
+                selection.Errors
+                |> List.exists (fun error ->
+                    match error with
+                    | SelectionError.AmbiguousEmptyCases _ -> true
+                    | SelectionError.AmbiguousPositionalRouting _ -> true
+                    | _ -> false
+                )
+                |> shouldEqual true
+
+        let config = Config.QuickThrowOnFailure.WithMaxTest 3000
+        Check.One (config, Prop.forAll (Arb.fromGen cases) property)
+
+        // The generator must explore all the regimes, or this test is not testing anything.
+        uniqueCount |> shouldBeGreaterThan 300
+        rejectedCount |> shouldBeGreaterThan 200
+        ambiguousCount |> shouldBeGreaterThan 20
+        withEvents |> shouldBeGreaterThan 500

--- a/WoofWare.Myriad.Plugins/ArgParserRuntime.fs
+++ b/WoofWare.Myriad.Plugins/ArgParserRuntime.fs
@@ -421,7 +421,7 @@ module internal ArgParserRuntime =
 
         go ScanState.AwaitingKey [] args
 
-    /// A failure to choose a unique case for a Sum node.
+    /// A failure to choose a unique case for a Sum node, or to route the positional stream.
     [<RequireQualifiedAccess>]
     type SelectionError =
         /// Occurrences were seen for leaves belonging to two (or more) different cases of one
@@ -433,6 +433,16 @@ module internal ArgParserRuntime =
         /// arguments, so the choice is ambiguous. (A generation-time check normally rejects
         /// schemas where this can happen; this is the runtime safety net.)
         | AmbiguousEmptyCases of sumId : int * caseNames : string list
+        /// Positional tokens were seen, but no positional sink consistent with the named
+        /// arguments can consume them all. `source` is the first positional token, as spelled.
+        | UnroutablePositional of source : string
+        /// The positional stream could be consumed by more than one sink, and nothing else
+        /// distinguishes their alternatives. `source` is the first positional token, as
+        /// spelled; `sinkIds` are the competing sinks. (A generation-time check normally
+        /// rejects schemas where this can happen with bare tokens; this is the runtime safety
+        /// net, and it can also fire for a keyed form shared between otherwise-undistinguished
+        /// alternatives.)
+        | AmbiguousPositionalRouting of source : string * sinkIds : int list
 
     /// The result of case selection: which case index was chosen for each Sum node reachable in
     /// the selected interpretation, and which leaves are *active* (belong to selected cases).
@@ -499,7 +509,16 @@ module internal ArgParserRuntime =
     /// "touched" if any leaf beneath it received an occurrence. Exactly one touched case means
     /// that case is selected; two or more touched cases is a conflict; zero touched cases falls
     /// back to the unique case satisfiable with no arguments.
-    let select (schema : ErasedSchema) (observed : Map<int, string>) : Selection =
+    /// Like `select` below, but a positional-stream hypothesis may be supplied: the sink with
+    /// the given id is treated as one additional observed (optional) leaf, its witness being
+    /// the given source text. This is how the resolver asks "which case would be selected if
+    /// sink p consumed the positional stream?".
+    let private selectWith
+        (schema : ErasedSchema)
+        (observed : Map<int, string>)
+        (positionalWitness : (int * string) option)
+        : Selection
+        =
         let leavesById = schema.Leaves |> List.map (fun leaf -> leaf.Id, leaf) |> Map.ofList
 
         let rec go (tree : ErasedTree) : Map<int, int> * Set<int> * Set<int> * SelectionError list =
@@ -522,6 +541,15 @@ module internal ArgParserRuntime =
                     |> List.choose (fun (i, (name, case)) ->
                         let witness =
                             leafIds case |> List.tryPick (fun leafId -> Map.tryFind leafId observed)
+
+                        let witness =
+                            match witness with
+                            | Some source -> Some source
+                            | None ->
+                                match positionalWitness with
+                                | Some (positionalId, source) when positionalIds case |> List.contains positionalId ->
+                                    Some source
+                                | _ -> None
 
                         match witness with
                         | Some source -> Some (i, name, source)
@@ -568,6 +596,175 @@ module internal ArgParserRuntime =
                         "WoofWare.Myriad internal error: two positional sinks were active at once; the schema was not validated"
             Errors = errors
         }
+
+    let select (schema : ErasedSchema) (observed : Map<int, string>) : Selection = selectWith schema observed None
+
+    /// A positional event's original spelling, for error messages.
+    let describePositionalEvent (event : PositionalEvent) : string =
+        match event.Form with
+        | PositionalForm.Bare -> event.Value
+        | PositionalForm.KeyEquals key -> key + "=" + event.Value
+        | PositionalForm.KeySpaced key -> key + " " + event.Value
+
+    /// Structural resolution: select a case for every Sum *and* route the positional stream,
+    /// given the named observations and the scanned positional events. Pure, and independent
+    /// of conversion by construction: it sees only which named leaves were observed and how
+    /// the positional tokens were spelled.
+    ///
+    /// The rule (mirroring the exhaustive reference semantics): a complete interpretation
+    /// accepts the input iff it contains every observed named leaf, all its required leaves
+    /// were observed, and — when positional tokens exist — it contains a sink which is a
+    /// candidate of every positional event. The parse succeeds exactly when one
+    /// interpretation accepts. Efficiently: intersect the events' candidate sets, and run the
+    /// compositional selector once per candidate sink, with that sink treated as one
+    /// additional observed leaf.
+    ///
+    /// Error reporting prefers the friendliest diagnosis: an interpretation which is unique
+    /// up to missing required arguments is still selected (the missing arguments are reported
+    /// downstream, as for a purely named parse), so positional routing only surfaces in
+    /// errors when it is genuinely the obstacle.
+    let resolve
+        (schema : ErasedSchema)
+        (observed : Map<int, string>)
+        (positionalEvents : PositionalEvent list)
+        : Selection
+        =
+        match positionalEvents, schema.Positionals with
+        | [], _
+        | _, [] ->
+            // No positional tokens (the sink of the selected interpretation, if any, simply
+            // receives an empty stream), or no sinks at all (validation reports the leftover
+            // tokens wholesale, as ever).
+            select schema observed
+        | events, _ ->
+
+        let candidates =
+            events |> List.map (fun event -> event.Candidates) |> Set.intersectMany
+
+        /// Are all the required named leaves active under this selection observed?
+        let requiredComplete (selection : Selection) : bool =
+            schema.Leaves
+            |> List.forall (fun leaf ->
+                match leaf.Requirement with
+                | ErasedRequirement.Required ->
+                    not (Set.contains leaf.Id selection.ActiveLeaves)
+                    || Map.containsKey leaf.Id observed
+                | ErasedRequirement.Optional
+                | ErasedRequirement.HasDefault -> true
+            )
+
+        let firstSource = describePositionalEvent (List.head events)
+
+        // One hypothesis per sink which could consume every positional token, in sink
+        // declaration order. The witness text shown for a positional-driven case selection is
+        // the first event this sink could consume.
+        let hypotheses =
+            schema.Positionals
+            |> List.filter (fun p -> Set.contains p.Id candidates)
+            |> List.map (fun p ->
+                let witness =
+                    events
+                    |> List.tryFind (fun event -> Set.contains p.Id event.Candidates)
+                    |> Option.map describePositionalEvent
+                    |> Option.defaultValue firstSource
+
+                p.Id, selectWith schema observed (Some (p.Id, witness))
+            )
+
+        // A hypothesis is clean when the selector found no error and the hypothesised sink
+        // really is the selected interpretation's sink; it fully accepts when moreover no
+        // required named argument is missing.
+        let clean =
+            hypotheses
+            |> List.filter (fun (p, selection) ->
+                List.isEmpty selection.Errors
+                && (
+                    match selection.ActivePositional with
+                    | Some active -> active = p
+                    | None -> false
+                )
+            )
+
+        let fullyValid =
+            clean |> List.filter (fun (_, selection) -> requiredComplete selection)
+
+        // A hypothesis whose only defect is an untouched sum with several empty-satisfiable
+        // cases stands for *several* complete interpretations, every one of which accepts:
+        // the input is ambiguous through this sink alone. (Distinct from a conflict, which
+        // means no interpretation through this sink accepts at all.)
+        let innerAmbiguous =
+            hypotheses
+            |> List.filter (fun (p, selection) ->
+                not (List.isEmpty selection.Errors)
+                && (selection.Errors
+                    |> List.forall (fun error ->
+                        match error with
+                        | SelectionError.AmbiguousEmptyCases _ -> true
+                        | _ -> false
+                    ))
+                && (
+                    match selection.ActivePositional with
+                    | Some active -> active = p
+                    | None -> false
+                )
+                && requiredComplete selection
+            )
+
+        let ambiguous (competing : (int * Selection) list) : Selection =
+            {
+                Choices = Map.empty
+                ActiveLeaves = Set.empty
+                ActivePositional = None
+                Errors =
+                    [
+                        SelectionError.AmbiguousPositionalRouting (firstSource, competing |> List.map (fun (p, _) -> p))
+                    ]
+            }
+
+        match fullyValid, innerAmbiguous with
+        | [ (_, selection) ], [] -> selection
+        // A single sink can consume the stream, but several interpretations through it
+        // accept: its own ambiguity errors are the honest story.
+        | [], [ (_, selection) ] -> selection
+        | [], [] ->
+            match clean with
+            // Unique up to missing required arguments: select it, and let validation report
+            // the missing arguments in the ordinary way.
+            | [ (_, selection) ] -> selection
+            | clean ->
+                // Zero viable hypotheses (no sink can consume the stream consistently with
+                // the named arguments), or several, all missing required arguments. Diagnose
+                // from the named-only selection: its errors (no case selected, ambiguous
+                // empty cases, conflicts) are the friendliest story; the routing
+                // contradiction is added when the events share no candidate at all.
+                let selection = select schema observed
+
+                let unroutable =
+                    { selection with
+                        Errors = selection.Errors @ [ SelectionError.UnroutablePositional firstSource ]
+                    }
+
+                if Set.isEmpty candidates then
+                    unroutable
+                elif not (List.isEmpty selection.Errors) then
+                    selection
+                else
+                    match selection.ActivePositional with
+                    | Some active when events |> List.forall (fun event -> Set.contains active event.Candidates) ->
+                        // Defensive: a routable named-only selection should have appeared as
+                        // a clean hypothesis.
+                        selection
+                    | _ ->
+                        match clean with
+                        | _ :: _ :: _ ->
+                            // Defensive: a clean named-only selection should have made at
+                            // most one hypothesis clean.
+                            ambiguous clean
+                        | _ -> unroutable
+        | fullyValid, innerAmbiguous ->
+            // Several sinks could each consume the whole stream: genuinely ambiguous
+            // routing.
+            ambiguous (fullyValid @ innerAmbiguous)
 
     /// A structural error found after scanning and selection.
     [<RequireQualifiedAccess>]
@@ -1200,6 +1397,27 @@ module internal ArgParserRuntime =
                 sprintf
                     "Arguments do not determine which of these alternatives was intended: %s"
                     (String.concat ", " caseNames)
+                |> errors.Add
+            | SelectionError.UnroutablePositional source ->
+                sprintf
+                    "Positional argument '%s' does not belong to any single alternative consistent with the other arguments"
+                    source
+                |> errors.Add
+            | SelectionError.AmbiguousPositionalRouting (source, sinkIds) ->
+                let describeSink (sinkId : int) : string =
+                    let sink = schema.Positionals |> List.tryFind (fun p -> p.Id = sinkId)
+
+                    match sink with
+                    | Some sink ->
+                        match sink.Forms with
+                        | form :: _ -> "--" + form
+                        | [] -> sprintf "sink %i" sinkId
+                    | None -> sprintf "sink %i" sinkId
+
+                sprintf
+                    "Positional args (e.g. '%s') could belong to more than one alternative (%s); supply an argument which distinguishes them"
+                    source
+                    (sinkIds |> List.map describeSink |> String.concat ", ")
                 |> errors.Add
 
         for validationError in validationErrors do


### PR DESCRIPTION
Stage 5a of the positional-args-with-unions stack (5/8). Stacked on #577.

Adds the pure structural resolver: `resolve (schema) (observed) (positionalEvents) : Selection`, which performs case selection *and* positional routing together, before any value conversion. Conversion failures can therefore never influence which case wins or where a token goes.

Algorithm: intersect the events' candidate sets; for each candidate sink, form the hypothesis "this sink is active" by re-running selection with the sink as an extra observed leaf (`selectWith`); classify hypotheses as clean, fully valid, or **internally ambiguous** (the sink is routable but multiple interpretations through it accept); aggregate. New `SelectionError`s: `UnroutablePositional` (no sink can take a token — including when the candidate intersection is empty, which is now always reported alongside the named-only diagnosis) and `AmbiguousPositionalRouting`.

The centrepiece test is an equivalence property against the Stage 2 exhaustive reference semantics (3000 generated cases per run, with distribution counters to confirm the generator exercises ambiguous/unroutable regions). **This property caught a real bug during development**: hypotheses whose only errors were empty-case ambiguities were being discarded as incoherent, letting a different sink win "uniquely" where the definitional semantics says the parse is ambiguous. The `innerAmbiguous` classification is the fix; 120k cases pass after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
