### PR TITLE
ArgParser: escape an argument's spelling when emitting it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,7 @@ Notable changes are recorded here.
 
 # WoofWare.Myriad.Plugins 10.6.2
 
-Fixes `ArgParserGenerator` emitting an argument's spelling into the generated file without the escaping that spelling needs.
-An `[<ArgumentLongForm "back\\tab">]` was emitted as `"back\tab"`, whose `\t` is a tab, so the argument answered to a name other than the one declared (and a spelling containing e.g. `\q` could stop the generated file compiling at all).
-Verbatim spellings such as `@"back\tab"` were unaffected and remain so.
-This is the same round-trip hazard that `[<ArgumentDefaultValue>]` already guards against; the guard now covers names as well as values.
+`ArgParserGenerator` now correctly escapes strings from `ArgumentLongForm` where necessary.
 
 # WoofWare.Myriad.Plugins 10.6.1, WoofWare.Myriad.Plugins.Attributes 3.11.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 Notable changes are recorded here.
 
+# WoofWare.Myriad.Plugins 10.6.2
+
+Fixes `ArgParserGenerator` emitting an argument's spelling into the generated file without the escaping that spelling needs.
+An `[<ArgumentLongForm "back\\tab">]` was emitted as `"back\tab"`, whose `\t` is a tab, so the argument answered to a name other than the one declared (and a spelling containing e.g. `\q` could stop the generated file compiling at all).
+Verbatim spellings such as `@"back\tab"` were unaffected and remain so.
+This is the same round-trip hazard that `[<ArgumentDefaultValue>]` already guards against; the guard now covers names as well as values.
+
 # WoofWare.Myriad.Plugins 10.6.1, WoofWare.Myriad.Plugins.Attributes 3.11.1
 
 The `ArgParserGenerator` gains `[<ArgumentPrefix "foo">]`, placed on a field whose type is another argument record or a union of alternative argument sets: every argument that field contributes is namespaced, so `--blah` becomes `--foo-blah`.

--- a/ConsumePlugin/Args.fs
+++ b/ConsumePlugin/Args.fs
@@ -230,6 +230,21 @@ type ContainsAwkwardStringDefaults =
         Unicode : Choice<string, string>
     }
 
+/// An argument's *spelling* goes through the same round trip as a default value, and needs the same
+/// care: a `SynConst.String` holds decoded text, so re-emitting `"back\\tab"` naively gives
+/// `"back\tab"`, whose `\t` is a tab, and the argument answers to a name other than the one
+/// declared. A verbatim spelling decodes to the same text and must end up spelled the same way.
+[<ArgParser true>]
+type AwkwardLongForms =
+    {
+        [<ArgumentLongForm "back\\tab">]
+        Backslash : int
+        [<ArgumentLongForm @"verbatim\tab">]
+        Verbatim : int
+        [<ArgumentLongForm "café">]
+        Unicode : int
+    }
+
 [<ArgParser true>]
 type ManyLongForms =
     {

--- a/ConsumePlugin/Args.fs
+++ b/ConsumePlugin/Args.fs
@@ -243,6 +243,10 @@ type AwkwardLongForms =
         Verbatim : int
         [<ArgumentLongForm "café">]
         Unicode : int
+        /// F#'s attribute syntax permits parentheses around the argument, and the name checks
+        /// already see through them, so emission must too.
+        [<ArgumentLongForm("paren\\tab")>]
+        Parenthesised : int
     }
 
 [<ArgParser true>]

--- a/ConsumePlugin/GeneratedArgs.fs
+++ b/ConsumePlugin/GeneratedArgs.fs
@@ -5328,6 +5328,7 @@ module AwkwardLongFormsArgParse =
                     (sprintf "%s  %s%s%s" (sprintf "--%s" "back\\tab") "int32" "" "")
                     (sprintf "%s  %s%s%s" (sprintf "--%s" "verbatim\\tab") "int32" "" "")
                     (sprintf "%s  %s%s%s" (sprintf "--%s" "caf\u00e9") "int32" "" "")
+                    (sprintf "%s  %s%s%s" (sprintf "--%s" "paren\\tab") "int32" "" "")
                 ]
                 |> String.concat "\n"
 
@@ -5335,6 +5336,7 @@ module AwkwardLongFormsArgParse =
             let mutable arg_0 : int option = None
             let mutable arg_1 : int option = None
             let mutable arg_2 : int option = None
+            let mutable arg_3 : int option = None
 
             let parser_schema : ArgParserRuntime_BasicNoPositionals.ErasedSchema =
                 {
@@ -5361,9 +5363,20 @@ module AwkwardLongFormsArgParse =
                                 TypeDescription = ""
                                 Help = None
                             }
+
                             {
                                 Id = 2
                                 Forms = [ "caf\u00e9" ]
+                                AcceptsNegation = false
+                                Arity = ArgParserRuntime_BasicNoPositionals.ErasedArity.One
+                                Repeatable = false
+                                Requirement = ArgParserRuntime_BasicNoPositionals.ErasedRequirement.Required
+                                TypeDescription = ""
+                                Help = None
+                            }
+                            {
+                                Id = 3
+                                Forms = [ "paren\\tab" ]
                                 AcceptsNegation = false
                                 Arity = ArgParserRuntime_BasicNoPositionals.ErasedArity.One
                                 Repeatable = false
@@ -5378,6 +5391,7 @@ module AwkwardLongFormsArgParse =
                                 ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 0
                                 ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 1
                                 ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 2
+                                ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 3
                             ]
                         ))
                     Positionals = List.empty
@@ -5430,6 +5444,20 @@ module AwkwardLongFormsArgParse =
                         | None ->
                             failwith
                                 "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
+                | 3 ->
+                    match arg_3 with
+                    | Some _ -> None
+                    | None ->
+                        match occurrence.Value with
+                        | Some value ->
+                            try
+                                arg_3 <- Some (value |> (fun x -> System.Int32.Parse x))
+                                None
+                            with _ as exc ->
+                                (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                        | None ->
+                            failwith
+                                "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
                 | _ -> failwith "WoofWare.Myriad internal error in generated parser: unknown argument id"
 
             let parser_storePositional (positionalId : int) (value : string) (afterSeparator : bool) : string option =
@@ -5447,6 +5475,10 @@ module AwkwardLongFormsArgParse =
                     | None -> "<no value>"
                 | 2 ->
                     match arg_2 with
+                    | Some x -> x.ToString ()
+                    | None -> "<no value>"
+                | 3 ->
+                    match arg_3 with
                     | Some x -> x.ToString ()
                     | None -> "<no value>"
                 | _ -> "<no value>"
@@ -5474,6 +5506,12 @@ module AwkwardLongFormsArgParse =
                 {
                     Backslash =
                         (match arg_0 with
+                         | Some x -> x
+                         | None ->
+                             failwith
+                                 "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
+                    Parenthesised =
+                        (match arg_3 with
                          | Some x -> x
                          | None ->
                              failwith

--- a/ConsumePlugin/GeneratedArgs.fs
+++ b/ConsumePlugin/GeneratedArgs.fs
@@ -5312,6 +5312,199 @@ open System
 open System.IO
 open WoofWare.Myriad.Plugins
 
+/// Methods to parse arguments for the type AwkwardLongForms
+[<AutoOpen>]
+module AwkwardLongFormsArgParse =
+    /// Extension methods for argument parsing
+    type AwkwardLongForms with
+
+        static member parse'
+            (getEnvironmentVariable : string -> string option)
+            (args : string list)
+            : AwkwardLongForms
+            =
+            let helpText () =
+                [
+                    (sprintf "%s  %s%s%s" (sprintf "--%s" "back\\tab") "int32" "" "")
+                    (sprintf "%s  %s%s%s" (sprintf "--%s" "verbatim\\tab") "int32" "" "")
+                    (sprintf "%s  %s%s%s" (sprintf "--%s" "caf\u00e9") "int32" "" "")
+                ]
+                |> String.concat "\n"
+
+            let parser_LeftoverArgs : string ResizeArray = ResizeArray ()
+            let mutable arg_0 : int option = None
+            let mutable arg_1 : int option = None
+            let mutable arg_2 : int option = None
+
+            let parser_schema : ArgParserRuntime_BasicNoPositionals.ErasedSchema =
+                {
+                    Leaves =
+                        [
+                            {
+                                Id = 0
+                                Forms = [ "back\\tab" ]
+                                AcceptsNegation = false
+                                Arity = ArgParserRuntime_BasicNoPositionals.ErasedArity.One
+                                Repeatable = false
+                                Requirement = ArgParserRuntime_BasicNoPositionals.ErasedRequirement.Required
+                                TypeDescription = ""
+                                Help = None
+                            }
+
+                            {
+                                Id = 1
+                                Forms = [ "verbatim\\tab" ]
+                                AcceptsNegation = false
+                                Arity = ArgParserRuntime_BasicNoPositionals.ErasedArity.One
+                                Repeatable = false
+                                Requirement = ArgParserRuntime_BasicNoPositionals.ErasedRequirement.Required
+                                TypeDescription = ""
+                                Help = None
+                            }
+                            {
+                                Id = 2
+                                Forms = [ "caf\u00e9" ]
+                                AcceptsNegation = false
+                                Arity = ArgParserRuntime_BasicNoPositionals.ErasedArity.One
+                                Repeatable = false
+                                Requirement = ArgParserRuntime_BasicNoPositionals.ErasedRequirement.Required
+                                TypeDescription = ""
+                                Help = None
+                            }
+                        ]
+                    Tree =
+                        (ArgParserRuntime_BasicNoPositionals.ErasedTree.Product (
+                            [
+                                ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 0
+                                ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 1
+                                ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 2
+                            ]
+                        ))
+                    Positionals = List.empty
+                }
+
+            let parser_storeOccurrence
+                (occurrence : ArgParserRuntime_BasicNoPositionals.ErasedOccurrence)
+                : string option
+                =
+                match occurrence.LeafId with
+                | 0 ->
+                    match arg_0 with
+                    | Some _ -> None
+                    | None ->
+                        match occurrence.Value with
+                        | Some value ->
+                            try
+                                arg_0 <- Some (value |> (fun x -> System.Int32.Parse x))
+                                None
+                            with _ as exc ->
+                                (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                        | None ->
+                            failwith
+                                "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
+                | 1 ->
+                    match arg_1 with
+                    | Some _ -> None
+                    | None ->
+                        match occurrence.Value with
+                        | Some value ->
+                            try
+                                arg_1 <- Some (value |> (fun x -> System.Int32.Parse x))
+                                None
+                            with _ as exc ->
+                                (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                        | None ->
+                            failwith
+                                "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
+                | 2 ->
+                    match arg_2 with
+                    | Some _ -> None
+                    | None ->
+                        match occurrence.Value with
+                        | Some value ->
+                            try
+                                arg_2 <- Some (value |> (fun x -> System.Int32.Parse x))
+                                None
+                            with _ as exc ->
+                                (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                        | None ->
+                            failwith
+                                "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
+                | _ -> failwith "WoofWare.Myriad internal error in generated parser: unknown argument id"
+
+            let parser_storePositional (positionalId : int) (value : string) (afterSeparator : bool) : string option =
+                failwith "WoofWare.Myriad internal error in generated parser: no positional sink exists"
+
+            let parser_renderStored (leafId : int) : string =
+                match leafId with
+                | 0 ->
+                    match arg_0 with
+                    | Some x -> x.ToString ()
+                    | None -> "<no value>"
+                | 1 ->
+                    match arg_1 with
+                    | Some x -> x.ToString ()
+                    | None -> "<no value>"
+                | 2 ->
+                    match arg_2 with
+                    | Some x -> x.ToString ()
+                    | None -> "<no value>"
+                | _ -> "<no value>"
+
+            let parser_applyDefault (leafId : int) : string option =
+                match leafId with
+                | _ -> failwith "WoofWare.Myriad internal error in generated parser: unknown defaulted argument id"
+
+            let parser_callbacks : ArgParserRuntime_BasicNoPositionals.TypedCallbacks =
+                {
+                    StoreOccurrence = parser_storeOccurrence
+                    StorePositional = parser_storePositional
+                    HelpText = helpText
+                    RenderStored = parser_renderStored
+                    ApplyDefault = parser_applyDefault
+                }
+
+            match
+                ArgParserRuntime_BasicNoPositionals.runParse
+                    (ArgParserRuntime_BasicNoPositionals.WellFormedSchema.checkOrFail parser_schema)
+                    parser_callbacks
+                    args
+            with
+            | ArgParserRuntime_BasicNoPositionals.ParseOutcome.Success parser_selection ->
+                {
+                    Backslash =
+                        (match arg_0 with
+                         | Some x -> x
+                         | None ->
+                             failwith
+                                 "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
+                    Unicode =
+                        (match arg_2 with
+                         | Some x -> x
+                         | None ->
+                             failwith
+                                 "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
+                    Verbatim =
+                        (match arg_1 with
+                         | Some x -> x
+                         | None ->
+                             failwith
+                                 "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
+                }
+            | ArgParserRuntime_BasicNoPositionals.ParseOutcome.HelpRequested ->
+                helpText () |> failwithf "Help text requested.\n%s"
+            | ArgParserRuntime_BasicNoPositionals.ParseOutcome.Fatal message -> failwith message
+            | ArgParserRuntime_BasicNoPositionals.ParseOutcome.Errors errors ->
+                errors |> String.concat "\n" |> failwithf "Errors during parse!\n%s"
+
+        static member parse (args : string list) : AwkwardLongForms =
+            AwkwardLongForms.parse' (System.Environment.GetEnvironmentVariable >> Option.ofObj) args
+namespace ConsumePlugin
+
+open System
+open System.IO
+open WoofWare.Myriad.Plugins
+
 /// Methods to parse arguments for the type ManyLongForms
 [<AutoOpen>]
 module ManyLongFormsArgParse =

--- a/ConsumePlugin/GeneratedPrefixArgs.fs
+++ b/ConsumePlugin/GeneratedPrefixArgs.fs
@@ -2281,6 +2281,242 @@ namespace ConsumePlugin
 
 open WoofWare.Myriad.Plugins
 
+/// Methods to parse arguments for the type PrefixedAwkwardSpelling
+[<AutoOpen>]
+module PrefixedAwkwardSpellingArgParse =
+    /// Extension methods for argument parsing
+    type PrefixedAwkwardSpelling with
+
+        static member parse'
+            (getEnvironmentVariable : string -> string option)
+            (args : string list)
+            : PrefixedAwkwardSpelling
+            =
+            let helpText () =
+                [
+                    (sprintf "%s  %s%s%s" (sprintf "--%s" "aw\\newline-back\\tab") "int32" "" "")
+                ]
+                |> String.concat "\n"
+
+            let parser_LeftoverArgs : string ResizeArray = ResizeArray ()
+            let mutable arg_0 : int option = None
+
+            let parser_schema : ArgParserRuntime_PrefixedParent.ErasedSchema =
+                {
+                    Leaves =
+                        [
+                            {
+                                Id = 0
+                                Forms = [ "aw\\newline-back\\tab" ]
+                                AcceptsNegation = false
+                                Arity = ArgParserRuntime_PrefixedParent.ErasedArity.One
+                                Repeatable = false
+                                Requirement = ArgParserRuntime_PrefixedParent.ErasedRequirement.Required
+                                TypeDescription = ""
+                                Help = None
+                            }
+                        ]
+                    Tree =
+                        (ArgParserRuntime_PrefixedParent.ErasedTree.Product (
+                            [
+                                ArgParserRuntime_PrefixedParent.ErasedTree.Product (
+                                    [ ArgParserRuntime_PrefixedParent.ErasedTree.Leaf 0 ]
+                                )
+                            ]
+                        ))
+                    Positionals = List.empty
+                }
+
+            let parser_storeOccurrence (occurrence : ArgParserRuntime_PrefixedParent.ErasedOccurrence) : string option =
+                match occurrence.LeafId with
+                | 0 ->
+                    match arg_0 with
+                    | Some _ -> None
+                    | None ->
+                        match occurrence.Value with
+                        | Some value ->
+                            try
+                                arg_0 <- Some (value |> (fun x -> System.Int32.Parse x))
+                                None
+                            with _ as exc ->
+                                (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                        | None ->
+                            failwith
+                                "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
+                | _ -> failwith "WoofWare.Myriad internal error in generated parser: unknown argument id"
+
+            let parser_storePositional (positionalId : int) (value : string) (afterSeparator : bool) : string option =
+                failwith "WoofWare.Myriad internal error in generated parser: no positional sink exists"
+
+            let parser_renderStored (leafId : int) : string =
+                match leafId with
+                | 0 ->
+                    match arg_0 with
+                    | Some x -> x.ToString ()
+                    | None -> "<no value>"
+                | _ -> "<no value>"
+
+            let parser_applyDefault (leafId : int) : string option =
+                match leafId with
+                | _ -> failwith "WoofWare.Myriad internal error in generated parser: unknown defaulted argument id"
+
+            let parser_callbacks : ArgParserRuntime_PrefixedParent.TypedCallbacks =
+                {
+                    StoreOccurrence = parser_storeOccurrence
+                    StorePositional = parser_storePositional
+                    HelpText = helpText
+                    RenderStored = parser_renderStored
+                    ApplyDefault = parser_applyDefault
+                }
+
+            match
+                ArgParserRuntime_PrefixedParent.runParse
+                    (ArgParserRuntime_PrefixedParent.WellFormedSchema.checkOrFail parser_schema)
+                    parser_callbacks
+                    args
+            with
+            | ArgParserRuntime_PrefixedParent.ParseOutcome.Success parser_selection ->
+                {
+                    Child =
+                        {
+                            Awkward =
+                                (match arg_0 with
+                                 | Some x -> x
+                                 | None ->
+                                     failwith
+                                         "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
+                        }
+                }
+            | ArgParserRuntime_PrefixedParent.ParseOutcome.HelpRequested ->
+                helpText () |> failwithf "Help text requested.\n%s"
+            | ArgParserRuntime_PrefixedParent.ParseOutcome.Fatal message -> failwith message
+            | ArgParserRuntime_PrefixedParent.ParseOutcome.Errors errors ->
+                errors |> String.concat "\n" |> failwithf "Errors during parse!\n%s"
+
+        static member parse (args : string list) : PrefixedAwkwardSpelling =
+            PrefixedAwkwardSpelling.parse' (System.Environment.GetEnvironmentVariable >> Option.ofObj) args
+namespace ConsumePlugin
+
+open WoofWare.Myriad.Plugins
+
+/// Methods to parse arguments for the type PrefixedViaLiteral
+[<AutoOpen>]
+module PrefixedViaLiteralArgParse =
+    /// Extension methods for argument parsing
+    type PrefixedViaLiteral with
+
+        static member parse'
+            (getEnvironmentVariable : string -> string option)
+            (args : string list)
+            : PrefixedViaLiteral
+            =
+            let helpText () =
+                [
+                    (sprintf "%s  %s%s%s" (sprintf "--%s" "viaesc\\tab-" + (ViaLiteral)) "int32" "" "")
+                ]
+                |> String.concat "\n"
+
+            let parser_LeftoverArgs : string ResizeArray = ResizeArray ()
+            let mutable arg_0 : int option = None
+
+            let parser_schema : ArgParserRuntime_PrefixedParent.ErasedSchema =
+                {
+                    Leaves =
+                        [
+                            {
+                                Id = 0
+                                Forms = [ "viaesc\\tab-" + (ViaLiteral) ]
+                                AcceptsNegation = false
+                                Arity = ArgParserRuntime_PrefixedParent.ErasedArity.One
+                                Repeatable = false
+                                Requirement = ArgParserRuntime_PrefixedParent.ErasedRequirement.Required
+                                TypeDescription = ""
+                                Help = None
+                            }
+                        ]
+                    Tree =
+                        (ArgParserRuntime_PrefixedParent.ErasedTree.Product (
+                            [
+                                ArgParserRuntime_PrefixedParent.ErasedTree.Product (
+                                    [ ArgParserRuntime_PrefixedParent.ErasedTree.Leaf 0 ]
+                                )
+                            ]
+                        ))
+                    Positionals = List.empty
+                }
+
+            let parser_storeOccurrence (occurrence : ArgParserRuntime_PrefixedParent.ErasedOccurrence) : string option =
+                match occurrence.LeafId with
+                | 0 ->
+                    match arg_0 with
+                    | Some _ -> None
+                    | None ->
+                        match occurrence.Value with
+                        | Some value ->
+                            try
+                                arg_0 <- Some (value |> (fun x -> System.Int32.Parse x))
+                                None
+                            with _ as exc ->
+                                (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                        | None ->
+                            failwith
+                                "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
+                | _ -> failwith "WoofWare.Myriad internal error in generated parser: unknown argument id"
+
+            let parser_storePositional (positionalId : int) (value : string) (afterSeparator : bool) : string option =
+                failwith "WoofWare.Myriad internal error in generated parser: no positional sink exists"
+
+            let parser_renderStored (leafId : int) : string =
+                match leafId with
+                | 0 ->
+                    match arg_0 with
+                    | Some x -> x.ToString ()
+                    | None -> "<no value>"
+                | _ -> "<no value>"
+
+            let parser_applyDefault (leafId : int) : string option =
+                match leafId with
+                | _ -> failwith "WoofWare.Myriad internal error in generated parser: unknown defaulted argument id"
+
+            let parser_callbacks : ArgParserRuntime_PrefixedParent.TypedCallbacks =
+                {
+                    StoreOccurrence = parser_storeOccurrence
+                    StorePositional = parser_storePositional
+                    HelpText = helpText
+                    RenderStored = parser_renderStored
+                    ApplyDefault = parser_applyDefault
+                }
+
+            match
+                ArgParserRuntime_PrefixedParent.runParse
+                    (ArgParserRuntime_PrefixedParent.WellFormedSchema.checkOrFail parser_schema)
+                    parser_callbacks
+                    args
+            with
+            | ArgParserRuntime_PrefixedParent.ParseOutcome.Success parser_selection ->
+                {
+                    Child =
+                        {
+                            X =
+                                (match arg_0 with
+                                 | Some x -> x
+                                 | None ->
+                                     failwith
+                                         "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
+                        }
+                }
+            | ArgParserRuntime_PrefixedParent.ParseOutcome.HelpRequested ->
+                helpText () |> failwithf "Help text requested.\n%s"
+            | ArgParserRuntime_PrefixedParent.ParseOutcome.Fatal message -> failwith message
+            | ArgParserRuntime_PrefixedParent.ParseOutcome.Errors errors ->
+                errors |> String.concat "\n" |> failwithf "Errors during parse!\n%s"
+
+        static member parse (args : string list) : PrefixedViaLiteral =
+            PrefixedViaLiteral.parse' (System.Environment.GetEnvironmentVariable >> Option.ofObj) args
+namespace ConsumePlugin
+
+open WoofWare.Myriad.Plugins
+
 /// Methods to parse arguments for the type PrefixedLongForms
 [<AutoOpen>]
 module PrefixedLongFormsArgParse =

--- a/ConsumePlugin/PrefixArgs.fs
+++ b/ConsumePlugin/PrefixArgs.fs
@@ -82,6 +82,42 @@ type PrefixedThroughUnprefixed =
         Middle : UnprefixedMiddle
     }
 
+type ChildWithAwkwardSpelling =
+    {
+        [<ArgumentLongForm "back\\tab">]
+        Awkward : int
+    }
+
+/// Prefixing *rebuilds* a spelling, so the combined name is a constant we invent rather than one
+/// the author wrote, and it needs the escaping their source supplied just as much. Without it the
+/// emitted `\n` and `\t` here are read back as a newline and a tab.
+[<ArgParser true>]
+type PrefixedAwkwardSpelling =
+    {
+        [<ArgumentPrefix "aw\\newline">]
+        Child : ChildWithAwkwardSpelling
+    }
+
+[<AutoOpen>]
+module PrefixLongFormLiterals =
+    [<Literal>]
+    let ViaLiteral = "via-literal"
+
+type ChildViaLiteral =
+    {
+        [<ArgumentLongForm(ViaLiteral)>]
+        X : int
+    }
+
+/// A long form we cannot read at generation time becomes a concatenation the generated program
+/// performs, so the prefix half of it is a constant we invent and must escape.
+[<ArgParser true>]
+type PrefixedViaLiteral =
+    {
+        [<ArgumentPrefix "viaesc\\tab">]
+        Child : ChildViaLiteral
+    }
+
 type ChildWithLongForms =
     {
         [<ArgumentLongForm "renamed">]

--- a/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParser.fs
+++ b/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParser.fs
@@ -1042,12 +1042,13 @@ Trailing argument --unknown had no value. Use a double-dash to separate position
     let ``Long forms needing escaping survive re-emission`` () =
         let getEnvVar (_ : string) = failwith "should not call"
 
-        AwkwardLongForms.parse' getEnvVar [ "--back\\tab=1" ; "--verbatim\\tab=2" ; "--café=3" ]
+        AwkwardLongForms.parse' getEnvVar [ "--back\\tab=1" ; "--verbatim\\tab=2" ; "--café=3" ; "--paren\\tab=4" ]
         |> shouldEqual
             {
                 Backslash = 1
                 Verbatim = 2
                 Unicode = 3
+                Parenthesised = 4
             }
 
     /// The help text advertises the same spellings the scanner accepts.
@@ -1063,4 +1064,5 @@ Trailing argument --unknown had no value. Use a double-dash to separate position
             """Help text requested.
 --back\tab  int32
 --verbatim\tab  int32
---café  int32"""
+--café  int32
+--paren\tab  int32"""

--- a/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParser.fs
+++ b/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParser.fs
@@ -1033,3 +1033,34 @@ Trailing argument --unknown had no value. Use a double-dash to separate position
         exc.Message |> shouldContainText "--bar  string"
         // Make sure there's no extra blank line at the beginning
         exc.Message.StartsWith '\n' |> shouldEqual false
+
+    /// An argument's spelling survives the generated file's round trip. A `SynConst.String` holds
+    /// *decoded* text, so re-emitting it demands the escaping the author's own source supplied:
+    /// without it `"back\\tab"` is emitted as `"back\tab"`, read back with a tab in it, and the
+    /// argument answers to a name other than the one declared.
+    [<Test>]
+    let ``Long forms needing escaping survive re-emission`` () =
+        let getEnvVar (_ : string) = failwith "should not call"
+
+        AwkwardLongForms.parse' getEnvVar [ "--back\\tab=1" ; "--verbatim\\tab=2" ; "--café=3" ]
+        |> shouldEqual
+            {
+                Backslash = 1
+                Verbatim = 2
+                Unicode = 3
+            }
+
+    /// The help text advertises the same spellings the scanner accepts.
+    [<Test>]
+    let ``Help text for long forms needing escaping`` () =
+        let getEnvVar (_ : string) = failwith "should not call"
+
+        let exc =
+            Assert.Throws<exn> (fun () -> AwkwardLongForms.parse' getEnvVar [ "--help" ] |> ignore<AwkwardLongForms>)
+
+        exc.Message
+        |> shouldEqual
+            """Help text requested.
+--back\tab  int32
+--verbatim\tab  int32
+--café  int32"""

--- a/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParserPrefix.fs
+++ b/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParserPrefix.fs
@@ -173,6 +173,35 @@ module TestArgParserPrefix =
 
         exc.Message |> shouldContainText "--flags-no-enable-feature"
 
+    /// Prefixing rebuilds a spelling as a fresh string constant, and a `SynConst.String` holds
+    /// *decoded* text, so the combined name needs the escaping the author's own source supplied.
+    /// Without it the emitted `\n` and `\t` are read back as a newline and a tab, and the argument
+    /// silently answers to a name other than the one declared.
+    [<Test>]
+    let ``A prefixed spelling containing backslashes survives re-emission`` () =
+        PrefixedAwkwardSpelling.parse' noEnvVar [ "--aw\\newline-back\\tab=3" ]
+        |> shouldEqual
+            {
+                Child =
+                    {
+                        Awkward = 3
+                    }
+            }
+
+    /// A long form we cannot read at generation time stays an expression the generated program
+    /// evaluates, so the prefix is concatenated to it at *runtime* -- but the prefix half is still a
+    /// constant we invent, and still needs escaping on the way out.
+    [<Test>]
+    let ``A prefix joined to an unreadable long form is escaped`` () =
+        PrefixedViaLiteral.parse' noEnvVar [ "--viaesc\\tab-via-literal=5" ]
+        |> shouldEqual
+            {
+                Child =
+                    {
+                        X = 5
+                    }
+            }
+
     /// A positional sink inside a prefixed sub-record still collects bare tokens, and its keyed
     /// alias -- the `--form=value` spelling which addresses the sink explicitly -- is prefixed like
     /// any other name.

--- a/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
+++ b/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
@@ -129,7 +129,10 @@ module private ArgFormEmission =
     /// A form we cannot read (an [<ArgumentLongForm>] naming a [<Literal>]) is an expression the
     /// generated program evaluates for itself, and passes through untouched.
     let emitArgForm (form : SynExpr) : SynExpr =
-        match form with
+        // F#'s attribute syntax permits parentheses around the argument, and the generation-time
+        // name checks already see through them (`literalForms`), so emission must agree: otherwise
+        // `[<ArgumentLongForm ("back\\tab")>]` would be checked as one name and emitted as another.
+        match SynExpr.stripOptionalParen form with
         | SynExpr.Const (SynConst.String (s, _, _), _) ->
             SynExpr.Const (SynConst.String (escapeStringConstant s, SynStringKind.Regular, range0), range0)
         | form -> form

--- a/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
+++ b/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
@@ -91,6 +91,49 @@ type private Accumulation<'choice> =
     /// no arguments (it is then empty), so it is neither optional nor defaultable.
     | Map of MapSpec
 
+/// Turning an argument's spelling into generated source. `ArgForm` holds the semantic spelling,
+/// which is what the generation-time name checks must compare; these ready it for emission.
+[<RequireQualifiedAccess>]
+module private ArgFormEmission =
+
+    /// Rewrite a string so that it can be dropped between the quotes of a generated regular string
+    /// literal and read back as itself.
+    ///
+    /// This is not simply "the F# escaping rules", because Fantomas has its own view: it emits a
+    /// `SynConst.String`'s text between quotes having escaped the quotes and nothing else. Anything
+    /// else which needs escaping is therefore ours to do (otherwise `C:\temp` would be emitted as
+    /// `"C:\temp"`, whose `\t` is a tab), and we escape the quote as `\u0022` rather than `\"` so
+    /// that Fantomas finds no quote to escape and hands our text through unaltered.
+    let escapeStringConstant (s : string) : string =
+        s
+        |> String.collect (fun c ->
+            match c with
+            | '\\' -> @"\\"
+            | '"' -> @"\u0022"
+            // Everything outside printable ASCII goes out as an escape: `\uXXXX` is a UTF-16 code
+            // unit, which is exactly what a char of a .NET string is, so this is faithful even for
+            // an unpaired surrogate, and it keeps the generated file free of any dependence on how
+            // it is encoded.
+            | c when c >= ' ' && c <= '~' -> System.Char.ToString c
+            | c -> sprintf @"\u%04x" (int c)
+        )
+
+    /// Ready an argument's spelling to be written into the generated file.
+    ///
+    /// `ArgForm` holds the *semantic* spelling: a `SynConst.String` carries decoded text, and the
+    /// generation-time name checks must compare what the scanner will compare, not a rendering of it
+    /// (`é` against `É` would miss the collision that `é` and `É` do have). Emission wants
+    /// the opposite, so escape here, at the boundary, and emit a regular string whatever the author
+    /// wrote -- a verbatim or triple-quoted spelling could not express the escapes we need.
+    ///
+    /// A form we cannot read (an [<ArgumentLongForm>] naming a [<Literal>]) is an expression the
+    /// generated program evaluates for itself, and passes through untouched.
+    let emitArgForm (form : SynExpr) : SynExpr =
+        match form with
+        | SynExpr.Const (SynConst.String (s, _, _), _) ->
+            SynExpr.Const (SynConst.String (escapeStringConstant s, SynStringKind.Regular, range0), range0)
+        | form -> form
+
 type private ParseFunction<'acc> =
     {
         FieldName : Ident
@@ -146,7 +189,8 @@ type private ParseFunction<'acc> =
             let combinedFormatString = standardFormatString + " / " + negatedFormatString
 
             // Apply all arg forms twice (once for standard, once for negated)
-            let allArgForms = arg.ArgForm @ arg.ArgForm
+            let allArgForms =
+                (arg.ArgForm @ arg.ArgForm) |> List.map ArgFormEmission.emitArgForm
 
             (SynExpr.applyFunction (SynExpr.createIdent "sprintf") (SynExpr.CreateConst combinedFormatString),
              allArgForms)
@@ -156,7 +200,8 @@ type private ParseFunction<'acc> =
             // Standard behavior: just --foo / --bar
             let formatString = List.replicate arg.ArgForm.Length "--%s" |> String.concat " / "
 
-            (SynExpr.applyFunction (SynExpr.createIdent "sprintf") (SynExpr.CreateConst formatString), arg.ArgForm)
+            (SynExpr.applyFunction (SynExpr.createIdent "sprintf") (SynExpr.CreateConst formatString),
+             arg.ArgForm |> List.map ArgFormEmission.emitArgForm)
             ||> List.fold SynExpr.applyFunction
             |> SynExpr.paren
 
@@ -831,28 +876,6 @@ module internal ArgParserGenerator =
             ids |> List.map _.idText |> String.concat "." |> Identifier
         | _ -> Unrecognised
 
-    /// Rewrite a string so that it can be dropped between the quotes of a generated regular string
-    /// literal and read back as itself.
-    ///
-    /// This is not simply "the F# escaping rules", because Fantomas has its own view: it emits a
-    /// `SynConst.String`'s text between quotes having escaped the quotes and nothing else. Anything
-    /// else which needs escaping is therefore ours to do (otherwise `C:\temp` would be emitted as
-    /// `"C:\temp"`, whose `\t` is a tab), and we escape the quote as `\u0022` rather than `\"` so
-    /// that Fantomas finds no quote to escape and hands our text through unaltered.
-    let private escapeStringConstant (s : string) : string =
-        s
-        |> String.collect (fun c ->
-            match c with
-            | '\\' -> @"\\"
-            | '"' -> @"\u0022"
-            // Everything outside printable ASCII goes out as an escape: `\uXXXX` is a UTF-16 code
-            // unit, which is exactly what a char of a .NET string is, so this is faithful even for
-            // an unpaired surrogate, and it keeps the generated file free of any dependence on how
-            // it is encoded.
-            | c when c >= ' ' && c <= '~' -> System.Char.ToString c
-            | c -> sprintf @"\u%04x" (int c)
-        )
-
     /// Build the expression for a recognised constant default.
     ///
     /// A `SynConst.Char` needs care: Fantomas renders one without its quotes, so `'a'` reaches the
@@ -869,7 +892,10 @@ module internal ArgParserGenerator =
         match c with
         | SynConst.Char c -> SynExpr.CreateConst c
         | SynConst.String (text = s) ->
-            SynExpr.Const (SynConst.String (escapeStringConstant s, SynStringKind.Regular, range0), range0)
+            SynExpr.Const (
+                SynConst.String (ArgFormEmission.escapeStringConstant s, SynStringKind.Regular, range0),
+                range0
+            )
         | c -> SynExpr.Const (c, range0)
 
     /// Builds a function or lambda of one string argument, which returns a `ty` (as modified by the `Accumulation`;
@@ -2131,7 +2157,7 @@ module internal ArgParserGenerator =
 
                     [
                         field "Id" (SynExpr.CreateConst index)
-                        field "Forms" (listOf pf.ArgForm)
+                        field "Forms" (listOf (pf.ArgForm |> List.map ArgFormEmission.emitArgForm))
                         field "AcceptsNegation" (SynExpr.CreateConst pf.AcceptsNegation)
                         field "Arity" arity
                         field "Repeatable" repeatable
@@ -2171,7 +2197,7 @@ module internal ArgParserGenerator =
 
                     [
                         field "Id" (SynExpr.CreateConst index)
-                        field "Forms" (listOf pf.ArgForm)
+                        field "Forms" (listOf (pf.ArgForm |> List.map ArgFormEmission.emitArgForm))
                         field "FlagLike" flagLike
                         field "TypeDescription" (SynExpr.CreateConst "")
                         field "Help" (SynExpr.createIdent "None")

--- a/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
+++ b/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
@@ -1336,7 +1336,17 @@ module internal ArgParserGenerator =
 
         match SynExpr.stripOptionalParen form with
         | SynExpr.Const (SynConst.String (s, _, _), _) -> SynExpr.CreateConst (prefix + s)
-        | form -> SynExpr.plus (SynExpr.CreateConst prefix) (SynExpr.paren form)
+        | form ->
+            // A form we cannot read stays an expression the generated program evaluates, so the
+            // prefix is joined to it there. That makes this branch pure emission -- `literalForms`
+            // matches only a bare constant, so nothing here reaches the name checks -- and the
+            // constant we are about to write out needs escaping like any other.
+            SynExpr.plus
+                (SynExpr.Const (
+                    SynConst.String (ArgFormEmission.escapeStringConstant prefix, SynStringKind.Regular, range0),
+                    range0
+                ))
+                (SynExpr.paren form)
 
     /// An argument schema must be a finite tree: a record or union which refers to itself, even
     /// indirectly, would expand forever. `ancestors` is the chain of type names currently being


### PR DESCRIPTION
A `SynConst.String` holds **decoded** text, so writing one into the generated file demands the escaping the author's own source supplied. `defaultValueExpr` already documents and guards against exactly this for default values (`ContainsAwkwardStringDefaults` in `ConsumePlugin/Args.fs` is its regression test). Argument *names* had no such guard:

```fsharp
[<ArgParser>]
type Args = { [<ArgumentLongForm "back\\tab">] Backslash : int }
```

was emitted as `Forms = [ "back\tab" ]` — whose `\t` is a tab — so the argument silently answered to a name other than the one declared. A spelling containing e.g. `\q` could stop the generated file compiling at all.

We now escape it at the emission sites (`HumanReadableArgForm`, and the erased schema's `Forms`), not in `ArgForm` itself. `ArgForm` needs the semantic spelling, not the escaped spelling, because at generation time we have to compare it to those of other fields to check collisions.

## Notes

- A verbatim spelling (`@"back\tab"`) was already emitted correctly, since Fantomas re-prints it as `@"..."`. It now goes out as an escaped regular string instead, which reads back the same.

Found while implementing `[<ArgumentPrefix>]` (#598), which rebuilds spellings and so hits this immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)