### PR TITLE
ArgParser: reject [<ArgumentLongForm>] on a field with a whole argument set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 Notable changes are recorded here.
 
+# WoofWare.Myriad.Plugins 10.5.2
+
+The `ArgParserGenerator` now rejects an `[<ArgumentLongForm>]` placed on a field whose type is another argument record, or a discriminated union of alternative argument sets.
+Such a field contributes a whole set of arguments, each named by its own field, so there is no single argument for the attribute to rename; it was previously read and then silently dropped, leaving a parser with names the author did not ask for and no indication why.
+
 # WoofWare.Myriad.Plugins 10.5.1, WoofWare.Myriad.Plugins.Attributes 3.10.1
 
 The `ArgParserGenerator` gains `[<ArgumentDefaultValue foo>]`, which is shorthand for an `[<ArgumentDefaultFunction>]` whose function just returns the constant `foo`.

--- a/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
+++ b/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
@@ -750,6 +750,27 @@ module internal ArgParserGenerator =
             "ArgumentMapEntrySeparator"
             "It controls how one occurrence of a map is split into several entries."
 
+    /// A field whose type is another argument record, or a union of alternative argument sets,
+    /// contributes that type's whole set of arguments, each named by its own field. There is no
+    /// single argument here for an [<ArgumentLongForm>] to rename, so it can only have been a
+    /// mistake; say so rather than dropping it, which is what the structural branches did when they
+    /// took over before the leaf machinery ran.
+    let private rejectLongFormAttribute (fieldName : Ident) (fieldType : SynType) (attrs : SynAttribute list) : unit =
+        let present =
+            attrs
+            |> List.exists (fun attr ->
+                match (List.last attr.TypeName.LongIdent).idText with
+                | "ArgumentLongForm"
+                | "ArgumentLongFormAttribute" -> true
+                | _ -> false
+            )
+
+        if present then
+            let ty = describeType fieldType
+
+            failwith
+                $"Field '%s{fieldName.idText}' has an [<ArgumentLongForm>], but its type %s{ty} is an argument record or a discriminated union of alternative argument sets, so it contributes a whole set of arguments rather than one. [<ArgumentLongForm>] renames a single argument, and there is none here to rename: the names come from the fields of %s{ty} itself. Put the attribute on the field you mean to rename."
+
     let private checkSeparatorAttributesPlacement
         (fieldName : Ident)
         (fieldType : SynType)
@@ -1369,6 +1390,7 @@ module internal ArgParserGenerator =
                     // must reject the map-only attributes themselves; otherwise an author who
                     // misplaced one would be told nothing at all.
                     rejectSeparatorAttributes ident fieldType attrs
+                    rejectLongFormAttribute ident fieldType attrs
 
                     // This field has a type we need to obtain from parsing another record.
                     let spec, counter = toParseSpec ancestors counter ambient childRecord
@@ -1379,6 +1401,7 @@ module internal ArgParserGenerator =
                 match ambientUnionMatch with
                 | Some union ->
                     rejectSeparatorAttributes ident fieldType attrs
+                    rejectLongFormAttribute ident fieldType attrs
 
                     // A discriminated union of alternative argument sets: exactly one case's
                     // arguments must be supplied. (Flag-like and data-free unions are argument

--- a/WoofWare.Myriad.Plugins/Test/TestArgParserRejection.fs
+++ b/WoofWare.Myriad.Plugins/Test/TestArgParserRejection.fs
@@ -2039,3 +2039,107 @@ type Args =
 """
 
         List.length modules |> shouldEqual 2
+
+    /// A field whose type is another argument record contributes that record's whole set of
+    /// arguments, each named by its own field. There is no single argument for an
+    /// [<ArgumentLongForm>] to rename, and the attribute was previously computed and then dropped
+    /// on the floor when the structural branch was taken -- leaving an author who reached for it a
+    /// parser with names they did not ask for and no indication why.
+    let private longFormOnStructural (field : string) (ty : string) : string =
+        $"Field '%s{field}' has an [<ArgumentLongForm>], but its type %s{ty} is an argument record or a discriminated union of alternative argument sets, so it contributes a whole set of arguments rather than one. [<ArgumentLongForm>] renames a single argument, and there is none here to rename: the names come from the fields of %s{ty} itself. Put the attribute on the field you mean to rename."
+
+    [<Test>]
+    let ``ArgumentLongForm on a sub-record field is rejected`` () =
+        """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+type Child =
+    {
+        Blah : int
+    }
+
+[<ArgParser>]
+type Args =
+    {
+        [<ArgumentLongForm "renamed">]
+        A : Child
+    }
+"""
+        |> shouldRejectWith (longFormOnStructural "A" "Child")
+
+    [<Test>]
+    let ``ArgumentLongForm on a union-typed field is rejected`` () =
+        """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+type FooArgs =
+    {
+        Foo : int
+    }
+
+type BarArgs =
+    {
+        Bar : int
+    }
+
+type Mode =
+    | FooCase of FooArgs
+    | BarCase of BarArgs
+
+[<ArgParser>]
+type Args =
+    {
+        [<ArgumentLongForm "renamed">]
+        A : Mode
+    }
+"""
+        |> shouldRejectWith (longFormOnStructural "A" "Mode")
+
+    /// Several aliases are no more meaningful than one.
+    [<Test>]
+    let ``Several ArgumentLongForms on a sub-record field are rejected`` () =
+        """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+type Child =
+    {
+        Blah : int
+    }
+
+[<ArgParser>]
+type Args =
+    {
+        [<ArgumentLongForm "renamed">]
+        [<ArgumentLongForm "r">]
+        A : Child
+    }
+"""
+        |> shouldRejectWith (longFormOnStructural "A" "Child")
+
+    /// The rejection is about the *field's* attribute, not about the child's: a sub-record whose
+    /// own fields carry long forms is entirely ordinary.
+    [<Test>]
+    let ``ArgumentLongForm inside a sub-record is still accepted`` () =
+        let modules =
+            generateFromSource
+                """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+type Child =
+    {
+        [<ArgumentLongForm "renamed">]
+        Blah : int
+    }
+
+[<ArgParser>]
+type Args =
+    {
+        A : Child
+    }
+"""
+
+        List.length modules |> shouldEqual 2


### PR DESCRIPTION
A field whose type is another argument record, or a union of alternative argument sets, contributes that type's *whole set* of arguments, each named by its own field:

```fsharp
type Child = { Blah : int }

[<ArgParser>]
type Args =
    {
        [<ArgumentLongForm "renamed">]   // silently ignored before this PR
        A : Child
    }
```

There is no single argument here for `[<ArgumentLongForm>]` to rename — the names come from `Child`'s own fields — so the attribute can only have been a mistake. It was nonetheless read and then dropped on the floor when the structural branch took over before any leaf machinery ran (`toParseSpec` computes `longForms` unconditionally, then discards it once `ambientRecordMatch` is `Some`), leaving the author with names they had not asked for and nothing to explain why.

This says so instead, beside the existing rejection of the map-only separator attributes in the same two branches.

Deliberately untouched: `[<ArgumentHelpText>]` is dropped in exactly the same place, and is being looked at separately.

Found while designing `[<ArgumentPrefix>]` (#598), because misusing `[<ArgumentLongForm>]` on a sub-record field is precisely what an author reaches for before discovering that feature. The two PRs are independent and can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)