### PR TITLE
ArgParser: add [<ArgumentDefaultValue foo>] for constant defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 Notable changes are recorded here.
 
+# WoofWare.Myriad.Plugins 10.5.1, WoofWare.Myriad.Plugins.Attributes 3.10.1
+
+The `ArgParserGenerator` gains `[<ArgumentDefaultValue foo>]`, which is shorthand for an `[<ArgumentDefaultFunction>]` whose function just returns the constant `foo`.
+`foo` must be a literal written out in full: the value is reproduced in the generated file rather than evaluated at your attribute, so anything whose meaning depends on where it is written is rejected.
+That covers names standing for constants (a `[<Literal>]` binding or an enum case), since the generated file hoists every `open` in your source above the parser and so a name need not resolve to the same binding there; and F#'s context-sensitive constants (`__LINE__`, `__SOURCE_FILE__`, `__SOURCE_DIRECTORY__`).
+Use `[<ArgumentDefaultFunction>]` for those, and for anything which is not a constant at all.
+
 # WoofWare.Myriad.Plugins 10.4.1, WoofWare.Myriad.Plugins.Attributes 3.9.1
 
 The `ArgParserGenerator` now supports `Map<'k, 'v>` fields, which accumulate key-value entries across occurrences as `list` fields accumulate values.
@@ -12,12 +19,6 @@ Each entry is split at its *first* key-value separator, so a value may contain t
 This means e.g. that some `Map<string, string>` are inexpressible (if the key contains the key-value separator); use `string list` and parse it yourself into a map if you need something smarter.
 Where the spellings are known at generation time we check them: an enumerated key or value with a case that no spelling can express is rejected rather than silently misparsed.
 Help text describes each half of an entry in the syntax that half accepts, so a flag-valued map advertises `map<..., bool>` and an enumerated one lists its case names.
-
-The `ArgParserGenerator` gains `[<ArgumentDefaultValue foo>]`: shorthand for an `[<ArgumentDefaultFunction>]` whose function just returns a constant.
-`foo` must be a literal written out in full: the value is reproduced in the generated file rather than evaluated at your attribute, so anything whose meaning depends on where it is written is rejected.
-That covers names standing for constants (a `[<Literal>]` binding or an enum case), since the generated file hoists every `open` in your source above the parser and so a name need not resolve to the same binding there; and F#'s context-sensitive constants (`__LINE__`, `__SOURCE_FILE__`, `__SOURCE_DIRECTORY__`).
-Use `[<ArgumentDefaultFunction>]` for those, and for anything which is not a constant at all.
-(`null` counts as a literal, so it is accepted, in the projects whose nullness settings let you write it at all.)
 
 # WoofWare.Myriad.Plugins 10.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ This means e.g. that some `Map<string, string>` are inexpressible (if the key co
 Where the spellings are known at generation time we check them: an enumerated key or value with a case that no spelling can express is rejected rather than silently misparsed.
 Help text describes each half of an entry in the syntax that half accepts, so a flag-valued map advertises `map<..., bool>` and an enumerated one lists its case names.
 
+The `ArgParserGenerator` gains `[<ArgumentDefaultValue foo>]`: shorthand for an `[<ArgumentDefaultFunction>]` whose function just returns a constant.
+`foo` is an ordinary .NET attribute argument, so F# restricts it to compile-time constants (literals, `[<Literal>]` bindings, and enum cases); anything else, including a discriminated union case, still needs `[<ArgumentDefaultFunction>]`.
+
 # WoofWare.Myriad.Plugins 10.3.1
 
 The `ArgParserGenerator` now supports positional args together with arbitrary discriminated-union args.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Help text describes each half of an entry in the syntax that half accepts, so a 
 
 The `ArgParserGenerator` gains `[<ArgumentDefaultValue foo>]`: shorthand for an `[<ArgumentDefaultFunction>]` whose function just returns a constant.
 `foo` is an ordinary .NET attribute argument, so F# restricts it to compile-time constants (literals, `[<Literal>]` bindings, and enum cases); anything else, including a discriminated union case, still needs `[<ArgumentDefaultFunction>]`.
+The value is spliced into the generated file rather than evaluated at your attribute, so F#'s context-sensitive constants (`__LINE__`, `__SOURCE_FILE__`, `__SOURCE_DIRECTORY__`) are rejected: they would be resolved against the generated file rather than yours.
 
 # WoofWare.Myriad.Plugins 10.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@ Where the spellings are known at generation time we check them: an enumerated ke
 Help text describes each half of an entry in the syntax that half accepts, so a flag-valued map advertises `map<..., bool>` and an enumerated one lists its case names.
 
 The `ArgParserGenerator` gains `[<ArgumentDefaultValue foo>]`: shorthand for an `[<ArgumentDefaultFunction>]` whose function just returns a constant.
-`foo` is an ordinary .NET attribute argument, so F# restricts it to compile-time constants (literals, `[<Literal>]` bindings, and enum cases); anything else, including a discriminated union case, still needs `[<ArgumentDefaultFunction>]`.
-The value is spliced into the generated file rather than evaluated at your attribute, so F#'s context-sensitive constants (`__LINE__`, `__SOURCE_FILE__`, `__SOURCE_DIRECTORY__`) are rejected: they would be resolved against the generated file rather than yours.
+`foo` must be a literal written out in full: the value is reproduced in the generated file rather than evaluated at your attribute, so anything whose meaning depends on where it is written is rejected.
+That covers names standing for constants (a `[<Literal>]` binding or an enum case), since the generated file hoists every `open` in your source above the parser and so a name need not resolve to the same binding there; and F#'s context-sensitive constants (`__LINE__`, `__SOURCE_FILE__`, `__SOURCE_DIRECTORY__`).
+Use `[<ArgumentDefaultFunction>]` for those, and for anything which is not a constant at all.
 
 # WoofWare.Myriad.Plugins 10.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The `ArgParserGenerator` gains `[<ArgumentDefaultValue foo>]`: shorthand for an 
 `foo` must be a literal written out in full: the value is reproduced in the generated file rather than evaluated at your attribute, so anything whose meaning depends on where it is written is rejected.
 That covers names standing for constants (a `[<Literal>]` binding or an enum case), since the generated file hoists every `open` in your source above the parser and so a name need not resolve to the same binding there; and F#'s context-sensitive constants (`__LINE__`, `__SOURCE_FILE__`, `__SOURCE_DIRECTORY__`).
 Use `[<ArgumentDefaultFunction>]` for those, and for anything which is not a constant at all.
+(`null` counts as a literal, so it is accepted, in the projects whose nullness settings let you write it at all.)
 
 # WoofWare.Myriad.Plugins 10.3.1
 

--- a/ConsumePlugin/Args.fs
+++ b/ConsumePlugin/Args.fs
@@ -196,6 +196,22 @@ type ContainsFlagDefaultValue =
 
     static member DefaultDryRun () = DryRunMode.Wet
 
+/// `[<ArgumentDefaultValue>]` is shorthand for an `[<ArgumentDefaultFunction>]` whose function
+/// returns a constant. The value is any valid .NET attribute argument: a literal, a `[<Literal>]`
+/// binding, or an enum case.
+[<ArgParser true>]
+type ContainsLiteralDefault =
+    {
+        [<ArgumentDefaultValue 3>]
+        IntVar : Choice<int, int>
+        [<ArgumentDefaultValue "hello world">]
+        StringVar : Choice<string, string>
+        // A non-literal argument requires parens: F#'s attribute syntax otherwise reads the
+        // identifier as the start of a named argument.
+        [<ArgumentDefaultValue(Consts.TRUE)>]
+        BoolVar : Choice<bool, bool>
+    }
+
 [<ArgParser true>]
 type ManyLongForms =
     {

--- a/ConsumePlugin/Args.fs
+++ b/ConsumePlugin/Args.fs
@@ -197,7 +197,7 @@ type ContainsFlagDefaultValue =
     static member DefaultDryRun () = DryRunMode.Wet
 
 /// `[<ArgumentDefaultValue>]` is shorthand for an `[<ArgumentDefaultFunction>]` whose function
-/// returns a constant. The value must be written out as a literal: we splice it into the generated
+/// returns a constant. The value must be written out as a literal: we reproduce it in the generated
 /// file, where a name would not necessarily mean what it means here.
 [<ArgParser true>]
 type ContainsLiteralDefault =
@@ -212,6 +212,22 @@ type ContainsLiteralDefault =
         // rebuild the constant rather than passing the user's through.
         [<ArgumentDefaultValue 'q'>]
         CharVar : Choice<char, char>
+    }
+
+/// We rebuild the literal in the generated file rather than echoing the user's source text, so
+/// escape-sensitive strings have to survive that round trip: a naively re-emitted `"C:\\temp"`
+/// becomes `"C:\temp"`, whose `\t` is a tab.
+[<ArgParser true>]
+type ContainsAwkwardStringDefaults =
+    {
+        [<ArgumentDefaultValue "C:\\temp">]
+        Backslash : Choice<string, string>
+        [<ArgumentDefaultValue @"say ""hi""">]
+        Quotes : Choice<string, string>
+        [<ArgumentDefaultValue "tab\there\nnewline">]
+        Control : Choice<string, string>
+        [<ArgumentDefaultValue "caf\u00e9 \u2603">]
+        Unicode : Choice<string, string>
     }
 
 [<ArgParser true>]

--- a/ConsumePlugin/Args.fs
+++ b/ConsumePlugin/Args.fs
@@ -197,8 +197,8 @@ type ContainsFlagDefaultValue =
     static member DefaultDryRun () = DryRunMode.Wet
 
 /// `[<ArgumentDefaultValue>]` is shorthand for an `[<ArgumentDefaultFunction>]` whose function
-/// returns a constant. The value is any valid .NET attribute argument: a literal, a `[<Literal>]`
-/// binding, or an enum case.
+/// returns a constant. The value must be written out as a literal: we splice it into the generated
+/// file, where a name would not necessarily mean what it means here.
 [<ArgParser true>]
 type ContainsLiteralDefault =
     {
@@ -206,10 +206,12 @@ type ContainsLiteralDefault =
         IntVar : Choice<int, int>
         [<ArgumentDefaultValue "hello world">]
         StringVar : Choice<string, string>
-        // A non-literal argument requires parens: F#'s attribute syntax otherwise reads the
-        // identifier as the start of a named argument.
-        [<ArgumentDefaultValue(Consts.TRUE)>]
+        [<ArgumentDefaultValue true>]
         BoolVar : Choice<bool, bool>
+        // Chars are the one literal Fantomas will not round-trip through a spliced node, so we
+        // rebuild the constant rather than passing the user's through.
+        [<ArgumentDefaultValue 'q'>]
+        CharVar : Choice<char, char>
     }
 
 [<ArgParser true>]

--- a/ConsumePlugin/GeneratedArgs.fs
+++ b/ConsumePlugin/GeneratedArgs.fs
@@ -4798,11 +4798,18 @@ module ContainsLiteralDefaultArgParse =
                         "string"
                         (("hello world").ToString () |> sprintf " (default value: %s)")
                         "")
+
                     (sprintf
                         "%s  %s%s%s"
                         (sprintf "--%s" "bool-var")
                         "bool"
-                        (((Consts.TRUE)).ToString () |> sprintf " (default value: %s)")
+                        ((true).ToString () |> sprintf " (default value: %s)")
+                        "")
+                    (sprintf
+                        "%s  %s%s%s"
+                        (sprintf "--%s" "char-var")
+                        "char"
+                        (((char 113)).ToString () |> sprintf " (default value: %s)")
                         "")
                 ]
                 |> String.concat "\n"
@@ -4811,6 +4818,7 @@ module ContainsLiteralDefaultArgParse =
             let mutable arg_0 : Choice<int, int> option = None
             let mutable arg_1 : Choice<string, string> option = None
             let mutable arg_2 : Choice<bool, bool> option = None
+            let mutable arg_3 : Choice<char, char> option = None
 
             let parser_schema : ArgParserRuntime_BasicNoPositionals.ErasedSchema =
                 {
@@ -4837,11 +4845,22 @@ module ContainsLiteralDefaultArgParse =
                                 TypeDescription = ""
                                 Help = None
                             }
+
                             {
                                 Id = 2
                                 Forms = [ "bool-var" ]
                                 AcceptsNegation = false
                                 Arity = ArgParserRuntime_BasicNoPositionals.ErasedArity.BoolLike
+                                Repeatable = false
+                                Requirement = ArgParserRuntime_BasicNoPositionals.ErasedRequirement.HasDefault
+                                TypeDescription = ""
+                                Help = None
+                            }
+                            {
+                                Id = 3
+                                Forms = [ "char-var" ]
+                                AcceptsNegation = false
+                                Arity = ArgParserRuntime_BasicNoPositionals.ErasedArity.One
                                 Repeatable = false
                                 Requirement = ArgParserRuntime_BasicNoPositionals.ErasedRequirement.HasDefault
                                 TypeDescription = ""
@@ -4854,6 +4873,7 @@ module ContainsLiteralDefaultArgParse =
                                 ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 0
                                 ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 1
                                 ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 2
+                                ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 3
                             ]
                         ))
                     Positionals = List.empty
@@ -4908,6 +4928,20 @@ module ContainsLiteralDefaultArgParse =
                         | None ->
                             arg_2 <- Some (Choice1Of2 ((if occurrence.Negated then false else true)))
                             None
+                | 3 ->
+                    match arg_3 with
+                    | Some _ -> None
+                    | None ->
+                        match occurrence.Value with
+                        | Some value ->
+                            try
+                                arg_3 <- Some (Choice1Of2 (value |> (fun x -> System.Char.Parse x)))
+                                None
+                            with _ as exc ->
+                                (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                        | None ->
+                            failwith
+                                "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
                 | _ -> failwith "WoofWare.Myriad internal error in generated parser: unknown argument id"
 
             let parser_storePositional (positionalId : int) (value : string) (afterSeparator : bool) : string option =
@@ -4930,6 +4964,11 @@ module ContainsLiteralDefaultArgParse =
                     | Some (Choice1Of2 x) -> x.ToString ()
                     | Some (Choice2Of2 x) -> x.ToString ()
                     | None -> "<no value>"
+                | 3 ->
+                    match arg_3 with
+                    | Some (Choice1Of2 x) -> x.ToString ()
+                    | Some (Choice2Of2 x) -> x.ToString ()
+                    | None -> "<no value>"
                 | _ -> "<no value>"
 
             let parser_applyDefault (leafId : int) : string option =
@@ -4941,7 +4980,10 @@ module ContainsLiteralDefaultArgParse =
                     arg_1 <- Some (Choice2Of2 (("hello world")))
                     None
                 | 2 ->
-                    arg_2 <- Some (Choice2Of2 (((Consts.TRUE))))
+                    arg_2 <- Some (Choice2Of2 ((true)))
+                    None
+                | 3 ->
+                    arg_3 <- Some (Choice2Of2 (((char 113))))
                     None
                 | _ -> failwith "WoofWare.Myriad internal error in generated parser: unknown defaulted argument id"
 
@@ -4964,6 +5006,12 @@ module ContainsLiteralDefaultArgParse =
                 {
                     BoolVar =
                         (match arg_2 with
+                         | Some x -> x
+                         | None ->
+                             failwith
+                                 "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
+                    CharVar =
+                        (match arg_3 with
                          | Some x -> x
                          | None ->
                              failwith

--- a/ConsumePlugin/GeneratedArgs.fs
+++ b/ConsumePlugin/GeneratedArgs.fs
@@ -4772,6 +4772,229 @@ open System
 open System.IO
 open WoofWare.Myriad.Plugins
 
+/// Methods to parse arguments for the type ContainsLiteralDefault
+[<AutoOpen>]
+module ContainsLiteralDefaultArgParse =
+    /// Extension methods for argument parsing
+    type ContainsLiteralDefault with
+
+        static member parse'
+            (getEnvironmentVariable : string -> string option)
+            (args : string list)
+            : ContainsLiteralDefault
+            =
+            let helpText () =
+                [
+                    (sprintf
+                        "%s  %s%s%s"
+                        (sprintf "--%s" "int-var")
+                        "int32"
+                        ((3).ToString () |> sprintf " (default value: %s)")
+                        "")
+
+                    (sprintf
+                        "%s  %s%s%s"
+                        (sprintf "--%s" "string-var")
+                        "string"
+                        (("hello world").ToString () |> sprintf " (default value: %s)")
+                        "")
+                    (sprintf
+                        "%s  %s%s%s"
+                        (sprintf "--%s" "bool-var")
+                        "bool"
+                        (((Consts.TRUE)).ToString () |> sprintf " (default value: %s)")
+                        "")
+                ]
+                |> String.concat "\n"
+
+            let parser_LeftoverArgs : string ResizeArray = ResizeArray ()
+            let mutable arg_0 : Choice<int, int> option = None
+            let mutable arg_1 : Choice<string, string> option = None
+            let mutable arg_2 : Choice<bool, bool> option = None
+
+            let parser_schema : ArgParserRuntime_BasicNoPositionals.ErasedSchema =
+                {
+                    Leaves =
+                        [
+                            {
+                                Id = 0
+                                Forms = [ "int-var" ]
+                                AcceptsNegation = false
+                                Arity = ArgParserRuntime_BasicNoPositionals.ErasedArity.One
+                                Repeatable = false
+                                Requirement = ArgParserRuntime_BasicNoPositionals.ErasedRequirement.HasDefault
+                                TypeDescription = ""
+                                Help = None
+                            }
+
+                            {
+                                Id = 1
+                                Forms = [ "string-var" ]
+                                AcceptsNegation = false
+                                Arity = ArgParserRuntime_BasicNoPositionals.ErasedArity.One
+                                Repeatable = false
+                                Requirement = ArgParserRuntime_BasicNoPositionals.ErasedRequirement.HasDefault
+                                TypeDescription = ""
+                                Help = None
+                            }
+                            {
+                                Id = 2
+                                Forms = [ "bool-var" ]
+                                AcceptsNegation = false
+                                Arity = ArgParserRuntime_BasicNoPositionals.ErasedArity.BoolLike
+                                Repeatable = false
+                                Requirement = ArgParserRuntime_BasicNoPositionals.ErasedRequirement.HasDefault
+                                TypeDescription = ""
+                                Help = None
+                            }
+                        ]
+                    Tree =
+                        (ArgParserRuntime_BasicNoPositionals.ErasedTree.Product (
+                            [
+                                ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 0
+                                ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 1
+                                ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 2
+                            ]
+                        ))
+                    Positionals = List.empty
+                }
+
+            let parser_storeOccurrence
+                (occurrence : ArgParserRuntime_BasicNoPositionals.ErasedOccurrence)
+                : string option
+                =
+                match occurrence.LeafId with
+                | 0 ->
+                    match arg_0 with
+                    | Some _ -> None
+                    | None ->
+                        match occurrence.Value with
+                        | Some value ->
+                            try
+                                arg_0 <- Some (Choice1Of2 (value |> (fun x -> System.Int32.Parse x)))
+                                None
+                            with _ as exc ->
+                                (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                        | None ->
+                            failwith
+                                "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
+                | 1 ->
+                    match arg_1 with
+                    | Some _ -> None
+                    | None ->
+                        match occurrence.Value with
+                        | Some value ->
+                            try
+                                arg_1 <- Some (Choice1Of2 (value |> (fun x -> x)))
+                                None
+                            with _ as exc ->
+                                (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                        | None ->
+                            failwith
+                                "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
+                | 2 ->
+                    match arg_2 with
+                    | Some _ -> None
+                    | None ->
+                        match occurrence.Value with
+                        | Some value ->
+                            try
+                                let parsedBool = System.Boolean.Parse value
+                                let parsedBool = if occurrence.Negated then not parsedBool else parsedBool
+                                arg_2 <- Some (Choice1Of2 (parsedBool))
+                                None
+                            with _ as exc ->
+                                (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                        | None ->
+                            arg_2 <- Some (Choice1Of2 ((if occurrence.Negated then false else true)))
+                            None
+                | _ -> failwith "WoofWare.Myriad internal error in generated parser: unknown argument id"
+
+            let parser_storePositional (positionalId : int) (value : string) (afterSeparator : bool) : string option =
+                failwith "WoofWare.Myriad internal error in generated parser: no positional sink exists"
+
+            let parser_renderStored (leafId : int) : string =
+                match leafId with
+                | 0 ->
+                    match arg_0 with
+                    | Some (Choice1Of2 x) -> x.ToString ()
+                    | Some (Choice2Of2 x) -> x.ToString ()
+                    | None -> "<no value>"
+                | 1 ->
+                    match arg_1 with
+                    | Some (Choice1Of2 x) -> x.ToString ()
+                    | Some (Choice2Of2 x) -> x.ToString ()
+                    | None -> "<no value>"
+                | 2 ->
+                    match arg_2 with
+                    | Some (Choice1Of2 x) -> x.ToString ()
+                    | Some (Choice2Of2 x) -> x.ToString ()
+                    | None -> "<no value>"
+                | _ -> "<no value>"
+
+            let parser_applyDefault (leafId : int) : string option =
+                match leafId with
+                | 0 ->
+                    arg_0 <- Some (Choice2Of2 ((3)))
+                    None
+                | 1 ->
+                    arg_1 <- Some (Choice2Of2 (("hello world")))
+                    None
+                | 2 ->
+                    arg_2 <- Some (Choice2Of2 (((Consts.TRUE))))
+                    None
+                | _ -> failwith "WoofWare.Myriad internal error in generated parser: unknown defaulted argument id"
+
+            let parser_callbacks : ArgParserRuntime_BasicNoPositionals.TypedCallbacks =
+                {
+                    StoreOccurrence = parser_storeOccurrence
+                    StorePositional = parser_storePositional
+                    HelpText = helpText
+                    RenderStored = parser_renderStored
+                    ApplyDefault = parser_applyDefault
+                }
+
+            match
+                ArgParserRuntime_BasicNoPositionals.runParse
+                    (ArgParserRuntime_BasicNoPositionals.WellFormedSchema.checkOrFail parser_schema)
+                    parser_callbacks
+                    args
+            with
+            | ArgParserRuntime_BasicNoPositionals.ParseOutcome.Success parser_selection ->
+                {
+                    BoolVar =
+                        (match arg_2 with
+                         | Some x -> x
+                         | None ->
+                             failwith
+                                 "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
+                    IntVar =
+                        (match arg_0 with
+                         | Some x -> x
+                         | None ->
+                             failwith
+                                 "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
+                    StringVar =
+                        (match arg_1 with
+                         | Some x -> x
+                         | None ->
+                             failwith
+                                 "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
+                }
+            | ArgParserRuntime_BasicNoPositionals.ParseOutcome.HelpRequested ->
+                helpText () |> failwithf "Help text requested.\n%s"
+            | ArgParserRuntime_BasicNoPositionals.ParseOutcome.Fatal message -> failwith message
+            | ArgParserRuntime_BasicNoPositionals.ParseOutcome.Errors errors ->
+                errors |> String.concat "\n" |> failwithf "Errors during parse!\n%s"
+
+        static member parse (args : string list) : ContainsLiteralDefault =
+            ContainsLiteralDefault.parse' (System.Environment.GetEnvironmentVariable >> Option.ofObj) args
+namespace ConsumePlugin
+
+open System
+open System.IO
+open WoofWare.Myriad.Plugins
+
 /// Methods to parse arguments for the type ManyLongForms
 [<AutoOpen>]
 module ManyLongFormsArgParse =

--- a/ConsumePlugin/GeneratedArgs.fs
+++ b/ConsumePlugin/GeneratedArgs.fs
@@ -5043,6 +5043,275 @@ open System
 open System.IO
 open WoofWare.Myriad.Plugins
 
+/// Methods to parse arguments for the type ContainsAwkwardStringDefaults
+[<AutoOpen>]
+module ContainsAwkwardStringDefaultsArgParse =
+    /// Extension methods for argument parsing
+    type ContainsAwkwardStringDefaults with
+
+        static member parse'
+            (getEnvironmentVariable : string -> string option)
+            (args : string list)
+            : ContainsAwkwardStringDefaults
+            =
+            let helpText () =
+                [
+                    (sprintf
+                        "%s  %s%s%s"
+                        (sprintf "--%s" "backslash")
+                        "string"
+                        (("C:\\temp").ToString () |> sprintf " (default value: %s)")
+                        "")
+
+                    (sprintf
+                        "%s  %s%s%s"
+                        (sprintf "--%s" "quotes")
+                        "string"
+                        (("say \u0022hi\u0022").ToString () |> sprintf " (default value: %s)")
+                        "")
+
+                    (sprintf
+                        "%s  %s%s%s"
+                        (sprintf "--%s" "control")
+                        "string"
+                        (("tab\u0009here\u000anewline").ToString () |> sprintf " (default value: %s)")
+                        "")
+                    (sprintf
+                        "%s  %s%s%s"
+                        (sprintf "--%s" "unicode")
+                        "string"
+                        (("caf\u00e9 \u2603").ToString () |> sprintf " (default value: %s)")
+                        "")
+                ]
+                |> String.concat "\n"
+
+            let parser_LeftoverArgs : string ResizeArray = ResizeArray ()
+            let mutable arg_0 : Choice<string, string> option = None
+            let mutable arg_1 : Choice<string, string> option = None
+            let mutable arg_2 : Choice<string, string> option = None
+            let mutable arg_3 : Choice<string, string> option = None
+
+            let parser_schema : ArgParserRuntime_BasicNoPositionals.ErasedSchema =
+                {
+                    Leaves =
+                        [
+                            {
+                                Id = 0
+                                Forms = [ "backslash" ]
+                                AcceptsNegation = false
+                                Arity = ArgParserRuntime_BasicNoPositionals.ErasedArity.One
+                                Repeatable = false
+                                Requirement = ArgParserRuntime_BasicNoPositionals.ErasedRequirement.HasDefault
+                                TypeDescription = ""
+                                Help = None
+                            }
+
+                            {
+                                Id = 1
+                                Forms = [ "quotes" ]
+                                AcceptsNegation = false
+                                Arity = ArgParserRuntime_BasicNoPositionals.ErasedArity.One
+                                Repeatable = false
+                                Requirement = ArgParserRuntime_BasicNoPositionals.ErasedRequirement.HasDefault
+                                TypeDescription = ""
+                                Help = None
+                            }
+
+                            {
+                                Id = 2
+                                Forms = [ "control" ]
+                                AcceptsNegation = false
+                                Arity = ArgParserRuntime_BasicNoPositionals.ErasedArity.One
+                                Repeatable = false
+                                Requirement = ArgParserRuntime_BasicNoPositionals.ErasedRequirement.HasDefault
+                                TypeDescription = ""
+                                Help = None
+                            }
+                            {
+                                Id = 3
+                                Forms = [ "unicode" ]
+                                AcceptsNegation = false
+                                Arity = ArgParserRuntime_BasicNoPositionals.ErasedArity.One
+                                Repeatable = false
+                                Requirement = ArgParserRuntime_BasicNoPositionals.ErasedRequirement.HasDefault
+                                TypeDescription = ""
+                                Help = None
+                            }
+                        ]
+                    Tree =
+                        (ArgParserRuntime_BasicNoPositionals.ErasedTree.Product (
+                            [
+                                ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 0
+                                ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 1
+                                ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 2
+                                ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 3
+                            ]
+                        ))
+                    Positionals = List.empty
+                }
+
+            let parser_storeOccurrence
+                (occurrence : ArgParserRuntime_BasicNoPositionals.ErasedOccurrence)
+                : string option
+                =
+                match occurrence.LeafId with
+                | 0 ->
+                    match arg_0 with
+                    | Some _ -> None
+                    | None ->
+                        match occurrence.Value with
+                        | Some value ->
+                            try
+                                arg_0 <- Some (Choice1Of2 (value |> (fun x -> x)))
+                                None
+                            with _ as exc ->
+                                (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                        | None ->
+                            failwith
+                                "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
+                | 1 ->
+                    match arg_1 with
+                    | Some _ -> None
+                    | None ->
+                        match occurrence.Value with
+                        | Some value ->
+                            try
+                                arg_1 <- Some (Choice1Of2 (value |> (fun x -> x)))
+                                None
+                            with _ as exc ->
+                                (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                        | None ->
+                            failwith
+                                "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
+                | 2 ->
+                    match arg_2 with
+                    | Some _ -> None
+                    | None ->
+                        match occurrence.Value with
+                        | Some value ->
+                            try
+                                arg_2 <- Some (Choice1Of2 (value |> (fun x -> x)))
+                                None
+                            with _ as exc ->
+                                (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                        | None ->
+                            failwith
+                                "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
+                | 3 ->
+                    match arg_3 with
+                    | Some _ -> None
+                    | None ->
+                        match occurrence.Value with
+                        | Some value ->
+                            try
+                                arg_3 <- Some (Choice1Of2 (value |> (fun x -> x)))
+                                None
+                            with _ as exc ->
+                                (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                        | None ->
+                            failwith
+                                "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
+                | _ -> failwith "WoofWare.Myriad internal error in generated parser: unknown argument id"
+
+            let parser_storePositional (positionalId : int) (value : string) (afterSeparator : bool) : string option =
+                failwith "WoofWare.Myriad internal error in generated parser: no positional sink exists"
+
+            let parser_renderStored (leafId : int) : string =
+                match leafId with
+                | 0 ->
+                    match arg_0 with
+                    | Some (Choice1Of2 x) -> x.ToString ()
+                    | Some (Choice2Of2 x) -> x.ToString ()
+                    | None -> "<no value>"
+                | 1 ->
+                    match arg_1 with
+                    | Some (Choice1Of2 x) -> x.ToString ()
+                    | Some (Choice2Of2 x) -> x.ToString ()
+                    | None -> "<no value>"
+                | 2 ->
+                    match arg_2 with
+                    | Some (Choice1Of2 x) -> x.ToString ()
+                    | Some (Choice2Of2 x) -> x.ToString ()
+                    | None -> "<no value>"
+                | 3 ->
+                    match arg_3 with
+                    | Some (Choice1Of2 x) -> x.ToString ()
+                    | Some (Choice2Of2 x) -> x.ToString ()
+                    | None -> "<no value>"
+                | _ -> "<no value>"
+
+            let parser_applyDefault (leafId : int) : string option =
+                match leafId with
+                | 0 ->
+                    arg_0 <- Some (Choice2Of2 (("C:\\temp")))
+                    None
+                | 1 ->
+                    arg_1 <- Some (Choice2Of2 (("say \u0022hi\u0022")))
+                    None
+                | 2 ->
+                    arg_2 <- Some (Choice2Of2 (("tab\u0009here\u000anewline")))
+                    None
+                | 3 ->
+                    arg_3 <- Some (Choice2Of2 (("caf\u00e9 \u2603")))
+                    None
+                | _ -> failwith "WoofWare.Myriad internal error in generated parser: unknown defaulted argument id"
+
+            let parser_callbacks : ArgParserRuntime_BasicNoPositionals.TypedCallbacks =
+                {
+                    StoreOccurrence = parser_storeOccurrence
+                    StorePositional = parser_storePositional
+                    HelpText = helpText
+                    RenderStored = parser_renderStored
+                    ApplyDefault = parser_applyDefault
+                }
+
+            match
+                ArgParserRuntime_BasicNoPositionals.runParse
+                    (ArgParserRuntime_BasicNoPositionals.WellFormedSchema.checkOrFail parser_schema)
+                    parser_callbacks
+                    args
+            with
+            | ArgParserRuntime_BasicNoPositionals.ParseOutcome.Success parser_selection ->
+                {
+                    Backslash =
+                        (match arg_0 with
+                         | Some x -> x
+                         | None ->
+                             failwith
+                                 "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
+                    Control =
+                        (match arg_2 with
+                         | Some x -> x
+                         | None ->
+                             failwith
+                                 "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
+                    Quotes =
+                        (match arg_1 with
+                         | Some x -> x
+                         | None ->
+                             failwith
+                                 "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
+                    Unicode =
+                        (match arg_3 with
+                         | Some x -> x
+                         | None ->
+                             failwith
+                                 "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
+                }
+            | ArgParserRuntime_BasicNoPositionals.ParseOutcome.HelpRequested ->
+                helpText () |> failwithf "Help text requested.\n%s"
+            | ArgParserRuntime_BasicNoPositionals.ParseOutcome.Fatal message -> failwith message
+            | ArgParserRuntime_BasicNoPositionals.ParseOutcome.Errors errors ->
+                errors |> String.concat "\n" |> failwithf "Errors during parse!\n%s"
+
+        static member parse (args : string list) : ContainsAwkwardStringDefaults =
+            ContainsAwkwardStringDefaults.parse' (System.Environment.GetEnvironmentVariable >> Option.ofObj) args
+namespace ConsumePlugin
+
+open System
+open System.IO
+open WoofWare.Myriad.Plugins
+
 /// Methods to parse arguments for the type ManyLongForms
 [<AutoOpen>]
 module ManyLongFormsArgParse =

--- a/README.md
+++ b/README.md
@@ -251,6 +251,9 @@ Since `foo` is an ordinary .NET attribute argument, F# restricts it to compile-t
 (A discriminated union case, such as a flag DU's, is not one of those, so those still need `[<ArgumentDefaultFunction>]`.)
 Note that F# requires parentheses around an attribute argument which is not a bare literal: `[<ArgumentDefaultValue(Consts.Foo)>]`, but `[<ArgumentDefaultValue 4>]`.
 
+The value is spliced into the generated file rather than evaluated at your attribute, so we recognise the constant forms and refuse anything else.
+In particular F#'s context-sensitive constants (`__LINE__`, `__SOURCE_FILE__`, `__SOURCE_DIRECTORY__`) are rejected despite being valid attribute arguments: they would be resolved against the generated file rather than yours.
+
 You can control `TimeSpan` and friends with the `[<InvariantCulture>]` and `[<ParseExact @"hh\:mm\:ss">]` attributes.
 
 You can generate extension methods for the type, instead of a module with the type's name, using `[<ArgParser (* isExtensionMethod = *) true>]`.

--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ type Foo =
         B : Choice<int, int>
         [<ArgumentDefaultEnvironmentVariable "MY_ENV_VAR">]
         BWithEnv : Choice<int, int>
+        [<ArgumentDefaultValue 4>]
+        BWithConstant : Choice<int, int>
         [<ArgumentDefaultFunction>]
         DryRun : Choice<DryRunMode, DryRunMode>
         AnimalPart : AnimalArgs
@@ -225,6 +227,7 @@ and you get back respectively these objects:
     A = None
     B = Choice2Of2 4
     BWithEnv = Choice2Of2 100 // whatever the value of $MY_ENV_VAR was, or a failed parse
+    BWithConstant = Choice2Of2 4
     DryRun = Choice2Of2 DryRunMode.Wet
     AnimalPart = AnimalArgs.Fowl { Species = "pheasant" }
 }
@@ -234,6 +237,7 @@ and you get back respectively these objects:
     A = None
     B = Choice2Of2 4
     BWithEnv = Choice1Of2 8
+    BWithConstant = Choice2Of2 4
     DryRun = Choice1Of2 DryRunMode.Dry
     AnimalPart = AnimalArgs.Fish { Fins = 39 }
 }
@@ -241,6 +245,11 @@ and you get back respectively these objects:
 
 Default arguments are handled as `Choice<'a, 'a>`:
 you get a `Choice1Of2` if the user provided the input, or a `Choice2Of2` if the parser filled in your specified default value.
+
+`[<ArgumentDefaultValue foo>]` is shorthand for an `[<ArgumentDefaultFunction>]` whose function just returns a constant.
+Since `foo` is an ordinary .NET attribute argument, F# restricts it to compile-time constants: literals, `[<Literal>]` bindings, and enum cases.
+(A discriminated union case, such as a flag DU's, is not one of those, so those still need `[<ArgumentDefaultFunction>]`.)
+Note that F# requires parentheses around an attribute argument which is not a bare literal: `[<ArgumentDefaultValue(Consts.Foo)>]`, but `[<ArgumentDefaultValue 4>]`.
 
 You can control `TimeSpan` and friends with the `[<InvariantCulture>]` and `[<ParseExact @"hh\:mm\:ss">]` attributes.
 

--- a/README.md
+++ b/README.md
@@ -247,12 +247,12 @@ Default arguments are handled as `Choice<'a, 'a>`:
 you get a `Choice1Of2` if the user provided the input, or a `Choice2Of2` if the parser filled in your specified default value.
 
 `[<ArgumentDefaultValue foo>]` is shorthand for an `[<ArgumentDefaultFunction>]` whose function just returns a constant.
-Since `foo` is an ordinary .NET attribute argument, F# restricts it to compile-time constants: literals, `[<Literal>]` bindings, and enum cases.
-(A discriminated union case, such as a flag DU's, is not one of those, so those still need `[<ArgumentDefaultFunction>]`.)
-Note that F# requires parentheses around an attribute argument which is not a bare literal: `[<ArgumentDefaultValue(Consts.Foo)>]`, but `[<ArgumentDefaultValue 4>]`.
+`foo` must be a literal written out in full.
 
-The value is spliced into the generated file rather than evaluated at your attribute, so we recognise the constant forms and refuse anything else.
-In particular F#'s context-sensitive constants (`__LINE__`, `__SOURCE_FILE__`, `__SOURCE_DIRECTORY__`) are rejected despite being valid attribute arguments: they would be resolved against the generated file rather than yours.
+The value is reproduced in the generated file rather than evaluated at your attribute, so anything whose meaning depends on where it is written is rejected.
+That includes a name standing for a constant (a `[<Literal>]` binding, an enum case): the generated file hoists every `open` in your source above the parser, so a name need not resolve to the same binding there as here, and a later `open` which shadows an earlier one would silently change the default's value.
+It also includes F#'s context-sensitive constants (`__LINE__`, `__SOURCE_FILE__`, `__SOURCE_DIRECTORY__`), which would be resolved against the generated file rather than yours.
+Use `[<ArgumentDefaultFunction>]` for any of those, and for anything which is not a constant at all (such as a flag DU's case): that function is evaluated in your own file.
 
 You can control `TimeSpan` and friends with the `[<InvariantCulture>]` and `[<ParseExact @"hh\:mm\:ss">]` attributes.
 

--- a/README.md
+++ b/README.md
@@ -254,6 +254,8 @@ That includes a name standing for a constant (a `[<Literal>]` binding, an enum c
 It also includes F#'s context-sensitive constants (`__LINE__`, `__SOURCE_FILE__`, `__SOURCE_DIRECTORY__`), which would be resolved against the generated file rather than yours.
 Use `[<ArgumentDefaultFunction>]` for any of those, and for anything which is not a constant at all (such as a flag DU's case): that function is evaluated in your own file.
 
+`null` is a literal like any other here, though F# will only let you write it if your own project is not checking nullness (an `obj`-typed attribute argument does not admit null when it is).
+
 You can control `TimeSpan` and friends with the `[<InvariantCulture>]` and `[<ParseExact @"hh\:mm\:ss">]` attributes.
 
 You can generate extension methods for the type, instead of a module with the type's name, using `[<ArgParser (* isExtensionMethod = *) true>]`.

--- a/README.md
+++ b/README.md
@@ -243,22 +243,11 @@ and you get back respectively these objects:
 }
 ```
 
-Default arguments are handled as `Choice<'a, 'a>`:
-you get a `Choice1Of2` if the user provided the input, or a `Choice2Of2` if the parser filled in your specified default value.
-
-`[<ArgumentDefaultValue foo>]` is shorthand for an `[<ArgumentDefaultFunction>]` whose function just returns a constant.
-`foo` must be a literal written out in full.
-
-The value is reproduced in the generated file rather than evaluated at your attribute, so anything whose meaning depends on where it is written is rejected.
-That includes a name standing for a constant (a `[<Literal>]` binding, an enum case): the generated file hoists every `open` in your source above the parser, so a name need not resolve to the same binding there as here, and a later `open` which shadows an earlier one would silently change the default's value.
-It also includes F#'s context-sensitive constants (`__LINE__`, `__SOURCE_FILE__`, `__SOURCE_DIRECTORY__`), which would be resolved against the generated file rather than yours.
-Use `[<ArgumentDefaultFunction>]` for any of those, and for anything which is not a constant at all (such as a flag DU's case): that function is evaluated in your own file.
-
-`null` is a literal like any other here, though F# will only let you write it if your own project is not checking nullness (an `obj`-typed attribute argument does not admit null when it is).
-
 You can control `TimeSpan` and friends with the `[<InvariantCulture>]` and `[<ParseExact @"hh\:mm\:ss">]` attributes.
 
 You can generate extension methods for the type, instead of a module with the type's name, using `[<ArgParser (* isExtensionMethod = *) true>]`.
+
+### Positional arguments
 
 You can collect leftover args as positional args, with `[<PositionalArgs>]`; this respects a trailing `--` so that you can specify positional args which look like flags.
 
@@ -266,6 +255,16 @@ Restrictions on the composition of positional args and DUs:
 
 * `[<PositionalArgs true>]` (to collect unrecognised flag-like arguments like `--unrecognised-arg` as positionals) will fail to generate code if present in a parser that also contains DUs, because the failure mode if the user makes a typo in an arg name is very confusing in that case.
 * We only use structural information, and not "we tried and failed to parse positional args as a specified type", when deciding which DU case to select. The parser uses named args to choose where the positional args are going to be collected, and only then tries to parse positional values.
+
+### Default arguments
+
+Default arguments are handled as `Choice<'a, 'a>`:
+you get a `Choice1Of2` if the user provided the input, or a `Choice2Of2` if the parser filled in your specified default value.
+
+`[<ArgumentDefaultValue foo>]` is shorthand for an `[<ArgumentDefaultFunction>]` whose function just returns a constant `foo`.
+`foo` must be a literal written out in full, because the value is reproduced in the generated file rather than evaluated at your attribute, so anything whose meaning depends on where it is written must be rejected for safety.
+That includes a name standing for a constant (a `[<Literal>]` binding, an enum case): the generated file hoists every `open` in your source above the parser, so a name need not resolve to the same binding there as here, and a later `open` which shadows an earlier one would silently change the default's value.
+Use `[<ArgumentDefaultFunction>]` if the generator rejects your `ArgumentDefaultValue`.
 
 ### Map-valued arguments
 

--- a/WoofWare.Myriad.Plugins.Attributes/ArgParserAttributes.fs
+++ b/WoofWare.Myriad.Plugins.Attributes/ArgParserAttributes.fs
@@ -62,6 +62,28 @@ type ArgumentDefaultFunctionAttribute () =
 type ArgumentDefaultEnvironmentVariableAttribute (envVar : string) =
     inherit Attribute ()
 
+/// Attribute indicating that this field shall have the given constant default value.
+/// This is shorthand for `[<ArgumentDefaultFunction>]` in the common case where the default function
+/// would simply return a constant.
+///
+/// This attribute can only be placed on fields of type `Choice<_, _>` where both type parameters
+/// are the same.
+/// After a successful parse, the value is Choice1Of2 if the user supplied an input,
+/// or Choice2Of2 if the input was this constant.
+///
+/// The value you supply is spliced verbatim into the generated code, so it must have the field's
+/// element type: `[<ArgumentDefaultValue 3>]` on a `Choice<int, int>`, but
+/// `[<ArgumentDefaultValue 3L>]` on a `Choice<int64, int64>`. A mismatch is a compile error in
+/// the generated file rather than at the attribute itself.
+///
+/// Since this is an ordinary .NET attribute argument, F# restricts you to compile-time constants:
+/// literals, `[<Literal>]` values, and enum cases. (Anything else, and in particular a discriminated
+/// union case such as a flag DU's, needs `[<ArgumentDefaultFunction>]` instead.) Note that F#'s
+/// attribute syntax requires parentheses around an argument which is not a bare literal:
+/// `[<ArgumentDefaultValue(Consts.Foo)>]`, but `[<ArgumentDefaultValue 3>]`.
+type ArgumentDefaultValueAttribute (defaultValue : obj) =
+    inherit Attribute ()
+
 /// Attribute indicating that this field or type shall have the given help text, when `--help` is invoked
 /// or when a parse error causes us to print help text.
 /// When applied to a record type, the help text appears at the top of the help output, before the field descriptions.

--- a/WoofWare.Myriad.Plugins.Attributes/ArgParserAttributes.fs
+++ b/WoofWare.Myriad.Plugins.Attributes/ArgParserAttributes.fs
@@ -71,7 +71,7 @@ type ArgumentDefaultEnvironmentVariableAttribute (envVar : string) =
 /// After a successful parse, the value is Choice1Of2 if the user supplied an input,
 /// or Choice2Of2 if the input was this constant.
 ///
-/// The value you supply is spliced verbatim into the generated code, so it must have the field's
+/// The value you supply is reproduced in the generated code, so it must have the field's
 /// element type: `[<ArgumentDefaultValue 3>]` on a `Choice<int, int>`, but
 /// `[<ArgumentDefaultValue 3L>]` on a `Choice<int64, int64>`. A mismatch is a compile error in
 /// the generated file rather than at the attribute itself.
@@ -90,6 +90,10 @@ type ArgumentDefaultEnvironmentVariableAttribute (envVar : string) =
 /// Use `[<ArgumentDefaultFunction>]` for any of those, and for anything which is not a constant at
 /// all (in particular a discriminated union case, such as a flag DU's): that function is evaluated
 /// in your own file, so it means what you wrote.
+///
+/// `null` is a literal like any other here. Note though that F# will only let you write it if your
+/// own project is not checking nullness (an `obj`-typed attribute argument does not admit null when
+/// it is), and that the `FS3559` warning, if you have turned it on, fires on the attribute too.
 type ArgumentDefaultValueAttribute (defaultValue : obj) =
     inherit Attribute ()
 

--- a/WoofWare.Myriad.Plugins.Attributes/ArgParserAttributes.fs
+++ b/WoofWare.Myriad.Plugins.Attributes/ArgParserAttributes.fs
@@ -81,6 +81,11 @@ type ArgumentDefaultEnvironmentVariableAttribute (envVar : string) =
 /// union case such as a flag DU's, needs `[<ArgumentDefaultFunction>]` instead.) Note that F#'s
 /// attribute syntax requires parentheses around an argument which is not a bare literal:
 /// `[<ArgumentDefaultValue(Consts.Foo)>]`, but `[<ArgumentDefaultValue 3>]`.
+///
+/// F#'s context-sensitive constants (`__LINE__`, `__SOURCE_FILE__`, `__SOURCE_DIRECTORY__`) are
+/// rejected, even though they are valid attribute arguments: since we splice rather than evaluate,
+/// they would be resolved against the generated file instead of yours. Use
+/// `[<ArgumentDefaultFunction>]`, whose function is evaluated in your own file, if you want one.
 type ArgumentDefaultValueAttribute (defaultValue : obj) =
     inherit Attribute ()
 

--- a/WoofWare.Myriad.Plugins.Attributes/ArgParserAttributes.fs
+++ b/WoofWare.Myriad.Plugins.Attributes/ArgParserAttributes.fs
@@ -76,16 +76,20 @@ type ArgumentDefaultEnvironmentVariableAttribute (envVar : string) =
 /// `[<ArgumentDefaultValue 3L>]` on a `Choice<int64, int64>`. A mismatch is a compile error in
 /// the generated file rather than at the attribute itself.
 ///
-/// Since this is an ordinary .NET attribute argument, F# restricts you to compile-time constants:
-/// literals, `[<Literal>]` values, and enum cases. (Anything else, and in particular a discriminated
-/// union case such as a flag DU's, needs `[<ArgumentDefaultFunction>]` instead.) Note that F#'s
-/// attribute syntax requires parentheses around an argument which is not a bare literal:
-/// `[<ArgumentDefaultValue(Consts.Foo)>]`, but `[<ArgumentDefaultValue 3>]`.
+/// The value must be a literal written out in full. We reproduce it in the generated file rather
+/// than evaluating it at your attribute, so anything whose meaning depends on where it is written
+/// is rejected:
 ///
-/// F#'s context-sensitive constants (`__LINE__`, `__SOURCE_FILE__`, `__SOURCE_DIRECTORY__`) are
-/// rejected, even though they are valid attribute arguments: since we splice rather than evaluate,
-/// they would be resolved against the generated file instead of yours. Use
-/// `[<ArgumentDefaultFunction>]`, whose function is evaluated in your own file, if you want one.
+/// * A name standing for a constant (a `[<Literal>]` binding, an enum case) is rejected. The
+///   generated file hoists every `open` in your source above the parser, so a name need not resolve
+///   to the same binding there as here -- a later `open` which shadows an earlier one would silently
+///   change the default's value.
+/// * F#'s context-sensitive constants (`__LINE__`, `__SOURCE_FILE__`, `__SOURCE_DIRECTORY__`) are
+///   rejected: they would be resolved against the generated file instead of yours.
+///
+/// Use `[<ArgumentDefaultFunction>]` for any of those, and for anything which is not a constant at
+/// all (in particular a discriminated union case, such as a flag DU's): that function is evaluated
+/// in your own file, so it means what you wrote.
 type ArgumentDefaultValueAttribute (defaultValue : obj) =
     inherit Attribute ()
 

--- a/WoofWare.Myriad.Plugins.Attributes/ArgParserAttributes.fs
+++ b/WoofWare.Myriad.Plugins.Attributes/ArgParserAttributes.fs
@@ -69,31 +69,17 @@ type ArgumentDefaultEnvironmentVariableAttribute (envVar : string) =
 /// This attribute can only be placed on fields of type `Choice<_, _>` where both type parameters
 /// are the same.
 /// After a successful parse, the value is Choice1Of2 if the user supplied an input,
-/// or Choice2Of2 if the input was this constant.
+/// or Choice2Of2 if the input was not supplied and defaulted to the constant.
 ///
 /// The value you supply is reproduced in the generated code, so it must have the field's
 /// element type: `[<ArgumentDefaultValue 3>]` on a `Choice<int, int>`, but
 /// `[<ArgumentDefaultValue 3L>]` on a `Choice<int64, int64>`. A mismatch is a compile error in
-/// the generated file rather than at the attribute itself.
+/// the generated file.
 ///
-/// The value must be a literal written out in full. We reproduce it in the generated file rather
-/// than evaluating it at your attribute, so anything whose meaning depends on where it is written
-/// is rejected:
-///
-/// * A name standing for a constant (a `[<Literal>]` binding, an enum case) is rejected. The
-///   generated file hoists every `open` in your source above the parser, so a name need not resolve
-///   to the same binding there as here -- a later `open` which shadows an earlier one would silently
-///   change the default's value.
-/// * F#'s context-sensitive constants (`__LINE__`, `__SOURCE_FILE__`, `__SOURCE_DIRECTORY__`) are
-///   rejected: they would be resolved against the generated file instead of yours.
-///
-/// Use `[<ArgumentDefaultFunction>]` for any of those, and for anything which is not a constant at
-/// all (in particular a discriminated union case, such as a flag DU's): that function is evaluated
-/// in your own file, so it means what you wrote.
-///
-/// `null` is a literal like any other here. Note though that F# will only let you write it if your
-/// own project is not checking nullness (an `obj`-typed attribute argument does not admit null when
-/// it is), and that the `FS3559` warning, if you have turned it on, fires on the attribute too.
+/// The value must be a literal written out in full.
+/// The generator rejects names (e.g. a `[<Literal>]` binding or an enum case), because their meanings may change
+/// depending on what `open` statements are present.
+/// You can fall back to using `[<ArgumentDefaultFunction>]` for those.
 type ArgumentDefaultValueAttribute (defaultValue : obj) =
     inherit Attribute ()
 

--- a/WoofWare.Myriad.Plugins.Attributes/SurfaceBaseline.txt
+++ b/WoofWare.Myriad.Plugins.Attributes/SurfaceBaseline.txt
@@ -7,6 +7,8 @@ WoofWare.Myriad.Plugins.ArgumentDefaultEnvironmentVariableAttribute inherit Syst
 WoofWare.Myriad.Plugins.ArgumentDefaultEnvironmentVariableAttribute..ctor [constructor]: string
 WoofWare.Myriad.Plugins.ArgumentDefaultFunctionAttribute inherit System.Attribute
 WoofWare.Myriad.Plugins.ArgumentDefaultFunctionAttribute..ctor [constructor]: unit
+WoofWare.Myriad.Plugins.ArgumentDefaultValueAttribute inherit System.Attribute
+WoofWare.Myriad.Plugins.ArgumentDefaultValueAttribute..ctor [constructor]: obj
 WoofWare.Myriad.Plugins.ArgumentFlagAttribute inherit System.Attribute
 WoofWare.Myriad.Plugins.ArgumentFlagAttribute..ctor [constructor]: bool
 WoofWare.Myriad.Plugins.ArgumentHelpTextAttribute inherit System.Attribute

--- a/WoofWare.Myriad.Plugins.Attributes/version.json
+++ b/WoofWare.Myriad.Plugins.Attributes/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.9",
+  "version": "3.10",
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],

--- a/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParser.fs
+++ b/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParser.fs
@@ -608,7 +608,12 @@ Required argument '--exact' received no value"""
         // user typed nothing. Fields must not interfere with each other.
         let getEnvVar (_ : string) = failwith "do not call"
 
-        let property (intVar : int option) (stringVar : NonNull<string> option) (boolVar : bool option) =
+        let property
+            (intVar : int option)
+            (stringVar : NonNull<string> option)
+            (boolVar : bool option)
+            (charVar : char option)
+            =
             // The `--key=value` spelling, so that a generated value which itself looks like a flag
             // (or is empty) is still unambiguously this argument's value.
             let args =
@@ -621,6 +626,9 @@ Required argument '--exact' received no value"""
                     | None -> ()
                     match boolVar with
                     | Some b -> $"--bool-var=%b{b}"
+                    | None -> ()
+                    match charVar with
+                    | Some c -> $"--char-var=%c{c}"
                     | None -> ()
                 ]
 
@@ -637,7 +645,11 @@ Required argument '--exact' received no value"""
                     BoolVar =
                         match boolVar with
                         | Some b -> Choice1Of2 b
-                        | None -> Choice2Of2 Consts.TRUE
+                        | None -> Choice2Of2 true
+                    CharVar =
+                        match charVar with
+                        | Some c -> Choice1Of2 c
+                        | None -> Choice2Of2 'q'
                 }
 
             ContainsLiteralDefault.parse' getEnvVar args = expected
@@ -659,7 +671,8 @@ Required argument '--exact' received no value"""
             """Help text requested.
 --int-var  int32 (default value: 3)
 --string-var  string (default value: hello world)
---bool-var  bool (default value: True)"""
+--bool-var  bool (default value: True)
+--char-var  char (default value: q)"""
 
     [<Test>]
     let ``Help text for flag DU`` () =

--- a/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParser.fs
+++ b/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParser.fs
@@ -674,6 +674,82 @@ Required argument '--exact' received no value"""
 --bool-var  bool (default value: True)
 --char-var  char (default value: q)"""
 
+    /// The literal is rebuilt in the generated file rather than echoed as the user's source text,
+    /// so a string whose spelling and value differ has to come out the other side intact. The
+    /// expected values here are written out independently of the spellings in the record's
+    /// attributes, which is the whole point of the test.
+    [<Test>]
+    let ``Awkward string defaults survive into the generated file`` () =
+        let getEnvVar (_ : string) = failwith "do not call"
+
+        let property
+            (backslash : NonNull<string> option)
+            (quotes : NonNull<string> option)
+            (control : NonNull<string> option)
+            (unicode : NonNull<string> option)
+            =
+            let args =
+                [
+                    match backslash with
+                    | Some (NonNull s) -> $"--backslash=%s{s}"
+                    | None -> ()
+                    match quotes with
+                    | Some (NonNull s) -> $"--quotes=%s{s}"
+                    | None -> ()
+                    match control with
+                    | Some (NonNull s) -> $"--control=%s{s}"
+                    | None -> ()
+                    match unicode with
+                    | Some (NonNull s) -> $"--unicode=%s{s}"
+                    | None -> ()
+                ]
+
+            let expected =
+                {
+                    Backslash =
+                        match backslash with
+                        | Some (NonNull s) -> Choice1Of2 s
+                        | None -> Choice2Of2 @"C:\temp"
+                    Quotes =
+                        match quotes with
+                        | Some (NonNull s) -> Choice1Of2 s
+                        | None -> Choice2Of2 "say \"hi\""
+                    Control =
+                        match control with
+                        | Some (NonNull s) -> Choice1Of2 s
+                        | None -> Choice2Of2 "tab\there\nnewline"
+                    Unicode =
+                        match unicode with
+                        | Some (NonNull s) -> Choice1Of2 s
+                        | None -> Choice2Of2 "caf\u00e9 \u2603"
+                }
+
+            ContainsAwkwardStringDefaults.parse' getEnvVar args = expected
+
+        Check.QuickThrowOnFailure property
+
+    [<Test>]
+    let ``Help text renders awkward string defaults`` () =
+        let getEnvVar (_ : string) = failwith "do not call"
+
+        let exc =
+            Assert.Throws<exn> (fun () ->
+                ContainsAwkwardStringDefaults.parse' getEnvVar [ "--help" ]
+                |> ignore<ContainsAwkwardStringDefaults>
+            )
+
+        let expected =
+            [
+                "Help text requested."
+                @"--backslash  string (default value: C:\temp)"
+                "--quotes  string (default value: say \"hi\")"
+                "--control  string (default value: tab\there\nnewline)"
+                "--unicode  string (default value: caf\u00e9 \u2603)"
+            ]
+            |> String.concat "\n"
+
+        exc.Message |> shouldEqual expected
+
     [<Test>]
     let ``Help text for flag DU`` () =
         let getEnvVar (_ : string) = failwith "do not call"

--- a/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParser.fs
+++ b/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParser.fs
@@ -602,6 +602,66 @@ Required argument '--exact' received no value"""
             }
 
     [<Test>]
+    let ``Literal defaults are taken exactly when the argument is absent`` () =
+        // The defining property of [<ArgumentDefaultValue>]: each field independently reports
+        // Choice1Of2 of whatever the user typed, or Choice2Of2 of the attribute's literal when the
+        // user typed nothing. Fields must not interfere with each other.
+        let getEnvVar (_ : string) = failwith "do not call"
+
+        let property (intVar : int option) (stringVar : NonNull<string> option) (boolVar : bool option) =
+            // The `--key=value` spelling, so that a generated value which itself looks like a flag
+            // (or is empty) is still unambiguously this argument's value.
+            let args =
+                [
+                    match intVar with
+                    | Some i -> $"--int-var=%i{i}"
+                    | None -> ()
+                    match stringVar with
+                    | Some (NonNull s) -> $"--string-var=%s{s}"
+                    | None -> ()
+                    match boolVar with
+                    | Some b -> $"--bool-var=%b{b}"
+                    | None -> ()
+                ]
+
+            let expected =
+                {
+                    IntVar =
+                        match intVar with
+                        | Some i -> Choice1Of2 i
+                        | None -> Choice2Of2 3
+                    StringVar =
+                        match stringVar with
+                        | Some (NonNull s) -> Choice1Of2 s
+                        | None -> Choice2Of2 "hello world"
+                    BoolVar =
+                        match boolVar with
+                        | Some b -> Choice1Of2 b
+                        | None -> Choice2Of2 Consts.TRUE
+                }
+
+            ContainsLiteralDefault.parse' getEnvVar args = expected
+
+        Check.QuickThrowOnFailure property
+
+    [<Test>]
+    let ``Help text renders literal defaults`` () =
+        let getEnvVar (_ : string) = failwith "do not call"
+
+        let exc =
+            Assert.Throws<exn> (fun () ->
+                ContainsLiteralDefault.parse' getEnvVar [ "--help" ]
+                |> ignore<ContainsLiteralDefault>
+            )
+
+        exc.Message
+        |> shouldEqual
+            """Help text requested.
+--int-var  int32 (default value: 3)
+--string-var  string (default value: hello world)
+--bool-var  bool (default value: True)"""
+
+    [<Test>]
     let ``Help text for flag DU`` () =
         let getEnvVar (_ : string) = failwith "do not call"
 

--- a/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
+++ b/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
@@ -52,11 +52,14 @@ type private ArgumentDefaultSpec =
     /// For example, if `type MyArgs = { Thing : Choice<int, int> }`, then
     /// we would use `MyArgs.DefaultThing () : int`.
     | FunctionCall of owner : Ident * name : Ident
-    /// From the constant the user wrote in `[<ArgumentDefaultValue 3>]`. F# restricts custom
-    /// attribute arguments to compile-time constants, so this expression is a literal, a
-    /// `[<Literal>]` binding, or an enum case; we splice it into the generated code verbatim,
-    /// exactly as we do the flag values of `[<ArgumentFlag>]`.
+    /// From the constant the user wrote in `[<ArgumentDefaultValue 3>]`. We rebuild the literal
+    /// rather than reusing the user's expression, so that nothing about where it lands in the
+    /// generated file can change what it means.
     | Literal of value : SynExpr
+    /// From `[<ArgumentDefaultValue null>]`. This is a literal like any other, but it is kept apart
+    /// from `Literal` because it is the one we cannot describe in help text the way we describe the
+    /// rest: `(null).ToString ()` does not even compile.
+    | NullLiteral
 
 /// How a `Map`-typed field spells its entries on the command line.
 ///
@@ -766,6 +769,8 @@ module internal ArgParserGenerator =
         /// A constant written out in full. It denotes the same value wherever it appears, so we can
         /// reproduce it in the generated file.
         | Constant of SynConst
+        /// The `null` literal, which F# admits as an object-valued attribute argument.
+        | Null
         /// One of F#'s context-sensitive constants (`__LINE__`, `__SOURCE_FILE__`,
         /// `__SOURCE_DIRECTORY__`), whose value depends on where it is written.
         | ContextSensitive of name : string
@@ -796,6 +801,7 @@ module internal ArgParserGenerator =
                 | c -> Constant c
 
             ofConst c
+        | SynExpr.Null _ -> Null
         // A `[<Literal>]` binding or an enum case. We have no type checker, so we cannot tell which
         // binding is meant; and the generated file hoists every `open` in the source above the
         // parser, so the name need not resolve to the same one there anyway.
@@ -804,6 +810,28 @@ module internal ArgParserGenerator =
             ids |> List.map _.idText |> String.concat "." |> Identifier
         | _ -> Unrecognised
 
+    /// Rewrite a string so that it can be dropped between the quotes of a generated regular string
+    /// literal and read back as itself.
+    ///
+    /// This is not simply "the F# escaping rules", because Fantomas has its own view: it emits a
+    /// `SynConst.String`'s text between quotes having escaped the quotes and nothing else. Anything
+    /// else which needs escaping is therefore ours to do (otherwise `C:\temp` would be emitted as
+    /// `"C:\temp"`, whose `\t` is a tab), and we escape the quote as `\u0022` rather than `\"` so
+    /// that Fantomas finds no quote to escape and hands our text through unaltered.
+    let private escapeStringConstant (s : string) : string =
+        s
+        |> String.collect (fun c ->
+            match c with
+            | '\\' -> @"\\"
+            | '"' -> @"\u0022"
+            // Everything outside printable ASCII goes out as an escape: `\uXXXX` is a UTF-16 code
+            // unit, which is exactly what a char of a .NET string is, so this is faithful even for
+            // an unpaired surrogate, and it keeps the generated file free of any dependence on how
+            // it is encoded.
+            | c when c >= ' ' && c <= '~' -> System.Char.ToString c
+            | c -> sprintf @"\u%04x" (int c)
+        )
+
     /// Build the expression for a recognised constant default.
     ///
     /// A `SynConst.Char` needs care: Fantomas renders one without its quotes, so `'a'` reaches the
@@ -811,9 +839,16 @@ module internal ArgParserGenerator =
     /// of that name). Giving the node a synthetic range does not help -- it is the rendering of the
     /// constant itself, not its range, which drops them -- so emit the code point converted instead,
     /// which needs no escaping and cannot be mistaken for an identifier.
+    ///
+    /// A `SynConst.String` needs care for the opposite reason: it holds the *decoded* text, so
+    /// re-emitting it demands the escaping the user's own source supplied. We emit a regular string
+    /// whatever the user wrote, since a verbatim or triple-quoted spelling could not express the
+    /// escapes we need.
     let private defaultValueExpr (c : SynConst) : SynExpr =
         match c with
         | SynConst.Char c -> SynExpr.CreateConst c
+        | SynConst.String (text = s) ->
+            SynExpr.Const (SynConst.String (escapeStringConstant s, SynStringKind.Regular, range0), range0)
         | c -> SynExpr.Const (c, range0)
 
     /// Builds a function or lambda of one string argument, which returns a `ty` (as modified by the `Accumulation`;
@@ -991,7 +1026,7 @@ module internal ArgParserGenerator =
                         | [ "Myriad" ; "Plugins" ; "ArgumentDefaultValueAttribute" ]
                         | [ "WoofWare" ; "Myriad" ; "Plugins" ; "ArgumentDefaultValue" ]
                         | [ "WoofWare" ; "Myriad" ; "Plugins" ; "ArgumentDefaultValueAttribute" ] ->
-                            let value =
+                            let spec =
                                 match classifyDefaultValue attr.ArgExpr with
                                 | DefaultValueExpr.ContextSensitive name ->
                                     failwith
@@ -1002,11 +1037,13 @@ module internal ArgParserGenerator =
                                 | DefaultValueExpr.Unrecognised ->
                                     failwith
                                         $"Field '%s{fieldName.idText}' has an [<ArgumentDefaultValue>] whose value we do not recognise as a constant. We reproduce the value in the generated file rather than evaluating it at your attribute, so we accept only a literal written out in full (optionally parenthesised). Use [<ArgumentDefaultFunction>] for anything else: that function is evaluated in your own file."
-                                | DefaultValueExpr.Constant c -> defaultValueExpr c
+                                | DefaultValueExpr.Null -> ArgumentDefaultSpec.NullLiteral
+                                | DefaultValueExpr.Constant c ->
+                                    // Parenthesised, because the expression lands in positions such
+                                    // as `(3).ToString ()` where a bare literal would lex wrongly.
+                                    ArgumentDefaultSpec.Literal (SynExpr.paren (defaultValueExpr c))
 
-                            // Parenthesised, because the expression lands in positions such as
-                            // `(3).ToString ()` where a bare literal would lex wrongly.
-                            ArgumentDefaultSpec.Literal (SynExpr.paren value) |> Some
+                            Some spec
                         | _ -> None
                     )
 
@@ -1619,6 +1656,10 @@ module internal ArgParserGenerator =
                     SynExpr.applyFunction (SynExpr.createIdent "sprintf") (SynExpr.CreateConst " (default value: %s)")
                 )
                 |> SynExpr.paren
+            | Accumulation.Choice ArgumentDefaultSpec.NullLiteral ->
+                // There is no spelling of `null` the user could type at the command line, and
+                // `ToString` on it would throw, so name it rather than rendering it.
+                SynExpr.CreateConst " (default value: <null>)"
             | Accumulation.List _ -> SynExpr.CreateConst " (can be repeated)"
             | Accumulation.Map spec ->
                 // The type's name says nothing about how to spell an entry, so the help text
@@ -2473,6 +2514,8 @@ module internal ArgParserGenerator =
                             // The literal already has the field's element type, so unlike the
                             // env-var case there is nothing to parse and nothing which can fail.
                             SynExpr.sequential [ storeDefault value ; SynExpr.createIdent "None" ]
+                        | ArgumentDefaultSpec.NullLiteral ->
+                            SynExpr.sequential [ storeDefault (SynExpr.Null range0) ; SynExpr.createIdent "None" ]
                         | ArgumentDefaultSpec.EnvironmentVariable name ->
                             // Environment variables permit the laxer boolean grammar: "1" and "0"
                             // as well as the usual literals.

--- a/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
+++ b/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
@@ -52,6 +52,11 @@ type private ArgumentDefaultSpec =
     /// For example, if `type MyArgs = { Thing : Choice<int, int> }`, then
     /// we would use `MyArgs.DefaultThing () : int`.
     | FunctionCall of owner : Ident * name : Ident
+    /// From the constant the user wrote in `[<ArgumentDefaultValue 3>]`. F# restricts custom
+    /// attribute arguments to compile-time constants, so this expression is a literal, a
+    /// `[<Literal>]` binding, or an enum case; we splice it into the generated code verbatim,
+    /// exactly as we do the flag values of `[<ArgumentFlag>]`.
+    | Literal of value : SynExpr
 
 /// How a `Map`-typed field spells its entries on the command line.
 ///
@@ -923,6 +928,17 @@ module internal ArgParserGenerator =
                         | [ "WoofWare" ; "Myriad" ; "Plugins" ; "ArgumentDefaultEnvironmentVariableAttribute" ] ->
 
                             ArgumentDefaultSpec.EnvironmentVariable attr.ArgExpr |> Some
+                        | [ "ArgumentDefaultValue" ]
+                        | [ "ArgumentDefaultValueAttribute" ]
+                        | [ "Plugins" ; "ArgumentDefaultValue" ]
+                        | [ "Plugins" ; "ArgumentDefaultValueAttribute" ]
+                        | [ "Myriad" ; "Plugins" ; "ArgumentDefaultValue" ]
+                        | [ "Myriad" ; "Plugins" ; "ArgumentDefaultValueAttribute" ]
+                        | [ "WoofWare" ; "Myriad" ; "Plugins" ; "ArgumentDefaultValue" ]
+                        | [ "WoofWare" ; "Myriad" ; "Plugins" ; "ArgumentDefaultValueAttribute" ] ->
+                            // Parenthesised, because the expression lands in positions such as
+                            // `(3).ToString ()` where a bare literal would lex wrongly.
+                            ArgumentDefaultSpec.Literal (SynExpr.paren attr.ArgExpr) |> Some
                         | _ -> None
                     )
 
@@ -1215,6 +1231,8 @@ module internal ArgParserGenerator =
                         match (List.last attr.TypeName.LongIdent).idText with
                         | "ArgumentDefaultFunction"
                         | "ArgumentDefaultFunctionAttribute"
+                        | "ArgumentDefaultValue"
+                        | "ArgumentDefaultValueAttribute"
                         | "ArgumentDefaultEnvironmentVariable"
                         | "ArgumentDefaultEnvironmentVariableAttribute" -> true
                         | _ -> false
@@ -1224,11 +1242,11 @@ module internal ArgParserGenerator =
                     match positionalArgAttr, fieldType with
                     | Some _, _ ->
                         failwith
-                            $"Field '%s{ident.idText}' is positional, so it cannot carry a default-value attribute ([<ArgumentDefaultFunction>] or [<ArgumentDefaultEnvironmentVariable>]): positional args are collected, not defaulted."
+                            $"Field '%s{ident.idText}' is positional, so it cannot carry a default-value attribute ([<ArgumentDefaultFunction>], [<ArgumentDefaultValue>], or [<ArgumentDefaultEnvironmentVariable>]): positional args are collected, not defaulted."
                     | None, ChoiceType _ -> ()
                     | None, _ ->
                         failwith
-                            $"Field '%s{ident.idText}' has a default-value attribute ([<ArgumentDefaultFunction>] or [<ArgumentDefaultEnvironmentVariable>]), but its type is not Choice<'a, 'a>. Defaults are surfaced through Choice<'a, 'a> so a successful parse can report whether a value was user-supplied (Choice1Of2) or defaulted (Choice2Of2); a bare field cannot express this. Change the field's type to Choice<'a, 'a>, or remove the attribute."
+                            $"Field '%s{ident.idText}' has a default-value attribute ([<ArgumentDefaultFunction>], [<ArgumentDefaultValue>], or [<ArgumentDefaultEnvironmentVariable>]), but its type is not Choice<'a, 'a>. Defaults are surfaced through Choice<'a, 'a> so a successful parse can report whether a value was user-supplied (Choice1Of2) or defaulted (Choice2Of2); a bare field cannot express this. Change the field's type to Choice<'a, 'a>, or remove the attribute."
 
                 let ambientRecordMatch =
                     match localTypeName fieldType with
@@ -1518,6 +1536,16 @@ module internal ArgParserGenerator =
             | Accumulation.Choice (ArgumentDefaultSpec.FunctionCall (owner, var)) ->
                 // Display the spelling the user would have to type to supply this value.
                 SynExpr.callMethod var.idText (SynExpr.createIdent' owner)
+                |> renderLeafValue flagCases arg.EnumCases
+                |> SynExpr.pipeThroughFunction (
+                    SynExpr.applyFunction (SynExpr.createIdent "sprintf") (SynExpr.CreateConst " (default value: %s)")
+                )
+                |> SynExpr.paren
+            | Accumulation.Choice (ArgumentDefaultSpec.Literal value) ->
+                // A literal written in the user's own source is not a secret, so unlike the env-var
+                // case we can display it; as for a default function, display the spelling the user
+                // would have to type to supply it.
+                value
                 |> renderLeafValue flagCases arg.EnumCases
                 |> SynExpr.pipeThroughFunction (
                     SynExpr.applyFunction (SynExpr.createIdent "sprintf") (SynExpr.CreateConst " (default value: %s)")
@@ -2373,6 +2401,10 @@ module internal ArgParserGenerator =
                                     storeDefault (SynExpr.callMethod name.idText (SynExpr.createIdent' owner))
                                     SynExpr.createIdent "None"
                                 ]
+                        | ArgumentDefaultSpec.Literal value ->
+                            // The literal already has the field's element type, so unlike the
+                            // env-var case there is nothing to parse and nothing which can fail.
+                            SynExpr.sequential [ storeDefault value ; SynExpr.createIdent "None" ]
                         | ArgumentDefaultSpec.EnvironmentVariable name ->
                             // Environment variables permit the laxer boolean grammar: "1" and "0"
                             // as well as the usual literals.

--- a/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
+++ b/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
@@ -763,22 +763,25 @@ module internal ArgParserGenerator =
 
     /// What we found in the argument of an `[<ArgumentDefaultValue>]`.
     type private DefaultValueExpr =
-        /// Safe to splice into the generated file: it means there what it means in the user's source.
-        | Constant
+        /// A constant written out in full. It denotes the same value wherever it appears, so we can
+        /// reproduce it in the generated file.
+        | Constant of SynConst
         /// One of F#'s context-sensitive constants (`__LINE__`, `__SOURCE_FILE__`,
         /// `__SOURCE_DIRECTORY__`), whose value depends on where it is written.
         | ContextSensitive of name : string
-        /// Some other shape, which we decline to splice sight-unseen.
+        /// A name standing for a constant, such as a `[<Literal>]` binding or an enum case.
+        | Identifier of name : string
+        /// Some other shape, which we decline to reproduce sight-unseen.
         | Unrecognised
 
-    /// We splice an `[<ArgumentDefaultValue>]`'s argument into the generated file rather than
-    /// evaluating it, so we accept only expressions which mean the same thing there as here. This
-    /// recognises the shapes rather than searching for bad ones: an expression we have not
-    /// anticipated must be refused, not spliced blind.
+    /// An `[<ArgumentDefaultValue>]`'s value has to be reproduced in the generated file, so we accept
+    /// only expressions which denote the same value there as here. This recognises the shapes rather
+    /// than searching for bad ones: an expression we have not anticipated must be refused, not
+    /// emitted blind.
     ///
     /// F# has already restricted a custom-attribute argument to a compile-time constant by the time
-    /// the whole compilation unit type-checks, so in practice this sees a literal, a reference to a
-    /// `[<Literal>]` binding or an enum case, or a context-sensitive constant.
+    /// the whole compilation unit type-checks, so in practice this sees a literal, a name standing
+    /// for one, or a context-sensitive constant.
     let rec private classifyDefaultValue (expr : SynExpr) : DefaultValueExpr =
         match expr with
         // F#'s attribute syntax requires parentheses around an argument which is not a bare literal,
@@ -789,15 +792,29 @@ module internal ArgParserGenerator =
                 match c with
                 | SynConst.SourceIdentifier (constant = name) -> ContextSensitive name
                 // A measure annotation such as `3.0<m>` wraps the constant it annotates.
-                | SynConst.Measure (constant = c) -> ofConst c
-                | _ -> Constant
+                | SynConst.Measure (constant = inner) -> ofConst inner
+                | c -> Constant c
 
             ofConst c
-        // A `[<Literal>]` binding or an enum case. The generated file inherits the source file's
-        // `open`s, so such a name resolves there exactly as it does at the attribute.
-        | SynExpr.Ident _
-        | SynExpr.LongIdent _ -> Constant
+        // A `[<Literal>]` binding or an enum case. We have no type checker, so we cannot tell which
+        // binding is meant; and the generated file hoists every `open` in the source above the
+        // parser, so the name need not resolve to the same one there anyway.
+        | SynExpr.Ident ident -> Identifier ident.idText
+        | SynExpr.LongIdent (longDotId = SynLongIdent (id = ids)) ->
+            ids |> List.map _.idText |> String.concat "." |> Identifier
         | _ -> Unrecognised
+
+    /// Build the expression for a recognised constant default.
+    ///
+    /// A `SynConst.Char` needs care: Fantomas renders one without its quotes, so `'a'` reaches the
+    /// generated file as a bare `a` and fails to compile (or, worse, picks up an unrelated binding
+    /// of that name). Giving the node a synthetic range does not help -- it is the rendering of the
+    /// constant itself, not its range, which drops them -- so emit the code point converted instead,
+    /// which needs no escaping and cannot be mistaken for an identifier.
+    let private defaultValueExpr (c : SynConst) : SynExpr =
+        match c with
+        | SynConst.Char c -> SynExpr.CreateConst c
+        | c -> SynExpr.Const (c, range0)
 
     /// Builds a function or lambda of one string argument, which returns a `ty` (as modified by the `Accumulation`;
     /// for example, maybe it returns a `ty option` or a `ty list`).
@@ -974,18 +991,22 @@ module internal ArgParserGenerator =
                         | [ "Myriad" ; "Plugins" ; "ArgumentDefaultValueAttribute" ]
                         | [ "WoofWare" ; "Myriad" ; "Plugins" ; "ArgumentDefaultValue" ]
                         | [ "WoofWare" ; "Myriad" ; "Plugins" ; "ArgumentDefaultValueAttribute" ] ->
-                            match classifyDefaultValue attr.ArgExpr with
-                            | DefaultValueExpr.ContextSensitive name ->
-                                failwith
-                                    $"Field '%s{fieldName.idText}' has an [<ArgumentDefaultValue>] whose value uses the context-sensitive constant %s{name}. Its value depends on where it is written, and we splice it into the generated file rather than evaluating it at your attribute, so it would not mean there what it means in your source; we also emit it in more than one place, so it need not even be consistent within the generated file. Use [<ArgumentDefaultFunction>] instead: that function is evaluated in your own file."
-                            | DefaultValueExpr.Unrecognised ->
-                                failwith
-                                    $"Field '%s{fieldName.idText}' has an [<ArgumentDefaultValue>] whose value we do not recognise as a constant. We splice the value into the generated file rather than evaluating it at your attribute, so we accept only a literal, or a reference to a [<Literal>] binding or an enum case (each optionally parenthesised). Use [<ArgumentDefaultFunction>] for anything else: that function is evaluated in your own file."
-                            | DefaultValueExpr.Constant -> ()
+                            let value =
+                                match classifyDefaultValue attr.ArgExpr with
+                                | DefaultValueExpr.ContextSensitive name ->
+                                    failwith
+                                        $"Field '%s{fieldName.idText}' has an [<ArgumentDefaultValue>] whose value uses the context-sensitive constant %s{name}. Its value depends on where it is written, and we reproduce it in the generated file rather than evaluating it at your attribute, so it would not mean there what it means in your source; we also emit it in more than one place, so it need not even be consistent within the generated file. Use [<ArgumentDefaultFunction>] instead: that function is evaluated in your own file."
+                                | DefaultValueExpr.Identifier name ->
+                                    failwith
+                                        $"Field '%s{fieldName.idText}' has an [<ArgumentDefaultValue>] whose value names something (%s{name}) rather than writing out a constant. We reproduce the value in the generated file rather than evaluating it at your attribute, and that file hoists every `open` in your source above the parser, so the name need not resolve to the same binding there as here. Write the constant out literally, or use [<ArgumentDefaultFunction>]: that function is evaluated in your own file."
+                                | DefaultValueExpr.Unrecognised ->
+                                    failwith
+                                        $"Field '%s{fieldName.idText}' has an [<ArgumentDefaultValue>] whose value we do not recognise as a constant. We reproduce the value in the generated file rather than evaluating it at your attribute, so we accept only a literal written out in full (optionally parenthesised). Use [<ArgumentDefaultFunction>] for anything else: that function is evaluated in your own file."
+                                | DefaultValueExpr.Constant c -> defaultValueExpr c
 
                             // Parenthesised, because the expression lands in positions such as
                             // `(3).ToString ()` where a bare literal would lex wrongly.
-                            ArgumentDefaultSpec.Literal (SynExpr.paren attr.ArgExpr) |> Some
+                            ArgumentDefaultSpec.Literal (SynExpr.paren value) |> Some
                         | _ -> None
                     )
 

--- a/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
+++ b/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
@@ -761,6 +761,44 @@ module internal ArgParserGenerator =
         | Accumulation.Choice _
         | Accumulation.List _ -> rejectSeparatorAttributes fieldName fieldType attrs
 
+    /// What we found in the argument of an `[<ArgumentDefaultValue>]`.
+    type private DefaultValueExpr =
+        /// Safe to splice into the generated file: it means there what it means in the user's source.
+        | Constant
+        /// One of F#'s context-sensitive constants (`__LINE__`, `__SOURCE_FILE__`,
+        /// `__SOURCE_DIRECTORY__`), whose value depends on where it is written.
+        | ContextSensitive of name : string
+        /// Some other shape, which we decline to splice sight-unseen.
+        | Unrecognised
+
+    /// We splice an `[<ArgumentDefaultValue>]`'s argument into the generated file rather than
+    /// evaluating it, so we accept only expressions which mean the same thing there as here. This
+    /// recognises the shapes rather than searching for bad ones: an expression we have not
+    /// anticipated must be refused, not spliced blind.
+    ///
+    /// F# has already restricted a custom-attribute argument to a compile-time constant by the time
+    /// the whole compilation unit type-checks, so in practice this sees a literal, a reference to a
+    /// `[<Literal>]` binding or an enum case, or a context-sensitive constant.
+    let rec private classifyDefaultValue (expr : SynExpr) : DefaultValueExpr =
+        match expr with
+        // F#'s attribute syntax requires parentheses around an argument which is not a bare literal,
+        // and the user may add more of their own.
+        | SynExpr.Paren (expr = e) -> classifyDefaultValue e
+        | SynExpr.Const (constant = c) ->
+            let rec ofConst (c : SynConst) : DefaultValueExpr =
+                match c with
+                | SynConst.SourceIdentifier (constant = name) -> ContextSensitive name
+                // A measure annotation such as `3.0<m>` wraps the constant it annotates.
+                | SynConst.Measure (constant = c) -> ofConst c
+                | _ -> Constant
+
+            ofConst c
+        // A `[<Literal>]` binding or an enum case. The generated file inherits the source file's
+        // `open`s, so such a name resolves there exactly as it does at the attribute.
+        | SynExpr.Ident _
+        | SynExpr.LongIdent _ -> Constant
+        | _ -> Unrecognised
+
     /// Builds a function or lambda of one string argument, which returns a `ty` (as modified by the `Accumulation`;
     /// for example, maybe it returns a `ty option` or a `ty list`).
     /// The resulting SynType is the type of the *element* being parsed; so if the Accumulation is List, the SynType
@@ -936,6 +974,15 @@ module internal ArgParserGenerator =
                         | [ "Myriad" ; "Plugins" ; "ArgumentDefaultValueAttribute" ]
                         | [ "WoofWare" ; "Myriad" ; "Plugins" ; "ArgumentDefaultValue" ]
                         | [ "WoofWare" ; "Myriad" ; "Plugins" ; "ArgumentDefaultValueAttribute" ] ->
+                            match classifyDefaultValue attr.ArgExpr with
+                            | DefaultValueExpr.ContextSensitive name ->
+                                failwith
+                                    $"Field '%s{fieldName.idText}' has an [<ArgumentDefaultValue>] whose value uses the context-sensitive constant %s{name}. Its value depends on where it is written, and we splice it into the generated file rather than evaluating it at your attribute, so it would not mean there what it means in your source; we also emit it in more than one place, so it need not even be consistent within the generated file. Use [<ArgumentDefaultFunction>] instead: that function is evaluated in your own file."
+                            | DefaultValueExpr.Unrecognised ->
+                                failwith
+                                    $"Field '%s{fieldName.idText}' has an [<ArgumentDefaultValue>] whose value we do not recognise as a constant. We splice the value into the generated file rather than evaluating it at your attribute, so we accept only a literal, or a reference to a [<Literal>] binding or an enum case (each optionally parenthesised). Use [<ArgumentDefaultFunction>] for anything else: that function is evaluated in your own file."
+                            | DefaultValueExpr.Constant -> ()
+
                             // Parenthesised, because the expression lands in positions such as
                             // `(3).ToString ()` where a bare literal would lex wrongly.
                             ArgumentDefaultSpec.Literal (SynExpr.paren attr.ArgExpr) |> Some

--- a/WoofWare.Myriad.Plugins/Test/TestArgParserRejection.fs
+++ b/WoofWare.Myriad.Plugins/Test/TestArgParserRejection.fs
@@ -1244,6 +1244,69 @@ type WithLiteralDefault =
         // One namespace for the embedded runtime module, one for the generated parser module.
         List.length modules |> shouldEqual 2
 
+    /// F#'s context-sensitive constants: valid attribute arguments, but their value depends on
+    /// where they are written.
+    let sourceIdentifiers : TestCaseData list =
+        [ "__LINE__" ; "__SOURCE_FILE__" ; "__SOURCE_DIRECTORY__" ]
+        |> List.map TestCaseData
+
+    [<TestCaseSource(nameof sourceIdentifiers)>]
+    let ``ArgumentDefaultValue with a context-sensitive constant is rejected`` (constant : string) =
+        // We splice the attribute's expression into the generated file, so one of these would be
+        // evaluated *there* rather than at the user's own attribute: __SOURCE_FILE__ would name the
+        // generated file. Worse, we emit the default in two places (the help text and the
+        // defaulting step), so __LINE__ would advertise one default and store another.
+        $"""namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+[<ArgParser>]
+type ContextSensitiveDefault =
+    {{
+        [<ArgumentDefaultValue(%s{constant})>]
+        Where : Choice<string, string>
+    }}
+"""
+        |> shouldRejectWith
+            $"Field 'Where' has an [<ArgumentDefaultValue>] whose value uses the context-sensitive constant %s{constant}. Its value depends on where it is written, and we splice it into the generated file rather than evaluating it at your attribute, so it would not mean there what it means in your source; we also emit it in more than one place, so it need not even be consistent within the generated file. Use [<ArgumentDefaultFunction>] instead: that function is evaluated in your own file."
+
+    [<Test>]
+    let ``ArgumentDefaultValue sees through redundant parentheses`` () =
+        // F#'s attribute syntax already requires one pair of parentheses around a non-literal
+        // argument, and the user may add more; the check must not be fooled by the extra layer.
+        """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+[<ArgParser>]
+type DoublyParenthesisedDefault =
+    {
+        [<ArgumentDefaultValue((__SOURCE_FILE__))>]
+        Where : Choice<string, string>
+    }
+"""
+        |> shouldRejectWith
+            "Field 'Where' has an [<ArgumentDefaultValue>] whose value uses the context-sensitive constant __SOURCE_FILE__. Its value depends on where it is written, and we splice it into the generated file rather than evaluating it at your attribute, so it would not mean there what it means in your source; we also emit it in more than one place, so it need not even be consistent within the generated file. Use [<ArgumentDefaultFunction>] instead: that function is evaluated in your own file."
+
+    [<Test>]
+    let ``ArgumentDefaultValue with an unrecognised expression is rejected`` () =
+        // We recognise the constant forms rather than hunting for bad ones, so an expression we
+        // have not anticipated is refused instead of being spliced sight-unseen. (F# would reject
+        // this attribute argument too, since it is not a compile-time constant.)
+        """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+[<ArgParser>]
+type ComputedDefault =
+    {
+        [<ArgumentDefaultValue(3 + 4)>]
+        Count : Choice<int, int>
+    }
+"""
+        |> shouldRejectWith
+            "Field 'Count' has an [<ArgumentDefaultValue>] whose value we do not recognise as a constant. We splice the value into the generated file rather than evaluating it at your attribute, so we accept only a literal, or a reference to a [<Literal>] binding or an enum case (each optionally parenthesised). Use [<ArgumentDefaultFunction>] for anything else: that function is evaluated in your own file."
+
     // Exactly one source may supply a field's default. With two, the generator would have to
     // invent a precedence order which is invisible at the use site, so it refuses instead.
 

--- a/WoofWare.Myriad.Plugins/Test/TestArgParserRejection.fs
+++ b/WoofWare.Myriad.Plugins/Test/TestArgParserRejection.fs
@@ -29,6 +29,15 @@ module TestArgParserRejection =
 
         exc.Message |> shouldEqual message
 
+    /// The three default-supplying attributes are interchangeable as far as the checks below are
+    /// concerned, so their rejection messages are shared; assert against these rather than
+    /// restating them per attribute.
+    let private defaultAttrOnNonChoice (field : string) : string =
+        $"Field '%s{field}' has a default-value attribute ([<ArgumentDefaultFunction>], [<ArgumentDefaultValue>], or [<ArgumentDefaultEnvironmentVariable>]), but its type is not Choice<'a, 'a>. Defaults are surfaced through Choice<'a, 'a> so a successful parse can report whether a value was user-supplied (Choice1Of2) or defaulted (Choice2Of2); a bare field cannot express this. Change the field's type to Choice<'a, 'a>, or remove the attribute."
+
+    let private defaultAttrOnPositional (field : string) : string =
+        $"Field '%s{field}' is positional, so it cannot carry a default-value attribute ([<ArgumentDefaultFunction>], [<ArgumentDefaultValue>], or [<ArgumentDefaultEnvironmentVariable>]): positional args are collected, not defaulted."
+
     [<Test>]
     let ``Long forms which differ only by case are rejected`` () =
         """namespace TestMe
@@ -1106,8 +1115,7 @@ type BareFlagDefault =
         DryRun : DryRunMode
     }
 """
-        |> shouldRejectWith
-            "Field 'DryRun' has a default-value attribute ([<ArgumentDefaultFunction>] or [<ArgumentDefaultEnvironmentVariable>]), but its type is not Choice<'a, 'a>. Defaults are surfaced through Choice<'a, 'a> so a successful parse can report whether a value was user-supplied (Choice1Of2) or defaulted (Choice2Of2); a bare field cannot express this. Change the field's type to Choice<'a, 'a>, or remove the attribute."
+        |> shouldRejectWith (defaultAttrOnNonChoice "DryRun")
 
     [<Test>]
     let ``ArgumentDefaultEnvironmentVariable on a bare scalar field is rejected`` () =
@@ -1123,8 +1131,7 @@ type BareScalarDefault =
         Count : int
     }
 """
-        |> shouldRejectWith
-            "Field 'Count' has a default-value attribute ([<ArgumentDefaultFunction>] or [<ArgumentDefaultEnvironmentVariable>]), but its type is not Choice<'a, 'a>. Defaults are surfaced through Choice<'a, 'a> so a successful parse can report whether a value was user-supplied (Choice1Of2) or defaulted (Choice2Of2); a bare field cannot express this. Change the field's type to Choice<'a, 'a>, or remove the attribute."
+        |> shouldRejectWith (defaultAttrOnNonChoice "Count")
 
     [<Test>]
     let ``A default attribute on a record-typed field is rejected`` () =
@@ -1146,8 +1153,7 @@ type ParentRecord =
         Child : ChildRecord
     }
 """
-        |> shouldRejectWith
-            "Field 'Child' has a default-value attribute ([<ArgumentDefaultFunction>] or [<ArgumentDefaultEnvironmentVariable>]), but its type is not Choice<'a, 'a>. Defaults are surfaced through Choice<'a, 'a> so a successful parse can report whether a value was user-supplied (Choice1Of2) or defaulted (Choice2Of2); a bare field cannot express this. Change the field's type to Choice<'a, 'a>, or remove the attribute."
+        |> shouldRejectWith (defaultAttrOnNonChoice "Child")
 
     [<Test>]
     let ``A default attribute on a positional field is rejected`` () =
@@ -1163,8 +1169,39 @@ type PositionalDefault =
         Rest : string list
     }
 """
-        |> shouldRejectWith
-            "Field 'Rest' is positional, so it cannot carry a default-value attribute ([<ArgumentDefaultFunction>] or [<ArgumentDefaultEnvironmentVariable>]): positional args are collected, not defaulted."
+        |> shouldRejectWith (defaultAttrOnPositional "Rest")
+
+    [<Test>]
+    let ``ArgumentDefaultValue on a bare scalar field is rejected`` () =
+        // The literal-default attribute inherits the Choice-only requirement of its siblings.
+        """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+[<ArgParser>]
+type BareScalarLiteralDefault =
+    {
+        [<ArgumentDefaultValue 3>]
+        Count : int
+    }
+"""
+        |> shouldRejectWith (defaultAttrOnNonChoice "Count")
+
+    [<Test>]
+    let ``ArgumentDefaultValue on a positional field is rejected`` () =
+        """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+[<ArgParser>]
+type PositionalLiteralDefault =
+    {
+        [<PositionalArgs>]
+        [<ArgumentDefaultValue 3>]
+        Rest : Choice<int, int> list
+    }
+"""
+        |> shouldRejectWith (defaultAttrOnPositional "Rest")
 
     [<Test>]
     let ``A default attribute on a Choice field generates successfully`` () =
@@ -1187,6 +1224,67 @@ type WithDefault =
 
         // One namespace for the embedded runtime module, one for the generated parser module.
         List.length modules |> shouldEqual 2
+
+    [<Test>]
+    let ``ArgumentDefaultValue on a Choice field generates successfully`` () =
+        let modules =
+            generateFromSource
+                """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+[<ArgParser>]
+type WithLiteralDefault =
+    {
+        [<ArgumentDefaultValue 4>]
+        Count : Choice<int, int>
+    }
+"""
+
+        // One namespace for the embedded runtime module, one for the generated parser module.
+        List.length modules |> shouldEqual 2
+
+    // Exactly one source may supply a field's default. With two, the generator would have to
+    // invent a precedence order which is invisible at the use site, so it refuses instead.
+
+    /// Every ordered pair drawn from the three default-supplying attributes, including each
+    /// attribute with itself: two spellings of the same source are just as ambiguous as two
+    /// different sources.
+    let conflictingDefaultAttrs : TestCaseData list =
+        let attrs =
+            [
+                "ArgumentDefaultFunction"
+                "ArgumentDefaultValue 3"
+                "ArgumentDefaultEnvironmentVariable \"MY_ENV_VAR\""
+            ]
+
+        attrs
+        |> List.collect (fun a -> attrs |> List.map (fun b -> TestCaseData (a, b)))
+
+    [<TestCaseSource(nameof conflictingDefaultAttrs)>]
+    let ``Two default attributes on one field are rejected`` (first : string, second : string) =
+        let source =
+            [
+                "namespace TestMe"
+                ""
+                "open WoofWare.Myriad.Plugins"
+                ""
+                "[<ArgParser>]"
+                "type TwoDefaults ="
+                "    {"
+                $"        [<%s{first}>]"
+                $"        [<%s{second}>]"
+                "        Count : Choice<int, int>"
+                "    }"
+                ""
+                "    static member DefaultCount () = 4"
+                ""
+            ]
+            |> String.concat "\n"
+
+        source
+        |> shouldRejectWith
+            "Expected Choice to be annotated with at most one ArgumentDefaultFunction or similar, but it was annotated with multiple. Field: Count"
 
     // ------------------------------------------------------------------------------------------
     // Data-free unions are argument *values*, spelled by case name (`--blah=a`), rather than sets

--- a/WoofWare.Myriad.Plugins/Test/TestArgParserRejection.fs
+++ b/WoofWare.Myriad.Plugins/Test/TestArgParserRejection.fs
@@ -35,6 +35,12 @@ module TestArgParserRejection =
     let private defaultAttrOnNonChoice (field : string) : string =
         $"Field '%s{field}' has a default-value attribute ([<ArgumentDefaultFunction>], [<ArgumentDefaultValue>], or [<ArgumentDefaultEnvironmentVariable>]), but its type is not Choice<'a, 'a>. Defaults are surfaced through Choice<'a, 'a> so a successful parse can report whether a value was user-supplied (Choice1Of2) or defaulted (Choice2Of2); a bare field cannot express this. Change the field's type to Choice<'a, 'a>, or remove the attribute."
 
+    let private contextSensitiveDefault (field : string) (constant : string) : string =
+        $"Field '%s{field}' has an [<ArgumentDefaultValue>] whose value uses the context-sensitive constant %s{constant}. Its value depends on where it is written, and we reproduce it in the generated file rather than evaluating it at your attribute, so it would not mean there what it means in your source; we also emit it in more than one place, so it need not even be consistent within the generated file. Use [<ArgumentDefaultFunction>] instead: that function is evaluated in your own file."
+
+    let private namedDefault (field : string) (name : string) : string =
+        $"Field '%s{field}' has an [<ArgumentDefaultValue>] whose value names something (%s{name}) rather than writing out a constant. We reproduce the value in the generated file rather than evaluating it at your attribute, and that file hoists every `open` in your source above the parser, so the name need not resolve to the same binding there as here. Write the constant out literally, or use [<ArgumentDefaultFunction>]: that function is evaluated in your own file."
+
     let private defaultAttrOnPositional (field : string) : string =
         $"Field '%s{field}' is positional, so it cannot carry a default-value attribute ([<ArgumentDefaultFunction>], [<ArgumentDefaultValue>], or [<ArgumentDefaultEnvironmentVariable>]): positional args are collected, not defaulted."
 
@@ -1267,8 +1273,7 @@ type ContextSensitiveDefault =
         Where : Choice<string, string>
     }}
 """
-        |> shouldRejectWith
-            $"Field 'Where' has an [<ArgumentDefaultValue>] whose value uses the context-sensitive constant %s{constant}. Its value depends on where it is written, and we splice it into the generated file rather than evaluating it at your attribute, so it would not mean there what it means in your source; we also emit it in more than one place, so it need not even be consistent within the generated file. Use [<ArgumentDefaultFunction>] instead: that function is evaluated in your own file."
+        |> shouldRejectWith (contextSensitiveDefault "Where" constant)
 
     [<Test>]
     let ``ArgumentDefaultValue sees through redundant parentheses`` () =
@@ -1285,8 +1290,37 @@ type DoublyParenthesisedDefault =
         Where : Choice<string, string>
     }
 """
-        |> shouldRejectWith
-            "Field 'Where' has an [<ArgumentDefaultValue>] whose value uses the context-sensitive constant __SOURCE_FILE__. Its value depends on where it is written, and we splice it into the generated file rather than evaluating it at your attribute, so it would not mean there what it means in your source; we also emit it in more than one place, so it need not even be consistent within the generated file. Use [<ArgumentDefaultFunction>] instead: that function is evaluated in your own file."
+        |> shouldRejectWith (contextSensitiveDefault "Where" "__SOURCE_FILE__")
+
+    /// The two ways to name a constant rather than write one out.
+    let identifierDefaults : TestCaseData list =
+        [
+            // A [<Literal>] binding, opened into scope.
+            "Sentinel"
+            // A qualified [<Literal>] binding, or an enum case.
+            "Consts.Sentinel"
+        ]
+        |> List.map TestCaseData
+
+    [<TestCaseSource(nameof identifierDefaults)>]
+    let ``ArgumentDefaultValue naming a constant is rejected`` (name : string) =
+        // The generated module hoists every `open` in the file above the parser, so a name resolves
+        // there against a different set of bindings than at the attribute: a later `open` which
+        // shadows an earlier one silently changes which constant the default means, and a file-local
+        // module abbreviation is not in scope at all. We have no type checker, so we cannot tell
+        // which binding was meant; refuse to guess.
+        $"""namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+[<ArgParser>]
+type NamedDefault =
+    {{
+        [<ArgumentDefaultValue(%s{name})>]
+        Which : Choice<string, string>
+    }}
+"""
+        |> shouldRejectWith (namedDefault "Which" name)
 
     [<Test>]
     let ``ArgumentDefaultValue with an unrecognised expression is rejected`` () =
@@ -1305,7 +1339,7 @@ type ComputedDefault =
     }
 """
         |> shouldRejectWith
-            "Field 'Count' has an [<ArgumentDefaultValue>] whose value we do not recognise as a constant. We splice the value into the generated file rather than evaluating it at your attribute, so we accept only a literal, or a reference to a [<Literal>] binding or an enum case (each optionally parenthesised). Use [<ArgumentDefaultFunction>] for anything else: that function is evaluated in your own file."
+            "Field 'Count' has an [<ArgumentDefaultValue>] whose value we do not recognise as a constant. We reproduce the value in the generated file rather than evaluating it at your attribute, so we accept only a literal written out in full (optionally parenthesised). Use [<ArgumentDefaultFunction>] for anything else: that function is evaluated in your own file."
 
     // Exactly one source may supply a field's default. With two, the generator would have to
     // invent a precedence order which is invisible at the use site, so it refuses instead.

--- a/WoofWare.Myriad.Plugins/Test/TestArgParserRejection.fs
+++ b/WoofWare.Myriad.Plugins/Test/TestArgParserRejection.fs
@@ -1250,6 +1250,28 @@ type WithLiteralDefault =
         // One namespace for the embedded runtime module, one for the generated parser module.
         List.length modules |> shouldEqual 2
 
+    [<Test>]
+    let ``ArgumentDefaultValue null generates successfully`` () =
+        // `null` is a written-out literal like any other -- F# admits it as an object-valued
+        // attribute argument -- so it must not fall through to the "unrecognised" rejection. It is
+        // the one literal whose help text cannot be rendered by calling `ToString` on it.
+        let modules =
+            generateFromSource
+                """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+[<ArgParser>]
+type WithNullDefault =
+    {
+        [<ArgumentDefaultValue null>]
+        Missing : Choice<string, string>
+    }
+"""
+
+        // One namespace for the embedded runtime module, one for the generated parser module.
+        List.length modules |> shouldEqual 2
+
     /// F#'s context-sensitive constants: valid attribute arguments, but their value depends on
     /// where they are written.
     let sourceIdentifiers : TestCaseData list =

--- a/WoofWare.Myriad.Plugins/version.json
+++ b/WoofWare.Myriad.Plugins/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "10.4",
+  "version": "10.5",
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],


### PR DESCRIPTION
Shorthand for the common case where an `[<ArgumentDefaultFunction>]`'s function would just return a constant. The attribute argument is a SynExpr spliced verbatim into the generated code, exactly as `[<ArgumentFlag>]`'s value already is; the generated file inherits the source file's `open`s, so an identifier resolves there as it does at the use site.

Because `foo` is an ordinary .NET custom-attribute argument, F# itself restricts it to compile-time constants (literals, `[<Literal>]` bindings, enum cases) on the user's own source line, so the generator's untyped pass need not validate it. A discriminated union case, including a flag DU's, is not such a constant and still needs `[<ArgumentDefaultFunction>]`.

The new attribute joins the existing "at most one default source" check, which until now had no test coverage at all; it is now exercised over every pair drawn from the three default-supplying attributes.