### PR TITLE
Don't version-bump WoofWare.Myriad.Plugins on its own test-project changes

### DIFF
--- a/WoofWare.Myriad.Plugins/version.json
+++ b/WoofWare.Myriad.Plugins/version.json
@@ -5,6 +5,7 @@
   ],
   "pathFilters": [
     "./",
+    ":^Test",
     ":/WoofWare.Myriad.Plugins.Attributes",
     ":^/WoofWare.Myriad.Plugins.Attributes/Test",
     ":/global.json",


### PR DESCRIPTION
Fixes #586.

## Cause

`32e196a` (Dependabot bumping `Microsoft.NET.Test.Sdk`) touched four files:

```
WoofWare.Myriad.Plugins.Attributes/Test/WoofWare.Myriad.Plugins.Attributes.Test.fsproj
WoofWare.Myriad.Plugins.Test/WoofWare.Myriad.Plugins.Test.fsproj
WoofWare.Myriad.Plugins/Test/WoofWare.Myriad.Plugins.GeneratorTest.fsproj   <-- the culprit
nix/deps.json
```

`WoofWare.Myriad.Plugins/version.json` has `"./"` as a path filter, which covers the *entire* package directory — including the `WoofWare.Myriad.Plugins/Test/` project added in #567 (`1dd0510`). So a test-only edit bumped the NBGV git height, and since `github-release` in `ci.yaml` runs unconditionally on pushes to `main` and derives its tag from the nupkg version, a new height meant a new tag and release: `WoofWare.Myriad.Plugins.10.2.4`.

`WoofWare.Myriad.Plugins.Attributes/version.json` already has `":^Test"`, which is why the identical change to *its* test fsproj produced no Attributes release.

## Verification

Height arithmetic replayed over git history matches the real tags exactly (`6f8f008` -> 10.2.3, `32e196a` -> 10.2.4); with `WoofWare.Myriad.Plugins/Test/` excluded, `32e196a` stays at height 3.

Confirmed with the actual `nbgv` 3.10.91 CLI, using synthetic commits on top of this change:

| commit content | resulting version |
|---|---|
| `WoofWare.Myriad.Plugins/Test/...` only | 10.2.5 (unchanged) |
| `WoofWare.Myriad.Plugins/List.fs` | 10.2.6 (bumped) |
| `nix/deps.json` only | 10.2.6 (unchanged) |

## Notes

- Forward-looking only: NBGV reads `version.json` as of each commit during the height walk, so 10.2.4 stays where it is and the version doesn't go backwards.
- `WoofWare.Myriad.Plugins.Test/` (the sibling directory) is *not* matched by `"./"` — NBGV respects directory boundaries, and `f70416d`, which touched only that directory, correctly produced no release. So `WoofWare.Myriad.Plugins/Test/` was the only gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)