### PR TITLE
ArgParser: support positional args inside union cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,9 @@
 Notable changes are recorded here.
 
-# Unreleased
+# WoofWare.Myriad.Plugins 10.3.1
 
-The `ArgParserGenerator` now supports positional args together with discriminated-union args, as long as the positional args reject unrecognised flag-like tokens (the default; `[<PositionalArgs true>]` remains banned in combination with a union).
-A `[<PositionalArgs>]` field may sit beside the union-typed field (the positional stream is shared by every alternative), or inside the cases' payload records (each alternative converts the stream at its own field's type).
-Case selection is purely structural and happens before any value conversion: named arguments (and, where unique to one alternative, the keyed `--rest=value` form of a positional field) select the case, bare positional tokens never do, and whether a token happens to parse at some case's element type never influences which case wins.
+The `ArgParserGenerator` now supports positional args together with arbitrary discriminated-union args.
+(As in 10.2.3, the non-default `[<PositionalArgs true>]`, which collects into the positional args any unrecognised flag-like arguments such as `--foo`, remains banned in combination with a union.)
 
 # WoofWare.Myriad.Plugins 10.2.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 Notable changes are recorded here.
 
+# Unreleased
+
+The `ArgParserGenerator` now supports positional args together with discriminated-union args, as long as the positional args reject unrecognised flag-like tokens (the default; `[<PositionalArgs true>]` remains banned in combination with a union).
+A `[<PositionalArgs>]` field may sit beside the union-typed field (the positional stream is shared by every alternative), or inside the cases' payload records (each alternative converts the stream at its own field's type).
+Case selection is purely structural and happens before any value conversion: named arguments (and, where unique to one alternative, the keyed `--rest=value` form of a positional field) select the case, bare positional tokens never do, and whether a token happens to parse at some case's element type never influences which case wins.
+
 # WoofWare.Myriad.Plugins 10.2.3
 
 The `ArgParserGenerator` now permits a `[<PositionalArgs>]` field at the top level alongside (though not within) a discriminated-union arg, as long as the positional sink rejects unrecognised flag-like tokens (the default; `[<PositionalArgs true>]` remains banned beside a union, because that would make it very confusing when you typo a DU-case-selecting flag).

--- a/ConsumePlugin/DuArgs.fs
+++ b/ConsumePlugin/DuArgs.fs
@@ -105,3 +105,50 @@ type CommandAndPositionals =
         [<PositionalArgs false>]
         Paths : string list
     }
+
+type FooModeArgs =
+    {
+        Foo : int
+
+        [<PositionalArgs>]
+        Rest : int list
+    }
+
+type BarModeArgs =
+    {
+        Bar : int
+
+        [<PositionalArgs>]
+        Rest : string list
+    }
+
+/// The motivating example of per-case positional args: both cases collect the positional
+/// stream (addressable under the same default `--rest` form, which is fine because the cases
+/// are mutually exclusive), but convert it at different types. Selection happens before any
+/// conversion, so whether a token parses as int never influences which case wins.
+[<ArgParser>]
+type FooBarMode =
+    | FooMode of FooModeArgs
+    | BarMode of BarModeArgs
+
+type PullArgs =
+    {
+        [<ArgumentLongForm "source">]
+        From : string
+
+        [<PositionalArgs>]
+        Refs : string list
+    }
+
+type StatusArgs =
+    {
+        Verbose : bool option
+    }
+
+/// Positional args in only one case: the other (all-optional) case is the empty command
+/// line's fallback, and a bare token structurally selects Pull because only Pull can consume
+/// it.
+[<ArgParser>]
+type GitLike =
+    | Pull of PullArgs
+    | Status of StatusArgs

--- a/ConsumePlugin/GeneratedDuArgs.fs
+++ b/ConsumePlugin/GeneratedDuArgs.fs
@@ -2417,3 +2417,387 @@ module CommandAndPositionals =
 
     let parse (args : string list) : CommandAndPositionals =
         parse' (System.Environment.GetEnvironmentVariable >> Option.ofObj) args
+namespace ConsumePlugin
+
+open WoofWare.Myriad.Plugins
+
+/// Methods to parse arguments for the type FooBarMode
+[<RequireQualifiedAccess ; CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+module FooBarMode =
+    let parse' (getEnvironmentVariable : string -> string option) (args : string list) : FooBarMode =
+        let helpText () =
+            [
+                "exactly one of the following sets of arguments:"
+                "FooMode:"
+                (sprintf "  %s  int32%s%s" (sprintf "--%s" "foo") "" "")
+                (sprintf "  %s  int32%s%s" (sprintf "--%s" "rest") " (positional args) (can be repeated)" "")
+                "BarMode:"
+                (sprintf "  %s  int32%s%s" (sprintf "--%s" "bar") "" "")
+                (sprintf "  %s  string%s%s" (sprintf "--%s" "rest") " (positional args) (can be repeated)" "")
+            ]
+            |> String.concat "\n"
+
+        let arg_2 : int ResizeArray = ResizeArray ()
+        let arg_4 : string ResizeArray = ResizeArray ()
+        let mutable arg_1 : int option = None
+        let mutable arg_3 : int option = None
+
+        let parser_schema : ArgParserRuntime_DuArgs.ErasedSchema =
+            {
+                Leaves =
+                    [
+                        {
+                            Id = 0
+                            Forms = [ "foo" ]
+                            AcceptsNegation = false
+                            Arity = ArgParserRuntime_DuArgs.ErasedArity.One
+                            Repeatable = false
+                            Requirement = ArgParserRuntime_DuArgs.ErasedRequirement.Required
+                            TypeDescription = ""
+                            Help = None
+                        }
+                        {
+                            Id = 1
+                            Forms = [ "bar" ]
+                            AcceptsNegation = false
+                            Arity = ArgParserRuntime_DuArgs.ErasedArity.One
+                            Repeatable = false
+                            Requirement = ArgParserRuntime_DuArgs.ErasedRequirement.Required
+                            TypeDescription = ""
+                            Help = None
+                        }
+                    ]
+                Tree =
+                    (ArgParserRuntime_DuArgs.ErasedTree.Sum (
+                        (0,
+                         [
+                             ("FooMode",
+                              ArgParserRuntime_DuArgs.ErasedTree.Product (
+                                  [
+                                      ArgParserRuntime_DuArgs.ErasedTree.Leaf 0
+                                      ArgParserRuntime_DuArgs.ErasedTree.PositionalLeaf 0
+                                  ]
+                              ))
+                             ("BarMode",
+                              ArgParserRuntime_DuArgs.ErasedTree.Product (
+                                  [
+                                      ArgParserRuntime_DuArgs.ErasedTree.Leaf 1
+                                      ArgParserRuntime_DuArgs.ErasedTree.PositionalLeaf 1
+                                  ]
+                              ))
+                         ])
+                    ))
+                Positionals =
+                    [
+                        {
+                            Id = 0
+                            Forms = [ "rest" ]
+                            FlagLike = ArgParserRuntime_DuArgs.ErasedFlagLikeBehaviour.Reject
+                            TypeDescription = ""
+                            Help = None
+                        }
+                        {
+                            Id = 1
+                            Forms = [ "rest" ]
+                            FlagLike = ArgParserRuntime_DuArgs.ErasedFlagLikeBehaviour.Reject
+                            TypeDescription = ""
+                            Help = None
+                        }
+                    ]
+            }
+
+        let parser_storeOccurrence (occurrence : ArgParserRuntime_DuArgs.ErasedOccurrence) : string option =
+            match occurrence.LeafId with
+            | 0 ->
+                match arg_1 with
+                | Some _ -> None
+                | None ->
+                    match occurrence.Value with
+                    | Some value ->
+                        try
+                            arg_1 <- Some (value |> (fun x -> System.Int32.Parse x))
+                            None
+                        with _ as exc ->
+                            (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                    | None ->
+                        failwith
+                            "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
+            | 1 ->
+                match arg_3 with
+                | Some _ -> None
+                | None ->
+                    match occurrence.Value with
+                    | Some value ->
+                        try
+                            arg_3 <- Some (value |> (fun x -> System.Int32.Parse x))
+                            None
+                        with _ as exc ->
+                            (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                    | None ->
+                        failwith
+                            "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
+            | _ -> failwith "WoofWare.Myriad internal error in generated parser: unknown argument id"
+
+        let parser_storePositional (positionalId : int) (value : string) (afterSeparator : bool) : string option =
+            match positionalId with
+            | 0 ->
+                try
+                    arg_2.Add (value |> (fun x -> System.Int32.Parse x))
+                    None
+                with _ as exc ->
+                    (sprintf "%s (at arg %s)" exc.Message value) |> Some
+            | 1 ->
+                try
+                    arg_4.Add (value |> (fun x -> x))
+                    None
+                with _ as exc ->
+                    (sprintf "%s (at arg %s)" exc.Message value) |> Some
+            | _ -> failwith "WoofWare.Myriad internal error in generated parser: unknown positional sink id"
+
+        let parser_renderStored (leafId : int) : string =
+            match leafId with
+            | 0 ->
+                match arg_1 with
+                | Some x -> x.ToString ()
+                | None -> "<no value>"
+            | 1 ->
+                match arg_3 with
+                | Some x -> x.ToString ()
+                | None -> "<no value>"
+            | _ -> "<no value>"
+
+        let parser_applyDefault (leafId : int) : string option =
+            match leafId with
+            | _ -> failwith "WoofWare.Myriad internal error in generated parser: unknown defaulted argument id"
+
+        let parser_callbacks : ArgParserRuntime_DuArgs.TypedCallbacks =
+            {
+                StoreOccurrence = parser_storeOccurrence
+                StorePositional = parser_storePositional
+                HelpText = helpText
+                RenderStored = parser_renderStored
+                ApplyDefault = parser_applyDefault
+            }
+
+        match
+            ArgParserRuntime_DuArgs.runParse
+                (ArgParserRuntime_DuArgs.WellFormedSchema.checkOrFail parser_schema)
+                parser_callbacks
+                args
+        with
+        | ArgParserRuntime_DuArgs.ParseOutcome.Success parser_selection ->
+            match Map.tryFind 0 parser_selection.Choices with
+            | Some 0 ->
+                FooBarMode.FooMode (
+                    {
+                        Foo =
+                            (match arg_1 with
+                             | Some x -> x
+                             | None ->
+                                 failwith
+                                     "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
+                        Rest = (arg_2 |> Seq.toList)
+                    }
+                )
+            | Some 1 ->
+                FooBarMode.BarMode (
+                    {
+                        Bar =
+                            (match arg_3 with
+                             | Some x -> x
+                             | None ->
+                                 failwith
+                                     "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
+                        Rest = (arg_4 |> Seq.toList)
+                    }
+                )
+            | _ ->
+                failwith
+                    "WoofWare.Myriad internal error in generated parser: no case selected despite a successful parse"
+        | ArgParserRuntime_DuArgs.ParseOutcome.HelpRequested -> helpText () |> failwithf "Help text requested.\n%s"
+        | ArgParserRuntime_DuArgs.ParseOutcome.Fatal message -> failwith message
+        | ArgParserRuntime_DuArgs.ParseOutcome.Errors errors ->
+            errors |> String.concat "\n" |> failwithf "Errors during parse!\n%s"
+
+    let parse (args : string list) : FooBarMode =
+        parse' (System.Environment.GetEnvironmentVariable >> Option.ofObj) args
+namespace ConsumePlugin
+
+open WoofWare.Myriad.Plugins
+
+/// Methods to parse arguments for the type GitLike
+[<RequireQualifiedAccess ; CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+module GitLike =
+    let parse' (getEnvironmentVariable : string -> string option) (args : string list) : GitLike =
+        let helpText () =
+            [
+                "exactly one of the following sets of arguments:"
+                "Pull:"
+                (sprintf "  %s  string%s%s" (sprintf "--%s" "source") "" "")
+                (sprintf "  %s  string%s%s" (sprintf "--%s" "refs") " (positional args) (can be repeated)" "")
+                "Status:"
+                (sprintf "  %s  bool%s%s" (sprintf "--%s" "verbose") " (optional)" "")
+            ]
+            |> String.concat "\n"
+
+        let arg_2 : string ResizeArray = ResizeArray ()
+        let mutable arg_1 : string option = None
+        let mutable arg_3 : bool option = None
+
+        let parser_schema : ArgParserRuntime_DuArgs.ErasedSchema =
+            {
+                Leaves =
+                    [
+                        {
+                            Id = 0
+                            Forms = [ "source" ]
+                            AcceptsNegation = false
+                            Arity = ArgParserRuntime_DuArgs.ErasedArity.One
+                            Repeatable = false
+                            Requirement = ArgParserRuntime_DuArgs.ErasedRequirement.Required
+                            TypeDescription = ""
+                            Help = None
+                        }
+                        {
+                            Id = 1
+                            Forms = [ "verbose" ]
+                            AcceptsNegation = false
+                            Arity = ArgParserRuntime_DuArgs.ErasedArity.BoolLike
+                            Repeatable = false
+                            Requirement = ArgParserRuntime_DuArgs.ErasedRequirement.Optional
+                            TypeDescription = ""
+                            Help = None
+                        }
+                    ]
+                Tree =
+                    (ArgParserRuntime_DuArgs.ErasedTree.Sum (
+                        (0,
+                         [
+                             ("Pull",
+                              ArgParserRuntime_DuArgs.ErasedTree.Product (
+                                  [
+                                      ArgParserRuntime_DuArgs.ErasedTree.Leaf 0
+                                      ArgParserRuntime_DuArgs.ErasedTree.PositionalLeaf 0
+                                  ]
+                              ))
+                             ("Status",
+                              ArgParserRuntime_DuArgs.ErasedTree.Product ([ ArgParserRuntime_DuArgs.ErasedTree.Leaf 1 ]))
+                         ])
+                    ))
+                Positionals =
+                    [
+                        {
+                            Id = 0
+                            Forms = [ "refs" ]
+                            FlagLike = ArgParserRuntime_DuArgs.ErasedFlagLikeBehaviour.Reject
+                            TypeDescription = ""
+                            Help = None
+                        }
+                    ]
+            }
+
+        let parser_storeOccurrence (occurrence : ArgParserRuntime_DuArgs.ErasedOccurrence) : string option =
+            match occurrence.LeafId with
+            | 0 ->
+                match arg_1 with
+                | Some _ -> None
+                | None ->
+                    match occurrence.Value with
+                    | Some value ->
+                        try
+                            arg_1 <- Some (value |> (fun x -> x))
+                            None
+                        with _ as exc ->
+                            (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                    | None ->
+                        failwith
+                            "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
+            | 1 ->
+                match arg_3 with
+                | Some _ -> None
+                | None ->
+                    match occurrence.Value with
+                    | Some value ->
+                        try
+                            let parsedBool = System.Boolean.Parse value
+                            let parsedBool = if occurrence.Negated then not parsedBool else parsedBool
+                            arg_3 <- Some (parsedBool)
+                            None
+                        with _ as exc ->
+                            (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                    | None ->
+                        arg_3 <- Some ((if occurrence.Negated then false else true))
+                        None
+            | _ -> failwith "WoofWare.Myriad internal error in generated parser: unknown argument id"
+
+        let parser_storePositional (positionalId : int) (value : string) (afterSeparator : bool) : string option =
+            match positionalId with
+            | 0 ->
+                try
+                    arg_2.Add (value |> (fun x -> x))
+                    None
+                with _ as exc ->
+                    (sprintf "%s (at arg %s)" exc.Message value) |> Some
+            | _ -> failwith "WoofWare.Myriad internal error in generated parser: unknown positional sink id"
+
+        let parser_renderStored (leafId : int) : string =
+            match leafId with
+            | 0 ->
+                match arg_1 with
+                | Some x -> x.ToString ()
+                | None -> "<no value>"
+            | 1 ->
+                match arg_3 with
+                | Some x -> x.ToString ()
+                | None -> "<no value>"
+            | _ -> "<no value>"
+
+        let parser_applyDefault (leafId : int) : string option =
+            match leafId with
+            | _ -> failwith "WoofWare.Myriad internal error in generated parser: unknown defaulted argument id"
+
+        let parser_callbacks : ArgParserRuntime_DuArgs.TypedCallbacks =
+            {
+                StoreOccurrence = parser_storeOccurrence
+                StorePositional = parser_storePositional
+                HelpText = helpText
+                RenderStored = parser_renderStored
+                ApplyDefault = parser_applyDefault
+            }
+
+        match
+            ArgParserRuntime_DuArgs.runParse
+                (ArgParserRuntime_DuArgs.WellFormedSchema.checkOrFail parser_schema)
+                parser_callbacks
+                args
+        with
+        | ArgParserRuntime_DuArgs.ParseOutcome.Success parser_selection ->
+            match Map.tryFind 0 parser_selection.Choices with
+            | Some 0 ->
+                GitLike.Pull (
+                    {
+                        From =
+                            (match arg_1 with
+                             | Some x -> x
+                             | None ->
+                                 failwith
+                                     "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
+                        Refs = (arg_2 |> Seq.toList)
+                    }
+                )
+            | Some 1 ->
+                GitLike.Status (
+                    {
+                        Verbose = arg_3
+                    }
+                )
+            | _ ->
+                failwith
+                    "WoofWare.Myriad internal error in generated parser: no case selected despite a successful parse"
+        | ArgParserRuntime_DuArgs.ParseOutcome.HelpRequested -> helpText () |> failwithf "Help text requested.\n%s"
+        | ArgParserRuntime_DuArgs.ParseOutcome.Fatal message -> failwith message
+        | ArgParserRuntime_DuArgs.ParseOutcome.Errors errors ->
+            errors |> String.concat "\n" |> failwithf "Errors during parse!\n%s"
+
+    let parse (args : string list) : GitLike =
+        parse' (System.Environment.GetEnvironmentVariable >> Option.ofObj) args

--- a/README.md
+++ b/README.md
@@ -247,7 +247,8 @@ You can control `TimeSpan` and friends with the `[<InvariantCulture>]` and `[<Pa
 You can generate extension methods for the type, instead of a module with the type's name, using `[<ArgParser (* isExtensionMethod = *) true>]`.
 
 You can collect leftover args as positional args, with `[<PositionalArgs>]`; this respects a trailing `--` so that you can specify positional args which look like flags.
-The positional args feature is currently *not* supported simultaneously with DUs, though: the generator will fail at build time.
+Positional args compose with discriminated unions: a `[<PositionalArgs>]` field may sit beside a DU field (the stream is shared by every alternative), or inside the cases' records (each alternative converts the stream with its own field's type, and the parse first selects the case using the named arguments alone, then converts).
+The one restriction is `[<PositionalArgs true>]` (collecting unrecognised `--flag`-like tokens as positional args): that cannot be combined with a DU, because a mistyped case-selecting argument would be silently collected instead of reported.
 
 If `--help` appears in a position where the parser is expecting a key (e.g. in the first position, or after a `--foo=bar`), the parser fails with help text.
 The parser also makes a limited effort to supply help text when encountering an invalid parse.
@@ -274,7 +275,6 @@ This is very bare-bones, but do raise GitHub issues if you like (or if you find 
 * I don't handle very many types at the leaves. You may find yourself needing to write wrapper types to contain the leaf values, if you want to parse them correctly.
 * I don't try very hard to find a valid parse. It may well be possible to find a case where I fail to parse despite there existing a valid parse.
 * There's no subcommand support (you'll have to do that yourself).
-* Discriminated unions can't currently be specified in a type that contains positional args. This is a limitation I hope to relax soon.
 
 It should work fine if you just want to compose a few primitive types, though.
 

--- a/README.md
+++ b/README.md
@@ -247,15 +247,20 @@ You can control `TimeSpan` and friends with the `[<InvariantCulture>]` and `[<Pa
 You can generate extension methods for the type, instead of a module with the type's name, using `[<ArgParser (* isExtensionMethod = *) true>]`.
 
 You can collect leftover args as positional args, with `[<PositionalArgs>]`; this respects a trailing `--` so that you can specify positional args which look like flags.
-Positional args compose with discriminated unions: a `[<PositionalArgs>]` field may sit beside a DU field (the stream is shared by every alternative), or inside the cases' records (each alternative converts the stream with its own field's type, and the parse first selects the case using the named arguments alone, then converts).
-The one restriction is `[<PositionalArgs true>]` (collecting unrecognised `--flag`-like tokens as positional args): that cannot be combined with a DU, because a mistyped case-selecting argument would be silently collected instead of reported.
+
+Restrictions on the composition of positional args and DUs:
+
+* `[<PositionalArgs true>]` (to collect unrecognised flag-like arguments like `--unrecognised-arg` as positionals) will fail to generate code if present in a parser that also contains DUs, because the failure mode if the user makes a typo in an arg name is very confusing in that case.
+* We only use structural information, and not "we tried and failed to parse positional args as a specified type", when deciding which DU case to select. The parser uses named args to choose where the positional args are going to be collected, and only then tries to parse positional values.
 
 If `--help` appears in a position where the parser is expecting a key (e.g. in the first position, or after a `--foo=bar`), the parser fails with help text.
 The parser also makes a limited effort to supply help text when encountering an invalid parse.
 
 Records compose: if your record contains other records which are visible to the source generator (that is, they're in the same file as the main args type), the fields of *those* records will also be included in the command line, as if you'd specified them inline in the top-level record.
 
-Discriminated unions compose with each other and with records, hopefully as you would expect: the fields specified by the record of a DU field must be mutually satisified, or the parse will fail to select that DU field.
+Discriminated unions compose with each other and with records, hopefully as you would expect: the fields specified by the record contained within the exactly-one field of each DU case must all be mutually satisified, or the parse will fail to select that DU field.
+We will fail at build time to generate a parser if you have several DU cases which contain fields of the same name, though, because in general resolving the parse in that case is NP-hard.
+(An upcoming piece of work will hopefully relax this restriction.)
 
 ### What's the point?
 

--- a/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParserDuCasePositional.fs
+++ b/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParserDuCasePositional.fs
@@ -1,0 +1,212 @@
+namespace WoofWare.Myriad.Plugins.Test
+
+open NUnit.Framework
+open FsUnitTyped
+open FsCheck
+open ConsumePlugin
+
+/// Positional args inside the cases of a discriminated-union argument schema: each alternative
+/// converts the positional stream at its own field's type, and case selection is purely
+/// structural — it happens before any conversion, so a token's parseability never chooses a
+/// case.
+[<TestFixture>]
+module TestArgParserDuCasePositional =
+
+    let noEnv (_ : string) : string option = None
+
+    [<Test>]
+    let ``The named discriminator selects the case, whose sink converts the stream`` () =
+        FooBarMode.parse' noEnv [ "--foo=1" ; "2" ; "3" ]
+        |> shouldEqual (
+            FooMode
+                {
+                    Foo = 1
+                    Rest = [ 2 ; 3 ]
+                }
+        )
+
+        FooBarMode.parse' noEnv [ "--bar=1" ; "x" ; "y" ]
+        |> shouldEqual (
+            BarMode
+                {
+                    Bar = 1
+                    Rest = [ "x" ; "y" ]
+                }
+        )
+
+    [<Test>]
+    let ``Parseability at another case's element type does not influence selection`` () =
+        // "2" and "3" would parse as int, but --bar selected BarMode, so they are strings.
+        FooBarMode.parse' noEnv [ "--bar=1" ; "2" ; "--" ; "3" ]
+        |> shouldEqual (
+            BarMode
+                {
+                    Bar = 1
+                    Rest = [ "2" ; "3" ]
+                }
+        )
+
+    [<Test>]
+    let ``Positional tokens alone select nothing, and conversions are not tried`` () =
+        // "x" is not an int, but no int conversion is attempted: the only error is the
+        // missing selection.
+        let exc =
+            Assert.Throws<exn> (fun () -> FooBarMode.parse' noEnv [ "x" ; "y" ] |> ignore<FooBarMode>)
+
+        exc.Message
+        |> shouldEqual
+            """Errors during parse!
+No arguments were supplied to select one of: FooMode, BarMode"""
+
+    [<Test>]
+    let ``A conversion failure in the selected case's sink does not fall back to the other case`` () =
+        // "bad" is not an int; the parse fails with a conversion error rather than quietly
+        // becoming BarMode (whose sink would have accepted any string).
+        let exc =
+            Assert.Throws<exn> (fun () -> FooBarMode.parse' noEnv [ "--foo=1" ; "bad" ] |> ignore<FooBarMode>)
+
+        exc.Message.Contains "bad" |> shouldEqual true
+        exc.Message.Contains "BarMode" |> shouldEqual false
+
+    [<Test>]
+    let ``The shared keyed form routes to whichever case the named arguments select`` () =
+        FooBarMode.parse' noEnv [ "--foo=1" ; "--rest=2" ]
+        |> shouldEqual (
+            FooMode
+                {
+                    Foo = 1
+                    Rest = [ 2 ]
+                }
+        )
+
+        // Case-insensitively, and wherever it appears relative to the discriminator.
+        FooBarMode.parse' noEnv [ "--REST=2" ; "--bar=3" ]
+        |> shouldEqual (
+            BarMode
+                {
+                    Bar = 3
+                    Rest = [ "2" ]
+                }
+        )
+
+    [<Test>]
+    let ``The shared keyed form alone selects nothing`` () =
+        let exc =
+            Assert.Throws<exn> (fun () -> FooBarMode.parse' noEnv [ "--rest=2" ] |> ignore<FooBarMode>)
+
+        exc.Message
+        |> shouldEqual
+            """Errors during parse!
+No arguments were supplied to select one of: FooMode, BarMode"""
+
+    [<Test>]
+    let ``Cross-case named arguments are a conflict, and conversions are not tried`` () =
+        let exc =
+            Assert.Throws<exn> (fun () -> FooBarMode.parse' noEnv [ "--foo=1" ; "--bar=2" ; "x" ] |> ignore<FooBarMode>)
+
+        exc.Message
+        |> shouldEqual
+            """Errors during parse!
+Arguments select more than one alternative: FooMode (via --foo=1), BarMode (via --bar=2)"""
+
+    [<Test>]
+    let ``A sink in only one case: bare tokens structurally select that case`` () =
+        // Only Pull can consume a positional token, so the token itself picks Pull; the
+        // missing required argument is then reported in the ordinary vocabulary.
+        let exc =
+            Assert.Throws<exn> (fun () -> GitLike.parse' noEnv [ "main" ] |> ignore<GitLike>)
+
+        exc.Message
+        |> shouldEqual
+            """Errors during parse!
+Required argument '--source' received no value"""
+
+        GitLike.parse' noEnv [ "--source=origin" ; "main" ; "dev" ]
+        |> shouldEqual (
+            Pull
+                {
+                    From = "origin"
+                    Refs = [ "main" ; "dev" ]
+                }
+        )
+
+    [<Test>]
+    let ``A sink in only one case: the empty command line still falls back to the other case`` () =
+        GitLike.parse' noEnv []
+        |> shouldEqual (
+            Status
+                {
+                    Verbose = None
+                }
+        )
+
+    [<Test>]
+    let ``An unrecognised flag-like token is still fatal`` () =
+        let exc =
+            Assert.Throws<exn> (fun () -> FooBarMode.parse' noEnv [ "--fooo=1" ; "2" ] |> ignore<FooBarMode>)
+
+        exc.Message
+        |> shouldEqual "Unable to process argument --fooo=1 as key --fooo and value 1"
+
+    [<Test>]
+    let ``Help text renders each case's positional args inside its group`` () =
+        let exc =
+            Assert.Throws<exn> (fun () -> FooBarMode.parse' noEnv [ "--help" ] |> ignore<FooBarMode>)
+
+        exc.Message
+        |> shouldEqual
+            """Help text requested.
+exactly one of the following sets of arguments:
+FooMode:
+  --foo  int32
+  --rest  int32 (positional args) (can be repeated)
+BarMode:
+  --bar  int32
+  --rest  string (positional args) (can be repeated)"""
+
+    [<Test>]
+    let ``Adding positional tokens never changes which case is selected`` () =
+        // Insertion points are safe by construction: the named arguments use --key=value.
+        let mutable nonemptyCount = 0
+
+        let property (useFoo : bool) (pos0 : int list) (pos1 : int list) (sep : bool) : unit =
+            if not (List.isEmpty (pos0 @ pos1)) then
+                nonemptyCount <- nonemptyCount + 1
+
+            let named = if useFoo then "--foo=1" else "--bar=1"
+
+            let args =
+                [
+                    yield! pos0 |> List.map string<int>
+                    yield named
+                    if sep then
+                        yield "--"
+                    yield! pos1 |> List.map string<int>
+                ]
+
+            let expectedInts = pos0 @ pos1
+
+            if useFoo then
+                FooBarMode.parse' noEnv args
+                |> shouldEqual (
+                    FooMode
+                        {
+                            Foo = 1
+                            Rest = expectedInts
+                        }
+                )
+            else
+                FooBarMode.parse' noEnv args
+                |> shouldEqual (
+                    BarMode
+                        {
+                            Bar = 1
+                            Rest = expectedInts |> List.map string<int>
+                        }
+                )
+
+        Check.QuickThrowOnFailure property
+
+        // The property is vacuous over empty positional lists; make sure the generator
+        // actually exercised nonempty ones.
+        nonemptyCount |> shouldBeGreaterThan 30

--- a/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParserDuCasePositional.fs
+++ b/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParserDuCasePositional.fs
@@ -15,7 +15,7 @@ module TestArgParserDuCasePositional =
     let noEnv (_ : string) : string option = None
 
     [<Test>]
-    let ``The named discriminator selects the case, whose sink converts the stream`` () =
+    let ``The named discriminator selects the case whose sink converts the stream`` () =
         FooBarMode.parse' noEnv [ "--foo=1" ; "2" ; "3" ]
         |> shouldEqual (
             FooMode

--- a/WoofWare.Myriad.Plugins.Test/WoofWare.Myriad.Plugins.Test.fsproj
+++ b/WoofWare.Myriad.Plugins.Test/WoofWare.Myriad.Plugins.Test.fsproj
@@ -47,6 +47,7 @@
     <Compile Include="TestArgParser\TestArgParserEdgeCases.fs" />
     <Compile Include="TestArgParser\TestArgParserDu.fs" />
     <Compile Include="TestArgParser\TestArgParserDuPositional.fs" />
+    <Compile Include="TestArgParser\TestArgParserDuCasePositional.fs" />
     <Compile Include="TestArgParser\TestArgParserPositionalReference.fs" />
     <Compile Include="TestArgParser\TestArgParserRuntime.fs" />
     <Compile Include="TestSwagger\TestSwaggerParse.fs" />

--- a/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
+++ b/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
@@ -242,22 +242,25 @@ module private ParseTree =
         | _ -> failwith "The argument name 'help' is reserved: --help always displays the help text."
 
         // Every name a `--token` could address, with a description of its claimant, in
-        // declaration order.
-        let claims : (string * string) list =
+        // declaration order. The boolean marks positional-args claimants: sinks in mutually
+        // exclusive union cases may share forms with each other (a keyed positional token
+        // means the same thing whichever sink is active), but not with anything else.
+        let claims : (string * string * bool) list =
             (nonPos
              |> List.collect (fun pf ->
                  let forms = literalForms pf.ArgForm
 
                  let plain =
                      forms
-                     |> List.map (fun form -> form, $"'--%s{form}' (field '%s{pf.FieldName.idText}')")
+                     |> List.map (fun form -> form, $"'--%s{form}' (field '%s{pf.FieldName.idText}')", false)
 
                  let negated =
                      if pf.AcceptsNegation then
                          forms
                          |> List.map (fun form ->
                              $"no-%s{form}",
-                             $"the --no- variant of field '%s{pf.FieldName.idText}' (which has [<ArgumentNegateWithPrefix>])"
+                             $"the --no- variant of field '%s{pf.FieldName.idText}' (which has [<ArgumentNegateWithPrefix>])",
+                             false
                          )
                      else
                          []
@@ -267,7 +270,9 @@ module private ParseTree =
             @ (pos
                |> List.collect (fun pf ->
                    literalForms pf.ArgForm
-                   |> List.map (fun form -> form, $"'--%s{form}' (the positional args)")
+                   |> List.map (fun form ->
+                       form, $"'--%s{form}' (the positional args, field '%s{pf.FieldName.idText}')", true
+                   )
                ))
 
         // Group under the scanner's own equality (OrdinalIgnoreCase), preserving
@@ -278,26 +283,28 @@ module private ParseTree =
             let indexOf =
                 System.Collections.Generic.Dictionary<string, int> (StringComparer.OrdinalIgnoreCase)
 
-            let buckets = ResizeArray<ResizeArray<string * string>> ()
+            let buckets = ResizeArray<ResizeArray<string * string * bool>> ()
 
-            for form, claimant in claims do
+            for form, claimant, isPositional in claims do
                 match indexOf.TryGetValue form with
-                | true, index -> buckets.[index].Add ((form, claimant))
+                | true, index -> buckets.[index].Add ((form, claimant, isPositional))
                 | false, _ ->
                     indexOf.[form] <- buckets.Count
                     let bucket = ResizeArray ()
-                    bucket.Add ((form, claimant))
+                    bucket.Add ((form, claimant, isPositional))
                     buckets.Add bucket
 
             buckets
             |> Seq.choose (fun bucket ->
-                if bucket.Count < 2 then
+                let allPositional = bucket |> Seq.forall (fun (_, _, isPositional) -> isPositional)
+
+                if bucket.Count < 2 || allPositional then
                     None
                 else
-                    let form, _ = bucket.[0]
+                    let form, _, _ = bucket.[0]
 
                     bucket
-                    |> Seq.map snd
+                    |> Seq.map (fun (_, claimant, _) -> claimant)
                     |> String.concat "; "
                     |> sprintf "The argument name '--%s' is claimed by: %s" form
                     |> Some
@@ -1004,13 +1011,7 @@ module internal ArgParserGenerator =
                 let spec, counter =
                     toParseSpec ancestors counter flagDus ambientUnions ambientRecords payloadRecord
 
-                if ParseTree.containsPositional spec then
-                    failwith
-                        $"Positional args are not permitted inside cases of the [<ArgParser>] union %s{union.Name.idText}: the parser could not tell which alternative a positional arg belongs to."
-
-                let tree = spec
-
-                counter, (case.Name, tree) :: acc
+                counter, (case.Name, spec) :: acc
             )
 
         let cases = List.rev cases
@@ -1195,33 +1196,32 @@ module internal ArgParserGenerator =
         let nonPos, pos = ParseTree.accumulators spec
         let hasSum = ParseTree.containsSum spec
 
-        // A positional sink may sit beside a union only when the scanner's treatment of an
-        // unrecognised `--key`-shaped token is provably Reject (fatal). A Collect-mode sink
-        // treats such a token as a positional arg, so a typo of a case-selecting argument would
-        // be silently collected — with a union in play, silently changing which alternative is
-        // chosen. Bare positional tokens are sound beside a union: they are routed to the sink
-        // and never influence case selection.
-        match pos with
-        | [ pf ] when hasSum ->
-            let includeFlagLike =
-                match pf.Accumulation with
-                | ChoicePositional.Normal fl
-                | ChoicePositional.Choice fl -> fl
+        // Positional args may live beside a union, or inside its cases, only when the
+        // scanner's treatment of an unrecognised `--key`-shaped token is provably Reject
+        // (fatal). A Collect-mode sink treats such a token as a positional arg, so a typo of a
+        // case-selecting argument would be silently collected — with a union in play, silently
+        // changing which alternative is chosen. Bare positional tokens are sound: they are
+        // routed to a sink only after case selection, and never influence it.
+        if hasSum then
+            for pf in pos do
+                let includeFlagLike =
+                    match pf.Accumulation with
+                    | ChoicePositional.Normal fl
+                    | ChoicePositional.Choice fl -> fl
 
-            match includeFlagLike with
-            // The default [<PositionalArgs>] is Reject.
-            | None -> ()
-            | Some expr ->
-                match SynExpr.stripOptionalParen expr with
-                | SynExpr.Const (SynConst.Bool false, _) -> ()
-                | SynExpr.Const (SynConst.Bool true, _) ->
-                    failwith
-                        "Positional args which collect unrecognised flag-like tokens ([<PositionalArgs true>]) cannot be combined with a discriminated-union arg: a mistyped case-selecting argument would be collected as a positional arg instead of being reported."
-                | _ ->
-                    // E.g. a [<Literal>] constant, which the untyped AST does not resolve.
-                    failwith
-                        "Positional args combined with a discriminated-union arg must provably reject unrecognised flag-like tokens: use [<PositionalArgs>] or a literal [<PositionalArgs false>]."
-        | _ -> ()
+                match includeFlagLike with
+                // The default [<PositionalArgs>] is Reject.
+                | None -> ()
+                | Some expr ->
+                    match SynExpr.stripOptionalParen expr with
+                    | SynExpr.Const (SynConst.Bool false, _) -> ()
+                    | SynExpr.Const (SynConst.Bool true, _) ->
+                        failwith
+                            "Positional args which collect unrecognised flag-like tokens ([<PositionalArgs true>]) cannot be combined with a discriminated-union arg: a mistyped case-selecting argument would be collected as a positional arg instead of being reported."
+                    | _ ->
+                        // E.g. a [<Literal>] constant, which the untyped AST does not resolve.
+                        failwith
+                            "Positional args combined with a discriminated-union arg must provably reject unrecognised flag-like tokens: use [<PositionalArgs>] or a literal [<PositionalArgs false>]."
 
         let bindings =
             nonPos

--- a/WoofWare.Myriad.Plugins/Test/TestArgParserRejection.fs
+++ b/WoofWare.Myriad.Plugins/Test/TestArgParserRejection.fs
@@ -438,15 +438,19 @@ type AmbiguousEmptyCases =
         |> shouldRejectWith
             "Cases CaseA, CaseB can all be satisfied without supplying any arguments, so an empty command line cannot choose between them. Make an argument in all but one of them mandatory."
 
-    [<Test>]
-    let ``Positional args are rejected inside a union case`` () =
-        """namespace TestMe
+    /// A union one of whose cases holds a positional sink, wrapped in a record; the sink's
+    /// attribute is rendered from the given text.
+    let private positionalInsideUnionSource (positionalAttr : string) : string =
+        sprintf
+            """namespace TestMe
 
 open WoofWare.Myriad.Plugins
 
 type SomePositionals =
     {
-        [<PositionalArgs>]
+        A : int
+
+        [<%s>]
         Rest : string list
     }
 
@@ -465,8 +469,138 @@ type PositionalInsideUnion =
         Choice : PositionalOrNot
     }
 """
+            positionalAttr
+
+    [<Test>]
+    let ``Reject-mode positional args are permitted inside a union case`` () =
+        for attr in [ "PositionalArgs" ; "PositionalArgs false" ] do
+            // One namespace for the embedded runtime module, one for the generated parser module.
+            generateFromSource (positionalInsideUnionSource attr)
+            |> List.length
+            |> shouldEqual 2
+
+    [<Test>]
+    let ``Collect-mode positional args are rejected inside a union case`` () =
+        positionalInsideUnionSource "PositionalArgs true"
         |> shouldRejectWith
-            "Positional args are not permitted inside cases of the [<ArgParser>] union PositionalOrNot: the parser could not tell which alternative a positional arg belongs to."
+            "Positional args which collect unrecognised flag-like tokens ([<PositionalArgs true>]) cannot be combined with a discriminated-union arg: a mistyped case-selecting argument would be collected as a positional arg instead of being reported."
+
+    [<Test>]
+    let ``A sink inside a union case cannot coexist with a sink beside the union`` () =
+        // Some complete alternative would contain two positional sinks, and argv holds a
+        // single positional stream.
+        """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+type SomePositionals =
+    {
+        A : int
+
+        [<PositionalArgs>]
+        Rest : string list
+    }
+
+type NotPositional =
+    {
+        C : int
+    }
+
+type PositionalOrNot =
+    | Pos of SomePositionals
+    | NotPos of NotPositional
+
+[<ArgParser>]
+type PositionalInsideUnion =
+    {
+        Choice : PositionalOrNot
+
+        [<PositionalArgs>]
+        Extra : string list
+    }
+"""
+        |> shouldRejectWith "Multiple entries tried to claim positional args! Choice and Extra"
+
+    [<Test>]
+    let ``Two positional fields in one record are rejected`` () =
+        """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+[<ArgParser>]
+type TwoSinks =
+    {
+        [<PositionalArgs>]
+        First : string list
+
+        [<PositionalArgs>]
+        Second : string list
+    }
+"""
+        |> shouldRejectWith "Multiple entries tried to claim positional args! First and Second"
+
+    [<Test>]
+    let ``Sinks in mutually exclusive cases may share their forms`` () =
+        // Both cases' sinks are addressable as --rest; a keyed --rest token has the same
+        // meaning whichever case wins, so this must generate successfully.
+        let modules =
+            generateFromSource
+                """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+type FooArgs =
+    {
+        Foo : int
+
+        [<PositionalArgs>]
+        Rest : int list
+    }
+
+type BarArgs =
+    {
+        Bar : int
+
+        [<PositionalArgs>]
+        Rest : string list
+    }
+
+[<ArgParser>]
+type DuArgs =
+    | FooCase of FooArgs
+    | BarCase of BarArgs
+"""
+
+        // One namespace for the embedded runtime module, one for the generated parser module.
+        List.length modules |> shouldEqual 2
+
+    [<Test>]
+    let ``A sink's form still may not collide with a named argument across cases`` () =
+        """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+type FooArgs =
+    {
+        Foo : int
+
+        [<PositionalArgs>]
+        [<ArgumentLongForm "target">]
+        Rest : int list
+    }
+
+type BarArgs =
+    {
+        Target : string
+    }
+
+[<ArgParser>]
+type DuArgs =
+    | FooCase of FooArgs
+    | BarCase of BarArgs
+"""
+        |> shouldRejectWith
+            "Conflicting argument names detected (names are matched case-insensitively):\nThe argument name '--target' is claimed by: '--target' (field 'Target'); '--target' (the positional args, field 'Rest')"
 
     /// A record holding a union-typed field and a positional sink, with the sink's
     /// [<PositionalArgs>] attribute rendered from the given text.

--- a/WoofWare.Myriad.Plugins/Test/TestArgParserRejection.fs
+++ b/WoofWare.Myriad.Plugins/Test/TestArgParserRejection.fs
@@ -575,6 +575,41 @@ type DuArgs =
         List.length modules |> shouldEqual 2
 
     [<Test>]
+    let ``Sinks in mutually exclusive cases may have different forms`` () =
+        // The cases' sinks are addressable as --rest and --others respectively; at most one
+        // case wins, so neither keyed form is ambiguous and this must generate successfully.
+        let modules =
+            generateFromSource
+                """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+type FooArgs =
+    {
+        Foo : int
+
+        [<PositionalArgs>]
+        Rest : int list
+    }
+
+type BarArgs =
+    {
+        Bar : int
+
+        [<PositionalArgs>]
+        Others : string list
+    }
+
+[<ArgParser>]
+type DuArgs =
+    | FooCase of FooArgs
+    | BarCase of BarArgs
+"""
+
+        // One namespace for the embedded runtime module, one for the generated parser module.
+        List.length modules |> shouldEqual 2
+
+    [<Test>]
     let ``A sink's form still may not collide with a named argument across cases`` () =
         """namespace TestMe
 

--- a/WoofWare.Myriad.Plugins/version.json
+++ b/WoofWare.Myriad.Plugins/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "10.2",
+  "version": "10.3",
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],


### PR DESCRIPTION
Stage 7 of the positional-args-with-unions stack (8/8). Stacked on #580.

The user-facing payoff: `[<PositionalArgs>]` fields are now permitted **inside the payload records of union cases**. Each alternative converts the positional stream at its own field's type:

```fsharp
[<ArgParser>]
type FooBarMode =
    | FooMode of FooModeArgs   // { Foo : int;  [<PositionalArgs>] Rest : int list }
    | BarMode of BarModeArgs   // { Bar : int;  [<PositionalArgs>] Rest : string list }
```

`--foo=1 2 3` yields `FooMode { Foo = 1; Rest = [2; 3] }`; `--bar=1 2 3` yields `BarMode` with `Rest = ["2"; "3"]`. Selection is structural and precedes conversion, so a token's parseability at some case's element type never chooses the case. Cases may share the keyed form (`--rest=...` routes to whichever case the named args select); a sink unique to one case makes bare tokens structurally select that case (see the `GitLike` fixture). Generation-time checks generalize: all-positional form-collision buckets are permitted, a case sink plus a common sink is rejected ("Multiple entries tried to claim positional args!"), the flag-like-policy rule from Stage 1 now applies to every sink under a sum, and help text renders each case's positional args inside its group.

README and CHANGELOG updated; the old "no positionals with unions" restriction documentation is removed. Includes plan-§8 integration tests plus a selection-invariance property.


---

Replaces #581, which was merged into `argparser-plain-tree` by mistake. That merge has been undone by force-push (`argparser-plain-tree` is back to its single commit) and this PR restores the review; the branch content is byte-identical to what #581 held.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
