### PR TITLE
ArgParser: group nested records' args in help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 Notable changes are recorded here.
 
+# WoofWare.Myriad.Plugins 10.7.1
+
+`ArgParserGenerator` help text now groups the arguments contributed by a field whose type is another argument record, or a union of alternative argument sets, under a header line naming that field.
+Previously those arguments were flattened into one undifferentiated list, so nothing indicated which arguments were declared together.
+A union-typed field's alternatives are now listed inside its field's group, rather than at the top level.
+
+An `[<ArgumentHelpText>]` on such a field is now honoured, and appears on that header line: it was previously read and then silently dropped, because the structural branches ran before the machinery which consumes it.
+So `[<ArgumentHelpText "Settings for the child thing">] Child : ChildRecord` gives a header of `Child: Settings for the child thing`.
+
+The grouping is applied whether or not any help text is present, so `--help` output changes for every parser containing a nested record or a union-typed field.
+Argument spellings are unaffected: a nested record's arguments still live in the same flat namespace as their parent's, and the header describes which arguments were declared together rather than anything the user must type.
+(Use `[<ArgumentPrefix>]` if you want the nesting reflected in the spellings too.)
+
 # WoofWare.Myriad.Plugins 10.6.2
 
 `ArgParserGenerator` now correctly escapes strings from `ArgumentLongForm` where necessary.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,7 @@ Notable changes are recorded here.
 # WoofWare.Myriad.Plugins 10.7.1
 
 `ArgParserGenerator` help text now groups the arguments contributed by a field whose type is another argument record, or a union of alternative argument sets, under a header line naming that field.
-Previously those arguments were flattened into one undifferentiated list, so nothing indicated which arguments were declared together.
-A union-typed field's alternatives are now listed inside its field's group, rather than at the top level.
-
-An `[<ArgumentHelpText>]` on such a field is now honoured, and appears on that header line: it was previously read and then silently dropped, because the structural branches ran before the machinery which consumes it.
-So `[<ArgumentHelpText "Settings for the child thing">] Child : ChildRecord` gives a header of `Child: Settings for the child thing`.
-
-The grouping is applied whether or not any help text is present, so `--help` output changes for every parser containing a nested record or a union-typed field.
-Argument spellings are unaffected: a nested record's arguments still live in the same flat namespace as their parent's, and the header describes which arguments were declared together rather than anything the user must type.
-(Use `[<ArgumentPrefix>]` if you want the nesting reflected in the spellings too.)
+(Previously those arguments were flattened into one undifferentiated list, so nothing indicated which arguments were declared together.)
 
 # WoofWare.Myriad.Plugins 10.6.2
 

--- a/ConsumePlugin/Args.fs
+++ b/ConsumePlugin/Args.fs
@@ -146,6 +146,18 @@ type ParentRecordSelfPos =
         AndAnother : bool list
     }
 
+/// A structural field's [<ArgumentHelpText>] describes the group of arguments the field
+/// contributes, rather than any single argument: it appears on the header line which introduces
+/// that group in the help text.
+[<ArgParser true>]
+type ParentRecordWithGroupHelp =
+    {
+        [<ArgumentHelpText "Settings for the child thing">]
+        Child : ChildRecord
+        [<ArgumentHelpText "Whether to and-another">]
+        AndAnother : bool
+    }
+
 [<ArgParser true>]
 type ChoicePositionals =
     {

--- a/ConsumePlugin/DuArgs.fs
+++ b/ConsumePlugin/DuArgs.fs
@@ -66,6 +66,16 @@ type DuWithDefaultArgs =
     | Defaulted of DefaultedArgs
     | Plain of PlainArgs
 
+/// A union-typed field's [<ArgumentHelpText>] describes the whole set of alternatives, so it
+/// heads the group which the alternatives are then listed inside.
+[<ArgParser>]
+type WithModeHelpArgs =
+    {
+        Verbose : bool
+        [<ArgumentHelpText "How loud to be">]
+        Mode : Mode
+    }
+
 /// A union beside a positional sink (default, i.e. Reject-mode): named arguments select the
 /// union case, and every bare token is routed to the sink whichever case wins. An unrecognised
 /// `--key`-shaped token remains fatal. The sink converts, so selection must not depend on the

--- a/ConsumePlugin/GeneratedArgs.fs
+++ b/ConsumePlugin/GeneratedArgs.fs
@@ -3296,8 +3296,9 @@ module ParentRecordArgParse =
         static member parse' (getEnvironmentVariable : string -> string option) (args : string list) : ParentRecord =
             let helpText () =
                 [
-                    (sprintf "%s  %s%s%s" (sprintf "--%s" "thing1") "int32" "" "")
-                    (sprintf "%s  %s%s%s" (sprintf "--%s" "thing2") "string" "" "")
+                    (sprintf "%s:" "Child")
+                    (sprintf "  %s  %s%s%s" (sprintf "--%s" "thing1") "int32" "" "")
+                    (sprintf "  %s  %s%s%s" (sprintf "--%s" "thing2") "string" "" "")
                     (sprintf "%s  %s%s%s" (sprintf "--%s" "and-another") "bool" "" "")
                 ]
                 |> String.concat "\n"
@@ -3498,8 +3499,10 @@ module ParentRecordChildDefaultArgParse =
             =
             let helpText () =
                 [
+                    (sprintf "%s:" "Child")
+
                     (sprintf
-                        "%s  %s%s%s"
+                        "  %s  %s%s%s"
                         (sprintf "--%s" "from-function")
                         "int32"
                         (ChildRecordWithDefault.DefaultFromFunction().ToString ()
@@ -3671,8 +3674,9 @@ module ParentRecordChildPosArgParse =
             let helpText () =
                 [
                     (sprintf "%s  %s%s%s" (sprintf "--%s" "and-another") "bool" "" "")
-                    (sprintf "%s  %s%s%s" (sprintf "--%s" "thing1") "int32" "" "")
-                    (sprintf "%s  %s%s%s" (sprintf "--%s" "thing2") "URI" " (positional args) (can be repeated)" "")
+                    (sprintf "%s:" "Child")
+                    (sprintf "  %s  %s%s%s" (sprintf "--%s" "thing1") "int32" "" "")
+                    (sprintf "  %s  %s%s%s" (sprintf "--%s" "thing2") "URI" " (positional args) (can be repeated)" "")
                 ]
                 |> String.concat "\n"
 
@@ -3853,8 +3857,9 @@ module ParentRecordSelfPosArgParse =
             =
             let helpText () =
                 [
-                    (sprintf "%s  %s%s%s" (sprintf "--%s" "thing1") "int32" "" "")
-                    (sprintf "%s  %s%s%s" (sprintf "--%s" "thing2") "string" "" "")
+                    (sprintf "%s:" "Child")
+                    (sprintf "  %s  %s%s%s" (sprintf "--%s" "thing1") "int32" "" "")
+                    (sprintf "  %s  %s%s%s" (sprintf "--%s" "thing2") "string" "" "")
                     (sprintf
                         "%s  %s%s%s"
                         (sprintf "--%s" "and-another")
@@ -4020,6 +4025,214 @@ module ParentRecordSelfPosArgParse =
 
         static member parse (args : string list) : ParentRecordSelfPos =
             ParentRecordSelfPos.parse' (System.Environment.GetEnvironmentVariable >> Option.ofObj) args
+namespace ConsumePlugin
+
+open System
+open System.IO
+open WoofWare.Myriad.Plugins
+
+/// Methods to parse arguments for the type ParentRecordWithGroupHelp
+[<AutoOpen>]
+module ParentRecordWithGroupHelpArgParse =
+    /// Extension methods for argument parsing
+    type ParentRecordWithGroupHelp with
+
+        static member parse'
+            (getEnvironmentVariable : string -> string option)
+            (args : string list)
+            : ParentRecordWithGroupHelp
+            =
+            let helpText () =
+                [
+                    (sprintf "%s: %s" "Child" ("Settings for the child thing"))
+                    (sprintf "  %s  %s%s%s" (sprintf "--%s" "thing1") "int32" "" "")
+                    (sprintf "  %s  %s%s%s" (sprintf "--%s" "thing2") "string" "" "")
+                    (sprintf
+                        "%s  %s%s%s"
+                        (sprintf "--%s" "and-another")
+                        "bool"
+                        ""
+                        (sprintf " : %s" ("Whether to and-another")))
+                ]
+                |> String.concat "\n"
+
+            let parser_LeftoverArgs : string ResizeArray = ResizeArray ()
+            let mutable arg_0 : int option = None
+            let mutable arg_1 : string option = None
+            let mutable arg_2 : bool option = None
+
+            let parser_schema : ArgParserRuntime_BasicNoPositionals.ErasedSchema =
+                {
+                    Leaves =
+                        [
+                            {
+                                Id = 0
+                                Forms = [ "thing1" ]
+                                AcceptsNegation = false
+                                Arity = ArgParserRuntime_BasicNoPositionals.ErasedArity.One
+                                Repeatable = false
+                                Requirement = ArgParserRuntime_BasicNoPositionals.ErasedRequirement.Required
+                                TypeDescription = ""
+                                Help = None
+                            }
+
+                            {
+                                Id = 1
+                                Forms = [ "thing2" ]
+                                AcceptsNegation = false
+                                Arity = ArgParserRuntime_BasicNoPositionals.ErasedArity.One
+                                Repeatable = false
+                                Requirement = ArgParserRuntime_BasicNoPositionals.ErasedRequirement.Required
+                                TypeDescription = ""
+                                Help = None
+                            }
+                            {
+                                Id = 2
+                                Forms = [ "and-another" ]
+                                AcceptsNegation = false
+                                Arity = ArgParserRuntime_BasicNoPositionals.ErasedArity.BoolLike
+                                Repeatable = false
+                                Requirement = ArgParserRuntime_BasicNoPositionals.ErasedRequirement.Required
+                                TypeDescription = ""
+                                Help = None
+                            }
+                        ]
+                    Tree =
+                        (ArgParserRuntime_BasicNoPositionals.ErasedTree.Product (
+                            [
+                                ArgParserRuntime_BasicNoPositionals.ErasedTree.Product (
+                                    [
+                                        ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 0
+                                        ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 1
+                                    ]
+                                )
+                                ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 2
+                            ]
+                        ))
+                    Positionals = List.empty
+                }
+
+            let parser_storeOccurrence
+                (occurrence : ArgParserRuntime_BasicNoPositionals.ErasedOccurrence)
+                : string option
+                =
+                match occurrence.LeafId with
+                | 0 ->
+                    match arg_0 with
+                    | Some _ -> None
+                    | None ->
+                        match occurrence.Value with
+                        | Some value ->
+                            try
+                                arg_0 <- Some (value |> (fun x -> System.Int32.Parse x))
+                                None
+                            with _ as exc ->
+                                (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                        | None ->
+                            failwith
+                                "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
+                | 1 ->
+                    match arg_1 with
+                    | Some _ -> None
+                    | None ->
+                        match occurrence.Value with
+                        | Some value ->
+                            try
+                                arg_1 <- Some (value |> (fun x -> x))
+                                None
+                            with _ as exc ->
+                                (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                        | None ->
+                            failwith
+                                "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
+                | 2 ->
+                    match arg_2 with
+                    | Some _ -> None
+                    | None ->
+                        match occurrence.Value with
+                        | Some value ->
+                            try
+                                let parsedBool = System.Boolean.Parse value
+                                let parsedBool = if occurrence.Negated then not parsedBool else parsedBool
+                                arg_2 <- Some (parsedBool)
+                                None
+                            with _ as exc ->
+                                (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                        | None ->
+                            arg_2 <- Some ((if occurrence.Negated then false else true))
+                            None
+                | _ -> failwith "WoofWare.Myriad internal error in generated parser: unknown argument id"
+
+            let parser_storePositional (positionalId : int) (value : string) (afterSeparator : bool) : string option =
+                failwith "WoofWare.Myriad internal error in generated parser: no positional sink exists"
+
+            let parser_renderStored (leafId : int) : string =
+                match leafId with
+                | 0 ->
+                    match arg_0 with
+                    | Some x -> x.ToString ()
+                    | None -> "<no value>"
+                | 1 ->
+                    match arg_1 with
+                    | Some x -> x.ToString ()
+                    | None -> "<no value>"
+                | 2 ->
+                    match arg_2 with
+                    | Some x -> x.ToString ()
+                    | None -> "<no value>"
+                | _ -> "<no value>"
+
+            let parser_applyDefault (leafId : int) : string option =
+                match leafId with
+                | _ -> failwith "WoofWare.Myriad internal error in generated parser: unknown defaulted argument id"
+
+            let parser_callbacks : ArgParserRuntime_BasicNoPositionals.TypedCallbacks =
+                {
+                    StoreOccurrence = parser_storeOccurrence
+                    StorePositional = parser_storePositional
+                    HelpText = helpText
+                    RenderStored = parser_renderStored
+                    ApplyDefault = parser_applyDefault
+                }
+
+            match
+                ArgParserRuntime_BasicNoPositionals.runParse
+                    (ArgParserRuntime_BasicNoPositionals.WellFormedSchema.checkOrFail parser_schema)
+                    parser_callbacks
+                    args
+            with
+            | ArgParserRuntime_BasicNoPositionals.ParseOutcome.Success parser_selection ->
+                {
+                    AndAnother =
+                        (match arg_2 with
+                         | Some x -> x
+                         | None ->
+                             failwith
+                                 "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
+                    Child =
+                        {
+                            Thing1 =
+                                (match arg_0 with
+                                 | Some x -> x
+                                 | None ->
+                                     failwith
+                                         "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
+                            Thing2 =
+                                (match arg_1 with
+                                 | Some x -> x
+                                 | None ->
+                                     failwith
+                                         "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
+                        }
+                }
+            | ArgParserRuntime_BasicNoPositionals.ParseOutcome.HelpRequested ->
+                helpText () |> failwithf "Help text requested.\n%s"
+            | ArgParserRuntime_BasicNoPositionals.ParseOutcome.Fatal message -> failwith message
+            | ArgParserRuntime_BasicNoPositionals.ParseOutcome.Errors errors ->
+                errors |> String.concat "\n" |> failwithf "Errors during parse!\n%s"
+
+        static member parse (args : string list) : ParentRecordWithGroupHelp =
+            ParentRecordWithGroupHelp.parse' (System.Environment.GetEnvironmentVariable >> Option.ofObj) args
 namespace ConsumePlugin
 
 open System

--- a/ConsumePlugin/GeneratedDuArgs.fs
+++ b/ConsumePlugin/GeneratedDuArgs.fs
@@ -1625,11 +1625,12 @@ module WithModeArgs =
         let helpText () =
             [
                 (sprintf "%s  %s%s%s" (sprintf "--%s" "verbose") "bool" "" "")
-                "exactly one of the following sets of arguments:"
-                "Auto:"
-                (sprintf "  %s  %s%s%s" (sprintf "--%s" "quiet") "bool" " (optional)" "")
-                "Manual:"
-                (sprintf "  %s  %s%s%s" (sprintf "--%s" "level") "int32" "" "")
+                (sprintf "%s:" "Mode")
+                "  exactly one of the following sets of arguments:"
+                "  Auto:"
+                (sprintf "    %s  %s%s%s" (sprintf "--%s" "quiet") "bool" " (optional)" "")
+                "  Manual:"
+                (sprintf "    %s  %s%s%s" (sprintf "--%s" "level") "int32" "" "")
             ]
             |> String.concat "\n"
 
@@ -1997,17 +1998,227 @@ namespace ConsumePlugin
 
 open WoofWare.Myriad.Plugins
 
+/// Methods to parse arguments for the type WithModeHelpArgs
+[<RequireQualifiedAccess ; CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+module WithModeHelpArgs =
+    let parse' (getEnvironmentVariable : string -> string option) (args : string list) : WithModeHelpArgs =
+        let helpText () =
+            [
+                (sprintf "%s  %s%s%s" (sprintf "--%s" "verbose") "bool" "" "")
+                (sprintf "%s: %s" "Mode" ("How loud to be"))
+                "  exactly one of the following sets of arguments:"
+                "  Auto:"
+                (sprintf "    %s  %s%s%s" (sprintf "--%s" "quiet") "bool" " (optional)" "")
+                "  Manual:"
+                (sprintf "    %s  %s%s%s" (sprintf "--%s" "level") "int32" "" "")
+            ]
+            |> String.concat "\n"
+
+        let parser_LeftoverArgs : string ResizeArray = ResizeArray ()
+        let mutable arg_0 : bool option = None
+        let mutable arg_2 : bool option = None
+        let mutable arg_3 : int option = None
+
+        let parser_schema : ArgParserRuntime_DuArgs.ErasedSchema =
+            {
+                Leaves =
+                    [
+                        {
+                            Id = 0
+                            Forms = [ "verbose" ]
+                            AcceptsNegation = false
+                            Arity = ArgParserRuntime_DuArgs.ErasedArity.BoolLike
+                            Repeatable = false
+                            Requirement = ArgParserRuntime_DuArgs.ErasedRequirement.Required
+                            TypeDescription = ""
+                            Help = None
+                        }
+
+                        {
+                            Id = 1
+                            Forms = [ "quiet" ]
+                            AcceptsNegation = false
+                            Arity = ArgParserRuntime_DuArgs.ErasedArity.BoolLike
+                            Repeatable = false
+                            Requirement = ArgParserRuntime_DuArgs.ErasedRequirement.Optional
+                            TypeDescription = ""
+                            Help = None
+                        }
+                        {
+                            Id = 2
+                            Forms = [ "level" ]
+                            AcceptsNegation = false
+                            Arity = ArgParserRuntime_DuArgs.ErasedArity.One
+                            Repeatable = false
+                            Requirement = ArgParserRuntime_DuArgs.ErasedRequirement.Required
+                            TypeDescription = ""
+                            Help = None
+                        }
+                    ]
+                Tree =
+                    (ArgParserRuntime_DuArgs.ErasedTree.Product (
+                        [
+                            ArgParserRuntime_DuArgs.ErasedTree.Leaf 0
+                            ArgParserRuntime_DuArgs.ErasedTree.Sum (
+                                (1,
+                                 [
+                                     ("Auto",
+                                      ArgParserRuntime_DuArgs.ErasedTree.Product (
+                                          [ ArgParserRuntime_DuArgs.ErasedTree.Leaf 1 ]
+                                      ))
+                                     ("Manual",
+                                      ArgParserRuntime_DuArgs.ErasedTree.Product (
+                                          [ ArgParserRuntime_DuArgs.ErasedTree.Leaf 2 ]
+                                      ))
+                                 ])
+                            )
+                        ]
+                    ))
+                Positionals = List.empty
+            }
+
+        let parser_storeOccurrence (occurrence : ArgParserRuntime_DuArgs.ErasedOccurrence) : string option =
+            match occurrence.LeafId with
+            | 0 ->
+                match arg_0 with
+                | Some _ -> None
+                | None ->
+                    match occurrence.Value with
+                    | Some value ->
+                        try
+                            let parsedBool = System.Boolean.Parse value
+                            let parsedBool = if occurrence.Negated then not parsedBool else parsedBool
+                            arg_0 <- Some (parsedBool)
+                            None
+                        with _ as exc ->
+                            (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                    | None ->
+                        arg_0 <- Some ((if occurrence.Negated then false else true))
+                        None
+            | 1 ->
+                match arg_2 with
+                | Some _ -> None
+                | None ->
+                    match occurrence.Value with
+                    | Some value ->
+                        try
+                            let parsedBool = System.Boolean.Parse value
+                            let parsedBool = if occurrence.Negated then not parsedBool else parsedBool
+                            arg_2 <- Some (parsedBool)
+                            None
+                        with _ as exc ->
+                            (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                    | None ->
+                        arg_2 <- Some ((if occurrence.Negated then false else true))
+                        None
+            | 2 ->
+                match arg_3 with
+                | Some _ -> None
+                | None ->
+                    match occurrence.Value with
+                    | Some value ->
+                        try
+                            arg_3 <- Some (value |> (fun x -> System.Int32.Parse x))
+                            None
+                        with _ as exc ->
+                            (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                    | None ->
+                        failwith
+                            "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
+            | _ -> failwith "WoofWare.Myriad internal error in generated parser: unknown argument id"
+
+        let parser_storePositional (positionalId : int) (value : string) (afterSeparator : bool) : string option =
+            failwith "WoofWare.Myriad internal error in generated parser: no positional sink exists"
+
+        let parser_renderStored (leafId : int) : string =
+            match leafId with
+            | 0 ->
+                match arg_0 with
+                | Some x -> x.ToString ()
+                | None -> "<no value>"
+            | 1 ->
+                match arg_2 with
+                | Some x -> x.ToString ()
+                | None -> "<no value>"
+            | 2 ->
+                match arg_3 with
+                | Some x -> x.ToString ()
+                | None -> "<no value>"
+            | _ -> "<no value>"
+
+        let parser_applyDefault (leafId : int) : string option =
+            match leafId with
+            | _ -> failwith "WoofWare.Myriad internal error in generated parser: unknown defaulted argument id"
+
+        let parser_callbacks : ArgParserRuntime_DuArgs.TypedCallbacks =
+            {
+                StoreOccurrence = parser_storeOccurrence
+                StorePositional = parser_storePositional
+                HelpText = helpText
+                RenderStored = parser_renderStored
+                ApplyDefault = parser_applyDefault
+            }
+
+        match
+            ArgParserRuntime_DuArgs.runParse
+                (ArgParserRuntime_DuArgs.WellFormedSchema.checkOrFail parser_schema)
+                parser_callbacks
+                args
+        with
+        | ArgParserRuntime_DuArgs.ParseOutcome.Success parser_selection ->
+            {
+                Mode =
+                    match Map.tryFind 1 parser_selection.Choices with
+                    | Some 0 ->
+                        Mode.Auto (
+                            {
+                                Quiet = arg_2
+                            }
+                        )
+                    | Some 1 ->
+                        Mode.Manual (
+                            {
+                                Level =
+                                    (match arg_3 with
+                                     | Some x -> x
+                                     | None ->
+                                         failwith
+                                             "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
+                            }
+                        )
+                    | _ ->
+                        failwith
+                            "WoofWare.Myriad internal error in generated parser: no case selected despite a successful parse"
+                Verbose =
+                    (match arg_0 with
+                     | Some x -> x
+                     | None ->
+                         failwith
+                             "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
+            }
+        | ArgParserRuntime_DuArgs.ParseOutcome.HelpRequested -> helpText () |> failwithf "Help text requested.\n%s"
+        | ArgParserRuntime_DuArgs.ParseOutcome.Fatal message -> failwith message
+        | ArgParserRuntime_DuArgs.ParseOutcome.Errors errors ->
+            errors |> String.concat "\n" |> failwithf "Errors during parse!\n%s"
+
+    let parse (args : string list) : WithModeHelpArgs =
+        parse' (System.Environment.GetEnvironmentVariable >> Option.ofObj) args
+namespace ConsumePlugin
+
+open WoofWare.Myriad.Plugins
+
 /// Methods to parse arguments for the type ModeAndPositionals
 [<RequireQualifiedAccess ; CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module ModeAndPositionals =
     let parse' (getEnvironmentVariable : string -> string option) (args : string list) : ModeAndPositionals =
         let helpText () =
             [
-                "exactly one of the following sets of arguments:"
-                "Auto:"
-                (sprintf "  %s  %s%s%s" (sprintf "--%s" "quiet") "bool" " (optional)" "")
-                "Manual:"
-                (sprintf "  %s  %s%s%s" (sprintf "--%s" "level") "int32" "" "")
+                (sprintf "%s:" "Mode")
+                "  exactly one of the following sets of arguments:"
+                "  Auto:"
+                (sprintf "    %s  %s%s%s" (sprintf "--%s" "quiet") "bool" " (optional)" "")
+                "  Manual:"
+                (sprintf "    %s  %s%s%s" (sprintf "--%s" "level") "int32" "" "")
                 (sprintf "%s  %s%s%s" (sprintf "--%s" "rest") "int32" " (positional args) (can be repeated)" "")
             ]
             |> String.concat "\n"
@@ -2190,12 +2401,13 @@ module CommandAndPositionals =
     let parse' (getEnvironmentVariable : string -> string option) (args : string list) : CommandAndPositionals =
         let helpText () =
             [
-                "exactly one of the following sets of arguments:"
-                "Fetch:"
-                (sprintf "  %s  %s%s%s" (sprintf "--%s" "url") "string" "" "")
-                "Push:"
-                (sprintf "  %s  %s%s%s" (sprintf "--%s" "remote") "string" "" "")
-                (sprintf "  %s  %s%s%s" (sprintf "--%s" "force") "bool" "" "")
+                (sprintf "%s:" "Command")
+                "  exactly one of the following sets of arguments:"
+                "  Fetch:"
+                (sprintf "    %s  %s%s%s" (sprintf "--%s" "url") "string" "" "")
+                "  Push:"
+                (sprintf "    %s  %s%s%s" (sprintf "--%s" "remote") "string" "" "")
+                (sprintf "    %s  %s%s%s" (sprintf "--%s" "force") "bool" "" "")
                 (sprintf "%s  %s%s%s" (sprintf "--%s" "paths") "string" " (positional args) (can be repeated)" "")
             ]
             |> String.concat "\n"

--- a/ConsumePlugin/GeneratedPrefixArgs.fs
+++ b/ConsumePlugin/GeneratedPrefixArgs.fs
@@ -1425,8 +1425,9 @@ module PrefixedParentArgParse =
         static member parse' (getEnvironmentVariable : string -> string option) (args : string list) : PrefixedParent =
             let helpText () =
                 [
-                    (sprintf "%s  %s%s%s" (sprintf "--%s" "foo-thing1") "int32" "" "")
-                    (sprintf "%s  %s%s%s" (sprintf "--%s" "foo-thing2") "string" "" "")
+                    (sprintf "%s:" "Child")
+                    (sprintf "  %s  %s%s%s" (sprintf "--%s" "foo-thing1") "int32" "" "")
+                    (sprintf "  %s  %s%s%s" (sprintf "--%s" "foo-thing2") "string" "" "")
                     (sprintf "%s  %s%s%s" (sprintf "--%s" "and-another") "bool" "" "")
                 ]
                 |> String.concat "\n"
@@ -1618,10 +1619,12 @@ module TransferArgParse =
         static member parse' (getEnvironmentVariable : string -> string option) (args : string list) : Transfer =
             let helpText () =
                 [
-                    (sprintf "%s  %s%s%s" (sprintf "--%s" "src-host") "string" "" "")
-                    (sprintf "%s  %s%s%s" (sprintf "--%s" "src-port") "int32" "" "")
-                    (sprintf "%s  %s%s%s" (sprintf "--%s" "dst-host") "string" "" "")
-                    (sprintf "%s  %s%s%s" (sprintf "--%s" "dst-port") "int32" "" "")
+                    (sprintf "%s:" "Source")
+                    (sprintf "  %s  %s%s%s" (sprintf "--%s" "src-host") "string" "" "")
+                    (sprintf "  %s  %s%s%s" (sprintf "--%s" "src-port") "int32" "" "")
+                    (sprintf "%s:" "Dest")
+                    (sprintf "  %s  %s%s%s" (sprintf "--%s" "dst-host") "string" "" "")
+                    (sprintf "  %s  %s%s%s" (sprintf "--%s" "dst-port") "int32" "" "")
                 ]
                 |> String.concat "\n"
 
@@ -1854,8 +1857,10 @@ module PrefixedNestedArgParse =
         static member parse' (getEnvironmentVariable : string -> string option) (args : string list) : PrefixedNested =
             let helpText () =
                 [
-                    (sprintf "%s  %s%s%s" (sprintf "--%s" "outer-inner-leaf") "int32" "" "")
-                    (sprintf "%s  %s%s%s" (sprintf "--%s" "outer-sibling") "int32" "" "")
+                    (sprintf "%s:" "Middle")
+                    (sprintf "%s:" "  Grandchild")
+                    (sprintf "    %s  %s%s%s" (sprintf "--%s" "outer-inner-leaf") "int32" "" "")
+                    (sprintf "  %s  %s%s%s" (sprintf "--%s" "outer-sibling") "int32" "" "")
                 ]
                 |> String.concat "\n"
 
@@ -2015,7 +2020,10 @@ module PrefixedFlattenedArgParse =
             : PrefixedFlattened
             =
             let helpText () =
-                [ (sprintf "%s  %s%s%s" (sprintf "--%s" "outer-inner-leaf") "int32" "" "") ]
+                [
+                    (sprintf "%s:" "Grandchild")
+                    (sprintf "  %s  %s%s%s" (sprintf "--%s" "outer-inner-leaf") "int32" "" "")
+                ]
                 |> String.concat "\n"
 
             let parser_LeftoverArgs : string ResizeArray = ResizeArray ()
@@ -2132,8 +2140,10 @@ module PrefixedThroughUnprefixedArgParse =
             =
             let helpText () =
                 [
-                    (sprintf "%s  %s%s%s" (sprintf "--%s" "outer-leaf") "int32" "" "")
-                    (sprintf "%s  %s%s%s" (sprintf "--%s" "outer-sibling") "int32" "" "")
+                    (sprintf "%s:" "Middle")
+                    (sprintf "%s:" "  Grandchild")
+                    (sprintf "    %s  %s%s%s" (sprintf "--%s" "outer-leaf") "int32" "" "")
+                    (sprintf "  %s  %s%s%s" (sprintf "--%s" "outer-sibling") "int32" "" "")
                 ]
                 |> String.concat "\n"
 
@@ -2294,7 +2304,8 @@ module PrefixedAwkwardSpellingArgParse =
             =
             let helpText () =
                 [
-                    (sprintf "%s  %s%s%s" (sprintf "--%s" "aw\\newline-back\\tab") "int32" "" "")
+                    (sprintf "%s:" "Child")
+                    (sprintf "  %s  %s%s%s" (sprintf "--%s" "aw\\newline-back\\tab") "int32" "" "")
                 ]
                 |> String.concat "\n"
 
@@ -2412,7 +2423,8 @@ module PrefixedViaLiteralArgParse =
             =
             let helpText () =
                 [
-                    (sprintf "%s  %s%s%s" (sprintf "--%s" "viaesc\\tab-" + (ViaLiteral)) "int32" "" "")
+                    (sprintf "%s:" "Child")
+                    (sprintf "  %s  %s%s%s" (sprintf "--%s" "viaesc\\tab-" + (ViaLiteral)) "int32" "" "")
                 ]
                 |> String.concat "\n"
 
@@ -2530,7 +2542,8 @@ module PrefixedLongFormsArgParse =
             =
             let helpText () =
                 [
-                    (sprintf "%s  %s%s%s" (sprintf "--%s / --%s" "pre-renamed" "pre-r") "int32" "" "")
+                    (sprintf "%s:" "Child")
+                    (sprintf "  %s  %s%s%s" (sprintf "--%s / --%s" "pre-renamed" "pre-r") "int32" "" "")
                 ]
                 |> String.concat "\n"
 
@@ -2648,8 +2661,9 @@ module PrefixedNegationArgParse =
             =
             let helpText () =
                 [
+                    (sprintf "%s:" "Child")
                     (sprintf
-                        "%s  %s%s%s"
+                        "  %s  %s%s%s"
                         (sprintf "--%s / --no-%s" "flags-enable-feature" "flags-enable-feature")
                         "bool"
                         ""
@@ -2773,8 +2787,14 @@ module PrefixedPositionalsArgParse =
             =
             let helpText () =
                 [
-                    (sprintf "%s  %s%s%s" (sprintf "--%s" "pos-thing1") "int32" "" "")
-                    (sprintf "%s  %s%s%s" (sprintf "--%s" "pos-rest") "string" " (positional args) (can be repeated)" "")
+                    (sprintf "%s:" "Child")
+                    (sprintf "  %s  %s%s%s" (sprintf "--%s" "pos-thing1") "int32" "" "")
+                    (sprintf
+                        "  %s  %s%s%s"
+                        (sprintf "--%s" "pos-rest")
+                        "string"
+                        " (positional args) (can be repeated)"
+                        "")
                 ]
                 |> String.concat "\n"
 
@@ -2908,8 +2928,9 @@ module PrefixedMapArgParse =
         static member parse' (getEnvironmentVariable : string -> string option) (args : string list) : PrefixedMap =
             let helpText () =
                 [
+                    (sprintf "%s:" "Child")
                     (sprintf
-                        "%s  %s%s%s"
+                        "  %s  %s%s%s"
                         (sprintf "--%s" "m-entries")
                         "map<string, string>"
                         " (KEY:VALUE[,KEY:VALUE...]; can be repeated)"
@@ -3056,11 +3077,12 @@ module PrefixedUnionArgParse =
         static member parse' (getEnvironmentVariable : string -> string option) (args : string list) : PrefixedUnion =
             let helpText () =
                 [
-                    "exactly one of the following sets of arguments:"
-                    "Auto:"
-                    (sprintf "  %s  %s%s%s" (sprintf "--%s" "mode-quiet") "bool" " (optional)" "")
-                    "Manual:"
-                    (sprintf "  %s  %s%s%s" (sprintf "--%s" "mode-level") "int32" "" "")
+                    (sprintf "%s:" "Mode")
+                    "  exactly one of the following sets of arguments:"
+                    "  Auto:"
+                    (sprintf "    %s  %s%s%s" (sprintf "--%s" "mode-quiet") "bool" " (optional)" "")
+                    "  Manual:"
+                    (sprintf "    %s  %s%s%s" (sprintf "--%s" "mode-level") "int32" "" "")
                 ]
                 |> String.concat "\n"
 

--- a/README.md
+++ b/README.md
@@ -346,6 +346,31 @@ That question is put to `OrdinalIgnoreCase` itself rather than answered from `To
 If `--help` appears in a position where the parser is expecting a key (e.g. in the first position, or after a `--foo=bar`), the parser fails with help text.
 The parser also makes a limited effort to supply help text when encountering an invalid parse.
 
+A field whose type is another argument record, or a union of alternative argument sets, contributes a whole group of arguments rather than one.
+Those arguments are listed under a header line naming the field, so that you can see which arguments were declared together; `[<ArgumentHelpText>]` on such a field describes the group, and appears on that header line.
+
+```fsharp
+type ChildRecord = { Thing1 : int ; Thing2 : string }
+
+[<ArgParser>]
+type Parent =
+    {
+        [<ArgumentHelpText "Settings for the child thing">]
+        Child : ChildRecord
+        AndAnother : bool
+    }
+```
+
+```
+Child: Settings for the child thing
+  --thing1  int32
+  --thing2  string
+--and-another  bool
+```
+
+The header is presentation only: a nested record's arguments live in the same flat namespace as their parent's, so you still type `--thing1`, not `--child-thing1`.
+Use `[<ArgumentPrefix>]` if you want the nesting reflected in the spellings too.
+
 ### Composition
 
 Records compose: if your record contains other records which are visible to the source generator (that is, they're in the same file as the main args type), the fields of *those* records will also be included in the command line, as if you'd specified them inline in the top-level record.

--- a/WoofWare.Myriad.Plugins.Attributes/ArgParserAttributes.fs
+++ b/WoofWare.Myriad.Plugins.Attributes/ArgParserAttributes.fs
@@ -85,8 +85,16 @@ type ArgumentDefaultValueAttribute (defaultValue : obj) =
 
 /// Attribute indicating that this field or type shall have the given help text, when `--help` is invoked
 /// or when a parse error causes us to print help text.
-/// When applied to a record type, the help text appears at the top of the help output, before the field descriptions.
-/// When applied to a field, the help text appears next to that field's description.
+///
+/// When applied to the [<ArgParser>]-tagged type, the help text appears at the top of the help output,
+/// before the field descriptions.
+///
+/// When applied to a leaf field, the help text appears next to that field's description.
+///
+/// When applied to a field whose type is another argument record, or a discriminated union of
+/// alternative argument sets, the help text describes the whole group of arguments that field
+/// contributes: it appears on the header line which introduces that group, above the indented list
+/// of the arguments themselves. (That header is written whether or not you supply any help text.)
 type ArgumentHelpTextAttribute (helpText : string) =
     inherit Attribute ()
 

--- a/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParser.fs
+++ b/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParser.fs
@@ -458,9 +458,28 @@ Required argument '--exact' received no value"""
         exc.Message
         |> shouldEqual
             """Help text requested.
---thing1  int32
---thing2  string
+Child:
+  --thing1  int32
+  --thing2  string
 --and-another  bool (positional args) (can be repeated)"""
+
+    [<Test>]
+    let ``Help text for a nested record is headed by the field's help text`` () =
+        let getEnvVar (_ : string) = failwith "should not call"
+
+        let exc =
+            Assert.Throws<exn> (fun () ->
+                ParentRecordWithGroupHelp.parse' getEnvVar [ "--help" ]
+                |> ignore<ParentRecordWithGroupHelp>
+            )
+
+        exc.Message
+        |> shouldEqual
+            """Help text requested.
+Child: Settings for the child thing
+  --thing1  int32
+  --thing2  string
+--and-another  bool : Whether to and-another"""
 
     [<Test>]
     let ``Positionals are tagged with Choice`` () =

--- a/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParserDu.fs
+++ b/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParserDu.fs
@@ -179,8 +179,25 @@ BarCase:
         |> shouldEqual
             """Help text requested.
 --verbose  bool
-exactly one of the following sets of arguments:
-Auto:
-  --quiet  bool (optional)
-Manual:
-  --level  int32"""
+Mode:
+  exactly one of the following sets of arguments:
+  Auto:
+    --quiet  bool (optional)
+  Manual:
+    --level  int32"""
+
+    [<Test>]
+    let ``Help text for a union-typed field is headed by the field's help text`` () =
+        let exc =
+            Assert.Throws<exn> (fun () -> WithModeHelpArgs.parse' noEnv [ "--help" ] |> ignore<WithModeHelpArgs>)
+
+        exc.Message
+        |> shouldEqual
+            """Help text requested.
+--verbose  bool
+Mode: How loud to be
+  exactly one of the following sets of arguments:
+  Auto:
+    --quiet  bool (optional)
+  Manual:
+    --level  int32"""

--- a/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParserDuPositional.fs
+++ b/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParserDuPositional.fs
@@ -129,11 +129,12 @@ No arguments were supplied to select one of: Fetch, Push"""
         exc.Message
         |> shouldEqual
             """Help text requested.
-exactly one of the following sets of arguments:
-Auto:
-  --quiet  bool (optional)
-Manual:
-  --level  int32
+Mode:
+  exactly one of the following sets of arguments:
+  Auto:
+    --quiet  bool (optional)
+  Manual:
+    --level  int32
 --rest  int32 (positional args) (can be repeated)"""
 
     [<Test>]

--- a/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParserPrefix.fs
+++ b/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParserPrefix.fs
@@ -274,8 +274,9 @@ module TestArgParserPrefix =
         exc.Message
         |> shouldEqual
             """Help text requested.
---foo-thing1  int32
---foo-thing2  string
+Child:
+  --foo-thing1  int32
+  --foo-thing2  string
 --and-another  bool"""
 
     [<Test>]

--- a/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
+++ b/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
@@ -216,12 +216,34 @@ type private ChoicePositional =
 type private ParseFunctionPositional = ParseFunction<ChoicePositional>
 type private ParseFunctionNonPositional = ParseFunction<Accumulation<ArgumentDefaultSpec>>
 
+/// How a structural field's arguments are introduced in help text: the header line under which
+/// the whole subtree is listed.
+///
+/// This is presentation only. A nested record's arguments live in the same flat namespace as its
+/// parent's, so the header describes which arguments were declared together rather than any
+/// spelling the user must type -- exactly as a union's case names already do.
+type private GroupHeader =
+    {
+        /// The nesting field's name, exactly as declared. This is a label rather than a spelling
+        /// the user types, so it is not argified: a union's case names already head their groups
+        /// verbatim, and the two kinds of group sit in the same help output.
+        Label : string
+        /// `[<ArgumentHelpText>]` on the nesting field, falling back to the same attribute on the
+        /// nested type's own definition.
+        Help : SynExpr option
+    }
+
 /// The parse tree mirroring the schema's shape: named-argument leaves, positional-stream
 /// leaves, products (records) and exclusive sums (unions of alternative argument sets).
 /// Build Branch nodes only through ParseTree.branch, which enforces the positional-capacity
 /// rule (argv holds a single positional stream, so at most one field chain of a record may
 /// claim positional args) and keeps the positional-claiming field after its siblings, which
 /// is where the positional args have always appeared in help text and in the erased schema.
+///
+/// `header` on a Branch or a Sum is the help-text group this node introduces. It is `Some` exactly
+/// when the node was reached through a field of a parent record, and `None` at the root (whose
+/// arguments are the top level, so there is nothing to introduce) and on a union case's payload
+/// record (whose header is the case name, which the Sum above it already emits).
 [<RequireQualifiedAccess>]
 type private ParseTree =
     | NonPositionalLeaf of ParseFunctionNonPositional
@@ -229,12 +251,19 @@ type private ParseTree =
     /// `assemble` takes the SynExpr's (e.g. each record field contents) corresponding to each
     /// `Ident` in the branch (e.g. each record field name), and composes them into a `SynExpr`
     /// (e.g. the record-typed object).
-    | Branch of fields : (Ident * ParseTree) list * assemble : (Map<string, SynExpr> -> SynExpr)
+    | Branch of
+        header : GroupHeader option *
+        fields : (Ident * ParseTree) list *
+        assemble : (Map<string, SynExpr> -> SynExpr)
     /// A discriminated-union arg: at runtime, exactly one case is selected by the arguments
     /// which were supplied. `sumId` ties this node to the erased schema's Sum node; `assemble`
     /// builds the union value from the selected case's name and its assembled payload.
     /// Positional args are not yet permitted inside union cases.
-    | Sum of sumId : int * cases : (Ident * ParseTree) list * assemble : (Ident -> SynExpr -> SynExpr)
+    | Sum of
+        sumId : int *
+        header : GroupHeader option *
+        cases : (Ident * ParseTree) list *
+        assemble : (Ident -> SynExpr -> SynExpr)
 
 [<RequireQualifiedAccess>]
 module private ParseTree =
@@ -244,18 +273,23 @@ module private ParseTree =
         match tree with
         | ParseTree.NonPositionalLeaf _ -> false
         | ParseTree.PositionalLeaf _ -> true
-        | ParseTree.Branch (fields, _) -> fields |> List.exists (fun (_, child) -> containsPositional child)
-        | ParseTree.Sum (_, cases, _) -> cases |> List.exists (fun (_, case) -> containsPositional case)
+        | ParseTree.Branch (_, fields, _) -> fields |> List.exists (fun (_, child) -> containsPositional child)
+        | ParseTree.Sum (_, _, cases, _) -> cases |> List.exists (fun (_, case) -> containsPositional case)
 
     /// The `Ident` here is the field name. Moves the positional-claiming field (at most one
     /// is permitted) after its siblings.
-    let branch (assemble : Map<string, SynExpr> -> SynExpr) (subs : (Ident * ParseTree) list) : ParseTree =
+    let branch
+        (header : GroupHeader option)
+        (assemble : Map<string, SynExpr> -> SynExpr)
+        (subs : (Ident * ParseTree) list)
+        : ParseTree
+        =
         let nonPos, pos =
             subs |> List.partition (fun (_, tree) -> not (containsPositional tree))
 
         match pos with
         | []
-        | [ _ ] -> ParseTree.Branch (nonPos @ pos, assemble)
+        | [ _ ] -> ParseTree.Branch (header, nonPos @ pos, assemble)
         | (first, _) :: (second, _) :: _ ->
             failwith $"Multiple entries tried to claim positional args! %s{first.idText} and %s{second.idText}"
 
@@ -267,13 +301,13 @@ module private ParseTree =
             match tree with
             | ParseTree.NonPositionalLeaf pf -> [ pf ], []
             | ParseTree.PositionalLeaf pf -> [], [ pf ]
-            | ParseTree.Branch (fields, _) ->
+            | ParseTree.Branch (_, fields, _) ->
                 (([], []), fields)
                 ||> List.fold (fun (nonPos, pos) (_, child) ->
                     let childNonPos, childPos = go child
                     nonPos @ childNonPos, pos @ childPos
                 )
-            | ParseTree.Sum (_, cases, _) ->
+            | ParseTree.Sum (_, _, cases, _) ->
                 (([], []), cases)
                 ||> List.fold (fun (nonPos, pos) (_, case) ->
                     let caseNonPos, casePos = go case
@@ -430,7 +464,7 @@ module private ParseTree =
         | ParseTree.NonPositionalLeaf _
         | ParseTree.PositionalLeaf _ -> false
         | ParseTree.Sum _ -> true
-        | ParseTree.Branch (fields, _) -> fields |> List.exists (fun (_, child) -> containsSum child)
+        | ParseTree.Branch (_, fields, _) -> fields |> List.exists (fun (_, child) -> containsSum child)
 
     /// Can this tree be satisfied by supplying no arguments at all? (Defaulted and optional
     /// leaves need nothing, as do positional args; a union needs nothing iff some case needs
@@ -446,8 +480,8 @@ module private ParseTree =
             // An unsupplied map is empty, exactly as an unsupplied list is.
             | Accumulation.Map _ -> true
         | ParseTree.PositionalLeaf _ -> true
-        | ParseTree.Branch (fields, _) -> fields |> List.forall (fun (_, child) -> emptySatisfiable child)
-        | ParseTree.Sum (_, cases, _) -> cases |> List.exists (fun (_, case) -> emptySatisfiable case)
+        | ParseTree.Branch (_, fields, _) -> fields |> List.forall (fun (_, child) -> emptySatisfiable child)
+        | ParseTree.Sum (_, _, cases, _) -> cases |> List.exists (fun (_, case) -> emptySatisfiable case)
 
     /// For every union node in the tree, at most one case may be satisfiable with no arguments:
     /// were two cases so satisfiable, an empty command line could not choose between them.
@@ -455,8 +489,8 @@ module private ParseTree =
         match tree with
         | ParseTree.NonPositionalLeaf _
         | ParseTree.PositionalLeaf _ -> ()
-        | ParseTree.Branch (fields, _) -> fields |> List.iter (fun (_, child) -> checkSumAmbiguity child)
-        | ParseTree.Sum (_, cases, _) ->
+        | ParseTree.Branch (_, fields, _) -> fields |> List.iter (fun (_, child) -> checkSumAmbiguity child)
+        | ParseTree.Sum (_, _, cases, _) ->
             cases |> List.iter (fun (_, case) -> checkSumAmbiguity case)
 
             match cases |> List.filter (fun (_, case) -> emptySatisfiable case) with
@@ -496,11 +530,11 @@ module private ParseTree =
             posCounter.Value <- posCounter.Value + 1
 
             SynExpr.applyFunction (rt [ "ErasedTree" ; "PositionalLeaf" ]) (SynExpr.CreateConst index)
-        | ParseTree.Branch (fields, _) ->
+        | ParseTree.Branch (_, fields, _) ->
             fields
             |> List.map (fun (_, child) -> toErasedTreeExpr rt listOf counter posCounter child)
             |> product
-        | ParseTree.Sum (sumId, cases, _) ->
+        | ParseTree.Sum (sumId, _, cases, _) ->
             let caseExprs =
                 cases
                 |> List.map (fun (caseName, payload) ->
@@ -553,7 +587,7 @@ module private ParseTree =
             SynExpr.createIdent' pf.TargetVariable
             |> SynExpr.pipeThroughFunction (SynExpr.createLongIdent [ "Seq" ; "toList" ])
             |> SynExpr.paren
-        | ParseTree.Sum (sumId, cases, assemble) ->
+        | ParseTree.Sum (sumId, _, cases, assemble) ->
             let scrutinee =
                 SynExpr.createLongIdent [ "Map" ; "tryFind" ]
                 |> SynExpr.applyTo (SynExpr.CreateConst sumId)
@@ -576,7 +610,7 @@ module private ParseTree =
                             "WoofWare.Myriad internal error in generated parser: no case selected despite a successful parse"))
 
             SynExpr.createMatch scrutinee (clauses @ [ fallthrough ])
-        | ParseTree.Branch (fields, assemble) ->
+        | ParseTree.Branch (_, fields, assemble) ->
             fields
             |> List.map (fun (fieldName, contents) ->
                 let instantiated = instantiate contents
@@ -1367,6 +1401,7 @@ module internal ArgParserGenerator =
     /// and is "" at the root.
     let rec private toParseSpec
         (ancestors : string list)
+        (header : GroupHeader option)
         (prefix : string)
         (counter : int)
         (ambient : AmbientTypes)
@@ -1407,7 +1442,10 @@ module internal ArgParserGenerator =
                         | _ -> None
                     )
 
-                let helpText =
+                // Kept separate from the `helpText` below, which folds in the parse format: a
+                // structural field's help introduces a whole group of arguments rather than
+                // describing one, so it must not pick up a leaf's parsing note.
+                let helpTextAttr =
                     attrs
                     |> List.tryPick (fun a ->
                         match (List.last a.TypeName.LongIdent).idText with
@@ -1417,7 +1455,7 @@ module internal ArgParserGenerator =
                     )
 
                 let helpText =
-                    match parseExactModifier, helpText with
+                    match parseExactModifier, helpTextAttr with
                     | None, ht -> ht
                     | Some pe, None ->
                         SynExpr.createIdent "sprintf"
@@ -1504,6 +1542,16 @@ module internal ArgParserGenerator =
                     | Some target -> ambient.StructuralUnions |> List.tryFind (fun u -> u.Name.idText = target)
                     | None -> None
 
+                // A structural field contributes a whole group of arguments rather than one, so its
+                // help text introduces that group rather than describing a single argument. The
+                // group exists whether or not the author wrote any help: the reader must be able to
+                // see which arguments were declared together, exactly as for a union's cases.
+                let groupHeader =
+                    {
+                        GroupHeader.Label = ident.idText
+                        GroupHeader.Help = helpTextAttr
+                    }
+
                 match ambientRecordMatch with
                 | Some childRecord ->
                     // The structural branches are taken before any leaf machinery runs, so they
@@ -1518,7 +1566,8 @@ module internal ArgParserGenerator =
                         | None -> prefix
                         | Some attrExpr -> extendPrefix ident prefix attrExpr
 
-                    let spec, counter = toParseSpec ancestors childPrefix counter ambient childRecord
+                    let spec, counter =
+                        toParseSpec ancestors (Some groupHeader) childPrefix counter ambient childRecord
 
                     counter, (ident, spec) :: acc
                 | None ->
@@ -1536,7 +1585,8 @@ module internal ArgParserGenerator =
                         | None -> prefix
                         | Some attrExpr -> extendPrefix ident prefix attrExpr
 
-                    let spec, counter = unionToParseSpec ancestors childPrefix counter ambient union
+                    let spec, counter =
+                        unionToParseSpec ancestors (Some groupHeader) childPrefix counter ambient union
 
                     counter, (ident, spec) :: acc
                 | None ->
@@ -1721,12 +1771,14 @@ module internal ArgParserGenerator =
         let tree =
             contents
             |> List.rev
-            |> ParseTree.branch (fun args ->
-                args
-                |> Map.toList
-                |> List.map (fun (ident, expr) -> SynLongIdent.create [ Ident.create ident ], expr)
-                |> SynExpr.createRecord None
-            )
+            |> ParseTree.branch
+                header
+                (fun args ->
+                    args
+                    |> Map.toList
+                    |> List.map (fun (ident, expr) -> SynLongIdent.create [ Ident.create ident ], expr)
+                    |> SynExpr.createRecord None
+                )
 
         tree, counter
 
@@ -1736,6 +1788,7 @@ module internal ArgParserGenerator =
     /// arguments must be supplied at runtime.
     and private unionToParseSpec
         (ancestors : string list)
+        (header : GroupHeader option)
         (prefix : string)
         (counter : int)
         (ambient : AmbientTypes)
@@ -1787,8 +1840,10 @@ module internal ArgParserGenerator =
                             $"Case %s{case.Name.idText} of [<ArgParser>] union %s{union.Name.idText} must have exactly one field: a record holding that case's arguments."
 
                 // A case is an alternative, not a nesting level: the prefix in force passes
-                // through unchanged, so every case's arguments are namespaced identically.
-                let spec, counter = toParseSpec ancestors prefix counter ambient payloadRecord
+                // through unchanged, so every case's arguments are namespaced identically. For
+                // the same reason the payload record introduces no help-text group of its own --
+                // `sumHelp` already heads it with the case name.
+                let spec, counter = toParseSpec ancestors None prefix counter ambient payloadRecord
 
                 counter, (case.Name, spec) :: acc
             )
@@ -1798,7 +1853,7 @@ module internal ArgParserGenerator =
         let assemble (caseName : Ident) (payload : SynExpr) : SynExpr =
             SynExpr.applyFunction (SynExpr.createLongIdent' [ union.Name ; caseName ]) payload
 
-        ParseTree.Sum (sumId, cases, assemble), counter
+        ParseTree.Sum (sumId, header, cases, assemble), counter
 
     let private helpText (typeHelp : SynExpr option) (tree : ParseTree) : SynBinding =
         let describeNonPositional (arg : ParseFunctionNonPositional) : SynExpr =
@@ -1897,18 +1952,61 @@ module internal ArgParserGenerator =
             |> SynExpr.applyTo helpText
             |> SynExpr.paren
 
-        // Walk the tree so that a union's alternatives are *grouped* in the help, not flattened
-        // into one undifferentiated list: the user must be able to see which arguments go
-        // together. Non-positional lines appear in declaration order; the positional-args
-        // line, if any, comes last, as it always has (ParseTree.branch keeps the
-        // positional-claiming field after its siblings, and a sink beside a union is shared
-        // by every alternative, so it stays outside the case groups).
+        /// The line introducing a structural field's group of arguments, e.g. `child:` or
+        /// `child: Database settings`. The help text is a SynExpr rather than a literal (it may be
+        /// any expression the author wrote in the attribute), so the description has to be
+        /// assembled by the generated program rather than spliced here.
+        let groupLine (depth : int) (header : GroupHeader) : SynExpr =
+            let indent = String.replicate depth "  "
+
+            // The label is a field name, which may be a backticked identifier and so may contain
+            // anything at all: it needs escaping on the way into the generated file exactly as an
+            // argument's spelling does. (`indent` is whitespace by construction, so it is safe to
+            // splice.)
+            let label =
+                SynExpr.Const (
+                    SynConst.String (
+                        ArgFormEmission.escapeStringConstant (indent + header.Label),
+                        SynStringKind.Regular,
+                        range0
+                    ),
+                    range0
+                )
+
+            match header.Help with
+            | None ->
+                SynExpr.applyFunction (SynExpr.createIdent "sprintf") (SynExpr.CreateConst "%s:")
+                |> SynExpr.applyTo label
+                |> SynExpr.paren
+            | Some help ->
+                // As in `toPrintable`: the label is user-derived and `%` is legal in a backticked
+                // identifier, so it is passed as an argument rather than spliced into the format.
+                SynExpr.applyFunction (SynExpr.createIdent "sprintf") (SynExpr.CreateConst "%s: %s")
+                |> SynExpr.applyTo label
+                |> SynExpr.applyTo (SynExpr.paren help)
+                |> SynExpr.paren
+
+        // Walk the tree so that a union's alternatives, and a nested record's arguments, are
+        // *grouped* in the help rather than flattened into one undifferentiated list: the user
+        // must be able to see which arguments go together. Non-positional lines appear in
+        // declaration order; the positional-args line, if any, comes last, as it always has
+        // (ParseTree.branch keeps the positional-claiming field after its siblings, and a sink
+        // beside a union is shared by every alternative, so it stays outside the case groups).
         let rec fieldHelp (depth : int) (tree : ParseTree) : SynExpr list =
             match tree with
             | ParseTree.NonPositionalLeaf pf -> [ toPrintable depth describeNonPositional pf ]
             | ParseTree.PositionalLeaf pf -> [ toPrintable depth describePositional pf ]
-            | ParseTree.Branch (fields, _) -> fields |> List.collect (fun (_, child) -> fieldHelp depth child)
-            | ParseTree.Sum (_, cases, _) -> sumHelp depth cases
+            | ParseTree.Branch (header, fields, _) ->
+                let children (depth : int) =
+                    fields |> List.collect (fun (_, child) -> fieldHelp depth child)
+
+                match header with
+                | None -> children depth
+                | Some header -> groupLine depth header :: children (depth + 1)
+            | ParseTree.Sum (_, header, cases, _) ->
+                match header with
+                | None -> sumHelp depth cases
+                | Some header -> groupLine depth header :: sumHelp (depth + 1) cases
 
         and sumHelp (depth : int) (cases : (Ident * ParseTree) list) : SynExpr list =
             let indent = String.replicate depth "  "
@@ -2962,7 +3060,10 @@ module internal ArgParserGenerator =
                                        _) ->
                 let record = RecordType.OfRecord sci smd access fields
 
-                let spec, _ = toParseSpec [] "" 0 ambient record
+                // The root's arguments are the top level of the help text, so there is no enclosing
+                // group for them to be introduced as; its own `[<ArgumentHelpText>]` is the type
+                // help, which `helpText` prints above everything.
+                let spec, _ = toParseSpec [] None "" 0 ambient record
 
                 record.Name, typeHelp attrs, spec
             | SynTypeDefn.SynTypeDefn (SynComponentInfo.SynComponentInfo (attributes = attrs) as sci,
@@ -2979,7 +3080,7 @@ module internal ArgParserGenerator =
                     failwith
                         $"No case of [<ArgParser>] union %s{union.Name.idText} has any data, so it is an enumerated value rather than a set of alternative argument sets: an empty command line could not choose between its cases. Use it as the type of a field of an [<ArgParser>] record instead, where it is supplied as `--field-name=a`."
 
-                let spec, _ = unionToParseSpec [] "" 0 ambient union
+                let spec, _ = unionToParseSpec [] None "" 0 ambient union
 
                 union.Name, typeHelp attrs, spec
             | _ ->

--- a/WoofWare.Myriad.Plugins/version.json
+++ b/WoofWare.Myriad.Plugins/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "10.6",
+  "version": "10.7",
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],


### PR DESCRIPTION
A field whose type is another argument record, or a union of alternative argument sets, contributes a whole *group* of arguments rather than one. Those arguments were flattened into the parent's list, so nothing showed which were declared together; and the `[<ArgumentHelpText>]` which would have described the group was read and then dropped, because the structural branches run before the machinery which consumes it.

```
Child: Settings for the child thing
  --thing1  int32
  --thing2  string
--and-another  bool : Whether to and-another
```

A union-typed field's alternatives now sit inside its group rather than at the top level:

```
--verbose  bool
Mode: How loud to be
  exactly one of the following sets of arguments:
  Auto:
    --quiet  bool (optional)
  Manual:
    --level  int32
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)