### PR TITLE
ArgParser: read ArgumentHelpText from nested records and unions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,10 @@ Notable changes are recorded here.
 # WoofWare.Myriad.Plugins 10.7.2
 
 `ArgParserGenerator` now reads `[<ArgumentHelpText>]` from a nested argument record or union of alternative argument sets, and not only from the `[<ArgParser>]`-tagged root, and from a discriminated union's case (and that case's payload record).
-The nested type's help heads the group of arguments that type contributes, wherever it is embedded, and a case's help heads its group the same way; previously both were silently ignored, despite the attribute documenting itself as applying to a record type generally, and despite a case having no field of its own for the group-header mechanism to attach to.
+The nested type's help heads the group of arguments that type contributes, wherever it is embedded, and a case's help heads its group the same way.
 
 An `[<ArgumentHelpText>]` on the more specific placement overrides the more general one: a field's overrides its nested type's, and a case's overrides its payload record's.
 One type, or one payload record, may be embedded or reused at several sites for different purposes, so the more specific placement is the one which can say what a particular occurrence is for.
-
-The value must be a literal string written out in full (optionally parenthesised): it is reproduced in the generated file rather than evaluated at your attribute, so a name naming a `[<Literal>]` constant is rejected (that file hoists every `open` in your source above the parser, so the name need not resolve to the same binding there as here), and a decoded string constant is re-escaped so that characters such as `\t` or `"` round-trip rather than being reinterpreted.
 
 # WoofWare.Myriad.Plugins 10.7.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 Notable changes are recorded here.
 
-# WoofWare.Myriad.Plugins 10.7.3
-
-`ArgParserGenerator` now reads `[<ArgumentHelpText>]` from a discriminated union's case, and from that case's payload record, and heads the case's group in help text with it.
-Previously a case's payload record's own `[<ArgumentHelpText>]` was silently dropped: only the case name appeared, with no way to describe the case itself (a case is not reached through a field, so the field-level mechanism which reads a nested record's own help text does not apply to it).
-An `[<ArgumentHelpText>]` on the case itself overrides the one on its payload record, for the same reason a field's overrides a nested record's: the case is the more specific placement.
-
 # WoofWare.Myriad.Plugins 10.7.2
 
 `ArgParserGenerator` now reads `[<ArgumentHelpText>]` from a nested argument record or union of alternative argument sets, and not only from the `[<ArgParser>]`-tagged root.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 Notable changes are recorded here.
 
+# WoofWare.Myriad.Plugins 10.7.3
+
+`ArgParserGenerator` now reads `[<ArgumentHelpText>]` from a discriminated union's case, and from that case's payload record, and heads the case's group in help text with it.
+Previously a case's payload record's own `[<ArgumentHelpText>]` was silently dropped: only the case name appeared, with no way to describe the case itself (a case is not reached through a field, so the field-level mechanism which reads a nested record's own help text does not apply to it).
+An `[<ArgumentHelpText>]` on the case itself overrides the one on its payload record, for the same reason a field's overrides a nested record's: the case is the more specific placement.
+
 # WoofWare.Myriad.Plugins 10.7.2
 
 `ArgParserGenerator` now reads `[<ArgumentHelpText>]` from a nested argument record or union of alternative argument sets, and not only from the `[<ArgParser>]`-tagged root.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@ Notable changes are recorded here.
 
 # WoofWare.Myriad.Plugins 10.7.2
 
-`ArgParserGenerator` now reads `[<ArgumentHelpText>]` from a nested argument record or union of alternative argument sets, and not only from the `[<ArgParser>]`-tagged root.
-The nested type's help heads the group of arguments that type contributes, wherever it is embedded; previously it was silently ignored, despite the attribute documenting itself as applying to a record type generally.
+`ArgParserGenerator` now reads `[<ArgumentHelpText>]` from a nested argument record or union of alternative argument sets, and not only from the `[<ArgParser>]`-tagged root, and from a discriminated union's case (and that case's payload record).
+The nested type's help heads the group of arguments that type contributes, wherever it is embedded, and a case's help heads its group the same way; previously both were silently ignored, despite the attribute documenting itself as applying to a record type generally, and despite a case having no field of its own for the group-header mechanism to attach to.
 
-An `[<ArgumentHelpText>]` on the *field* overrides the one on the type it refers to.
-The field is the more specific placement, and one type may be embedded at several sites for different purposes, so that is the one which can say what a particular occurrence is for.
+An `[<ArgumentHelpText>]` on the more specific placement overrides the more general one: a field's overrides its nested type's, and a case's overrides its payload record's.
+One type, or one payload record, may be embedded or reused at several sites for different purposes, so the more specific placement is the one which can say what a particular occurrence is for.
+
+The value must be a literal string written out in full (optionally parenthesised): it is reproduced in the generated file rather than evaluated at your attribute, so a name naming a `[<Literal>]` constant is rejected (that file hoists every `open` in your source above the parser, so the name need not resolve to the same binding there as here), and a decoded string constant is re-escaped so that characters such as `\t` or `"` round-trip rather than being reinterpreted.
 
 # WoofWare.Myriad.Plugins 10.7.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 Notable changes are recorded here.
 
+# WoofWare.Myriad.Plugins 10.7.2
+
+`ArgParserGenerator` now reads `[<ArgumentHelpText>]` from a nested argument record or union of alternative argument sets, and not only from the `[<ArgParser>]`-tagged root.
+The nested type's help heads the group of arguments that type contributes, wherever it is embedded; previously it was silently ignored, despite the attribute documenting itself as applying to a record type generally.
+
+An `[<ArgumentHelpText>]` on the *field* overrides the one on the type it refers to.
+The field is the more specific placement, and one type may be embedded at several sites for different purposes, so that is the one which can say what a particular occurrence is for.
+
 # WoofWare.Myriad.Plugins 10.7.1
 
 `ArgParserGenerator` help text now groups the arguments contributed by a field whose type is another argument record, or a union of alternative argument sets, under a header line naming that field.

--- a/ConsumePlugin/Args.fs
+++ b/ConsumePlugin/Args.fs
@@ -178,6 +178,16 @@ type ParentRecordWithTypeHelp =
         Secondary : DescribedChild
     }
 
+/// Help text may contain characters which need escaping to survive being reproduced in the
+/// generated file: FCS decodes the literal before Myriad ever sees it, so a backslash, a quote,
+/// and a control character must all be re-escaped rather than passed through as the decoded text.
+[<ArgParser true>]
+type ParentRecordWithEscapedHelp =
+    {
+        [<ArgumentHelpText "Path is C:\\temp, quote is \" and tab is \t.">]
+        Child : ChildRecord
+    }
+
 [<ArgParser true>]
 type ChoicePositionals =
     {

--- a/ConsumePlugin/Args.fs
+++ b/ConsumePlugin/Args.fs
@@ -158,6 +158,26 @@ type ParentRecordWithGroupHelp =
         AndAnother : bool
     }
 
+/// A nested type may describe itself, for the benefit of every site which embeds it.
+[<ArgumentHelpText "How to talk to the database">]
+type DescribedChild =
+    {
+        Host : string
+        Port : int
+    }
+
+/// `Primary` takes the type's own description; `Secondary` overrides it, because the field is the
+/// more specific placement and one type may be embedded for different purposes.
+[<ArgParser true>]
+type ParentRecordWithTypeHelp =
+    {
+        [<ArgumentPrefix "primary">]
+        Primary : DescribedChild
+        [<ArgumentPrefix "secondary">]
+        [<ArgumentHelpText "Where to fail over to">]
+        Secondary : DescribedChild
+    }
+
 [<ArgParser true>]
 type ChoicePositionals =
     {

--- a/ConsumePlugin/DuArgs.fs
+++ b/ConsumePlugin/DuArgs.fs
@@ -104,6 +104,27 @@ type WithTransportArgs =
         Fallback : Transport
     }
 
+[<ArgumentHelpText "Fetch a URL">]
+type FetchWithHelpArgs =
+    {
+        Url : string
+    }
+
+[<ArgumentHelpText "Push args, not that you'd know it from the case header">]
+type PushWithHelpArgs =
+    {
+        Remote : string
+    }
+
+/// A case's payload record may describe itself, for the benefit of that case; a case is not
+/// reached through a field, so there is no field-level attribute to check first, but the case
+/// itself is a more specific placement than its payload record and so overrides it, exactly as
+/// a field overrides a nested record's own description.
+[<ArgParser>]
+type CommandWithHelp =
+    | FetchCase of FetchWithHelpArgs
+    | [<ArgumentHelpText "Push to a remote">] PushCase of PushWithHelpArgs
+
 /// A union beside a positional sink (default, i.e. Reject-mode): named arguments select the
 /// union case, and every bare token is routed to the sink whichever case wins. An unrecognised
 /// `--key`-shaped token remains fatal. The sink converts, so selection must not depend on the

--- a/ConsumePlugin/DuArgs.fs
+++ b/ConsumePlugin/DuArgs.fs
@@ -76,6 +76,34 @@ type WithModeHelpArgs =
         Mode : Mode
     }
 
+/// A union of alternative argument sets may describe itself, for the benefit of every field which
+/// embeds it.
+[<ArgumentHelpText "Which transport to use">]
+type Transport =
+    | Tcp of TcpArgs
+    | Unix of UnixArgs
+
+and TcpArgs =
+    {
+        TcpPort : int
+    }
+
+and UnixArgs =
+    {
+        SocketPath : string
+    }
+
+/// `Fallback` takes the union's own description; `Preferred` overrides it from the field.
+[<ArgParser>]
+type WithTransportArgs =
+    {
+        [<ArgumentPrefix "preferred">]
+        [<ArgumentHelpText "Try this one first">]
+        Preferred : Transport
+        [<ArgumentPrefix "fallback">]
+        Fallback : Transport
+    }
+
 /// A union beside a positional sink (default, i.e. Reject-mode): named arguments select the
 /// union case, and every bare token is routed to the sink whichever case wins. An unrecognised
 /// `--key`-shaped token remains fatal. The sink converts, so selection must not depend on the

--- a/ConsumePlugin/GeneratedArgs.fs
+++ b/ConsumePlugin/GeneratedArgs.fs
@@ -4239,6 +4239,253 @@ open System
 open System.IO
 open WoofWare.Myriad.Plugins
 
+/// Methods to parse arguments for the type ParentRecordWithTypeHelp
+[<AutoOpen>]
+module ParentRecordWithTypeHelpArgParse =
+    /// Extension methods for argument parsing
+    type ParentRecordWithTypeHelp with
+
+        static member parse'
+            (getEnvironmentVariable : string -> string option)
+            (args : string list)
+            : ParentRecordWithTypeHelp
+            =
+            let helpText () =
+                [
+                    (sprintf "%s: %s" "Primary" ("How to talk to the database"))
+                    (sprintf "  %s  %s%s%s" (sprintf "--%s" "primary-host") "string" "" "")
+                    (sprintf "  %s  %s%s%s" (sprintf "--%s" "primary-port") "int32" "" "")
+                    (sprintf "%s: %s" "Secondary" ("Where to fail over to"))
+                    (sprintf "  %s  %s%s%s" (sprintf "--%s" "secondary-host") "string" "" "")
+                    (sprintf "  %s  %s%s%s" (sprintf "--%s" "secondary-port") "int32" "" "")
+                ]
+                |> String.concat "\n"
+
+            let parser_LeftoverArgs : string ResizeArray = ResizeArray ()
+            let mutable arg_0 : string option = None
+            let mutable arg_1 : int option = None
+            let mutable arg_2 : string option = None
+            let mutable arg_3 : int option = None
+
+            let parser_schema : ArgParserRuntime_BasicNoPositionals.ErasedSchema =
+                {
+                    Leaves =
+                        [
+                            {
+                                Id = 0
+                                Forms = [ "primary-host" ]
+                                AcceptsNegation = false
+                                Arity = ArgParserRuntime_BasicNoPositionals.ErasedArity.One
+                                Repeatable = false
+                                Requirement = ArgParserRuntime_BasicNoPositionals.ErasedRequirement.Required
+                                TypeDescription = ""
+                                Help = None
+                            }
+
+                            {
+                                Id = 1
+                                Forms = [ "primary-port" ]
+                                AcceptsNegation = false
+                                Arity = ArgParserRuntime_BasicNoPositionals.ErasedArity.One
+                                Repeatable = false
+                                Requirement = ArgParserRuntime_BasicNoPositionals.ErasedRequirement.Required
+                                TypeDescription = ""
+                                Help = None
+                            }
+
+                            {
+                                Id = 2
+                                Forms = [ "secondary-host" ]
+                                AcceptsNegation = false
+                                Arity = ArgParserRuntime_BasicNoPositionals.ErasedArity.One
+                                Repeatable = false
+                                Requirement = ArgParserRuntime_BasicNoPositionals.ErasedRequirement.Required
+                                TypeDescription = ""
+                                Help = None
+                            }
+                            {
+                                Id = 3
+                                Forms = [ "secondary-port" ]
+                                AcceptsNegation = false
+                                Arity = ArgParserRuntime_BasicNoPositionals.ErasedArity.One
+                                Repeatable = false
+                                Requirement = ArgParserRuntime_BasicNoPositionals.ErasedRequirement.Required
+                                TypeDescription = ""
+                                Help = None
+                            }
+                        ]
+                    Tree =
+                        (ArgParserRuntime_BasicNoPositionals.ErasedTree.Product (
+                            [
+                                ArgParserRuntime_BasicNoPositionals.ErasedTree.Product (
+                                    [
+                                        ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 0
+                                        ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 1
+                                    ]
+                                )
+                                ArgParserRuntime_BasicNoPositionals.ErasedTree.Product (
+                                    [
+                                        ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 2
+                                        ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 3
+                                    ]
+                                )
+                            ]
+                        ))
+                    Positionals = List.empty
+                }
+
+            let parser_storeOccurrence
+                (occurrence : ArgParserRuntime_BasicNoPositionals.ErasedOccurrence)
+                : string option
+                =
+                match occurrence.LeafId with
+                | 0 ->
+                    match arg_0 with
+                    | Some _ -> None
+                    | None ->
+                        match occurrence.Value with
+                        | Some value ->
+                            try
+                                arg_0 <- Some (value |> (fun x -> x))
+                                None
+                            with _ as exc ->
+                                (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                        | None ->
+                            failwith
+                                "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
+                | 1 ->
+                    match arg_1 with
+                    | Some _ -> None
+                    | None ->
+                        match occurrence.Value with
+                        | Some value ->
+                            try
+                                arg_1 <- Some (value |> (fun x -> System.Int32.Parse x))
+                                None
+                            with _ as exc ->
+                                (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                        | None ->
+                            failwith
+                                "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
+                | 2 ->
+                    match arg_2 with
+                    | Some _ -> None
+                    | None ->
+                        match occurrence.Value with
+                        | Some value ->
+                            try
+                                arg_2 <- Some (value |> (fun x -> x))
+                                None
+                            with _ as exc ->
+                                (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                        | None ->
+                            failwith
+                                "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
+                | 3 ->
+                    match arg_3 with
+                    | Some _ -> None
+                    | None ->
+                        match occurrence.Value with
+                        | Some value ->
+                            try
+                                arg_3 <- Some (value |> (fun x -> System.Int32.Parse x))
+                                None
+                            with _ as exc ->
+                                (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                        | None ->
+                            failwith
+                                "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
+                | _ -> failwith "WoofWare.Myriad internal error in generated parser: unknown argument id"
+
+            let parser_storePositional (positionalId : int) (value : string) (afterSeparator : bool) : string option =
+                failwith "WoofWare.Myriad internal error in generated parser: no positional sink exists"
+
+            let parser_renderStored (leafId : int) : string =
+                match leafId with
+                | 0 ->
+                    match arg_0 with
+                    | Some x -> x.ToString ()
+                    | None -> "<no value>"
+                | 1 ->
+                    match arg_1 with
+                    | Some x -> x.ToString ()
+                    | None -> "<no value>"
+                | 2 ->
+                    match arg_2 with
+                    | Some x -> x.ToString ()
+                    | None -> "<no value>"
+                | 3 ->
+                    match arg_3 with
+                    | Some x -> x.ToString ()
+                    | None -> "<no value>"
+                | _ -> "<no value>"
+
+            let parser_applyDefault (leafId : int) : string option =
+                match leafId with
+                | _ -> failwith "WoofWare.Myriad internal error in generated parser: unknown defaulted argument id"
+
+            let parser_callbacks : ArgParserRuntime_BasicNoPositionals.TypedCallbacks =
+                {
+                    StoreOccurrence = parser_storeOccurrence
+                    StorePositional = parser_storePositional
+                    HelpText = helpText
+                    RenderStored = parser_renderStored
+                    ApplyDefault = parser_applyDefault
+                }
+
+            match
+                ArgParserRuntime_BasicNoPositionals.runParse
+                    (ArgParserRuntime_BasicNoPositionals.WellFormedSchema.checkOrFail parser_schema)
+                    parser_callbacks
+                    args
+            with
+            | ArgParserRuntime_BasicNoPositionals.ParseOutcome.Success parser_selection ->
+                {
+                    Primary =
+                        {
+                            Host =
+                                (match arg_0 with
+                                 | Some x -> x
+                                 | None ->
+                                     failwith
+                                         "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
+                            Port =
+                                (match arg_1 with
+                                 | Some x -> x
+                                 | None ->
+                                     failwith
+                                         "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
+                        }
+                    Secondary =
+                        {
+                            Host =
+                                (match arg_2 with
+                                 | Some x -> x
+                                 | None ->
+                                     failwith
+                                         "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
+                            Port =
+                                (match arg_3 with
+                                 | Some x -> x
+                                 | None ->
+                                     failwith
+                                         "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
+                        }
+                }
+            | ArgParserRuntime_BasicNoPositionals.ParseOutcome.HelpRequested ->
+                helpText () |> failwithf "Help text requested.\n%s"
+            | ArgParserRuntime_BasicNoPositionals.ParseOutcome.Fatal message -> failwith message
+            | ArgParserRuntime_BasicNoPositionals.ParseOutcome.Errors errors ->
+                errors |> String.concat "\n" |> failwithf "Errors during parse!\n%s"
+
+        static member parse (args : string list) : ParentRecordWithTypeHelp =
+            ParentRecordWithTypeHelp.parse' (System.Environment.GetEnvironmentVariable >> Option.ofObj) args
+namespace ConsumePlugin
+
+open System
+open System.IO
+open WoofWare.Myriad.Plugins
+
 /// Methods to parse arguments for the type ChoicePositionals
 [<AutoOpen>]
 module ChoicePositionalsArgParse =

--- a/ConsumePlugin/GeneratedArgs.fs
+++ b/ConsumePlugin/GeneratedArgs.fs
@@ -4486,6 +4486,169 @@ open System
 open System.IO
 open WoofWare.Myriad.Plugins
 
+/// Methods to parse arguments for the type ParentRecordWithEscapedHelp
+[<AutoOpen>]
+module ParentRecordWithEscapedHelpArgParse =
+    /// Extension methods for argument parsing
+    type ParentRecordWithEscapedHelp with
+
+        static member parse'
+            (getEnvironmentVariable : string -> string option)
+            (args : string list)
+            : ParentRecordWithEscapedHelp
+            =
+            let helpText () =
+                [
+                    (sprintf "%s: %s" "Child" ("Path is C:\\temp, quote is \u0022 and tab is \u0009."))
+                    (sprintf "  %s  %s%s%s" (sprintf "--%s" "thing1") "int32" "" "")
+                    (sprintf "  %s  %s%s%s" (sprintf "--%s" "thing2") "string" "" "")
+                ]
+                |> String.concat "\n"
+
+            let parser_LeftoverArgs : string ResizeArray = ResizeArray ()
+            let mutable arg_0 : int option = None
+            let mutable arg_1 : string option = None
+
+            let parser_schema : ArgParserRuntime_BasicNoPositionals.ErasedSchema =
+                {
+                    Leaves =
+                        [
+                            {
+                                Id = 0
+                                Forms = [ "thing1" ]
+                                AcceptsNegation = false
+                                Arity = ArgParserRuntime_BasicNoPositionals.ErasedArity.One
+                                Repeatable = false
+                                Requirement = ArgParserRuntime_BasicNoPositionals.ErasedRequirement.Required
+                                TypeDescription = ""
+                                Help = None
+                            }
+                            {
+                                Id = 1
+                                Forms = [ "thing2" ]
+                                AcceptsNegation = false
+                                Arity = ArgParserRuntime_BasicNoPositionals.ErasedArity.One
+                                Repeatable = false
+                                Requirement = ArgParserRuntime_BasicNoPositionals.ErasedRequirement.Required
+                                TypeDescription = ""
+                                Help = None
+                            }
+                        ]
+                    Tree =
+                        (ArgParserRuntime_BasicNoPositionals.ErasedTree.Product (
+                            [
+                                ArgParserRuntime_BasicNoPositionals.ErasedTree.Product (
+                                    [
+                                        ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 0
+                                        ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 1
+                                    ]
+                                )
+                            ]
+                        ))
+                    Positionals = List.empty
+                }
+
+            let parser_storeOccurrence
+                (occurrence : ArgParserRuntime_BasicNoPositionals.ErasedOccurrence)
+                : string option
+                =
+                match occurrence.LeafId with
+                | 0 ->
+                    match arg_0 with
+                    | Some _ -> None
+                    | None ->
+                        match occurrence.Value with
+                        | Some value ->
+                            try
+                                arg_0 <- Some (value |> (fun x -> System.Int32.Parse x))
+                                None
+                            with _ as exc ->
+                                (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                        | None ->
+                            failwith
+                                "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
+                | 1 ->
+                    match arg_1 with
+                    | Some _ -> None
+                    | None ->
+                        match occurrence.Value with
+                        | Some value ->
+                            try
+                                arg_1 <- Some (value |> (fun x -> x))
+                                None
+                            with _ as exc ->
+                                (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                        | None ->
+                            failwith
+                                "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
+                | _ -> failwith "WoofWare.Myriad internal error in generated parser: unknown argument id"
+
+            let parser_storePositional (positionalId : int) (value : string) (afterSeparator : bool) : string option =
+                failwith "WoofWare.Myriad internal error in generated parser: no positional sink exists"
+
+            let parser_renderStored (leafId : int) : string =
+                match leafId with
+                | 0 ->
+                    match arg_0 with
+                    | Some x -> x.ToString ()
+                    | None -> "<no value>"
+                | 1 ->
+                    match arg_1 with
+                    | Some x -> x.ToString ()
+                    | None -> "<no value>"
+                | _ -> "<no value>"
+
+            let parser_applyDefault (leafId : int) : string option =
+                match leafId with
+                | _ -> failwith "WoofWare.Myriad internal error in generated parser: unknown defaulted argument id"
+
+            let parser_callbacks : ArgParserRuntime_BasicNoPositionals.TypedCallbacks =
+                {
+                    StoreOccurrence = parser_storeOccurrence
+                    StorePositional = parser_storePositional
+                    HelpText = helpText
+                    RenderStored = parser_renderStored
+                    ApplyDefault = parser_applyDefault
+                }
+
+            match
+                ArgParserRuntime_BasicNoPositionals.runParse
+                    (ArgParserRuntime_BasicNoPositionals.WellFormedSchema.checkOrFail parser_schema)
+                    parser_callbacks
+                    args
+            with
+            | ArgParserRuntime_BasicNoPositionals.ParseOutcome.Success parser_selection ->
+                {
+                    Child =
+                        {
+                            Thing1 =
+                                (match arg_0 with
+                                 | Some x -> x
+                                 | None ->
+                                     failwith
+                                         "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
+                            Thing2 =
+                                (match arg_1 with
+                                 | Some x -> x
+                                 | None ->
+                                     failwith
+                                         "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
+                        }
+                }
+            | ArgParserRuntime_BasicNoPositionals.ParseOutcome.HelpRequested ->
+                helpText () |> failwithf "Help text requested.\n%s"
+            | ArgParserRuntime_BasicNoPositionals.ParseOutcome.Fatal message -> failwith message
+            | ArgParserRuntime_BasicNoPositionals.ParseOutcome.Errors errors ->
+                errors |> String.concat "\n" |> failwithf "Errors during parse!\n%s"
+
+        static member parse (args : string list) : ParentRecordWithEscapedHelp =
+            ParentRecordWithEscapedHelp.parse' (System.Environment.GetEnvironmentVariable >> Option.ofObj) args
+namespace ConsumePlugin
+
+open System
+open System.IO
+open WoofWare.Myriad.Plugins
+
 /// Methods to parse arguments for the type ChoicePositionals
 [<AutoOpen>]
 module ChoicePositionalsArgParse =
@@ -7240,10 +7403,7 @@ module WithMultilineTypeHelp =
     let parse' (getEnvironmentVariable : string -> string option) (args : string list) : WithMultilineTypeHelp =
         let helpText () =
             [
-                "This is a multiline help text example.
-It spans multiple lines to test that multiline strings work correctly.
-You can use this to provide detailed documentation for your argument parser."
-
+                "This is a multiline help text example.\u000aIt spans multiple lines to test that multiline strings work correctly.\u000aYou can use this to provide detailed documentation for your argument parser."
                 ""
 
                 (sprintf

--- a/ConsumePlugin/GeneratedDuArgs.fs
+++ b/ConsumePlugin/GeneratedDuArgs.fs
@@ -1423,9 +1423,9 @@ module DuArgs =
         let helpText () =
             [
                 "exactly one of the following sets of arguments:"
-                "FooCase:"
+                (sprintf "%s:" "FooCase")
                 (sprintf "  %s  %s%s%s" (sprintf "--%s" "foo") "int32" "" (sprintf " : %s" ("The foo argument")))
-                "BarCase:"
+                (sprintf "%s:" "BarCase")
                 (sprintf "  %s  %s%s%s" (sprintf "--%s" "bar") "int32" "" "")
                 (sprintf "  %s  %s%s%s" (sprintf "--%s" "baz") "int32" "" "")
             ]
@@ -1627,9 +1627,9 @@ module WithModeArgs =
                 (sprintf "%s  %s%s%s" (sprintf "--%s" "verbose") "bool" "" "")
                 (sprintf "%s:" "Mode")
                 "  exactly one of the following sets of arguments:"
-                "  Auto:"
+                (sprintf "%s:" "  Auto")
                 (sprintf "    %s  %s%s%s" (sprintf "--%s" "quiet") "bool" " (optional)" "")
-                "  Manual:"
+                (sprintf "%s:" "  Manual")
                 (sprintf "    %s  %s%s%s" (sprintf "--%s" "level") "int32" "" "")
             ]
             |> String.concat "\n"
@@ -1834,7 +1834,7 @@ module DuWithDefaultArgs =
         let helpText () =
             [
                 "exactly one of the following sets of arguments:"
-                "Defaulted:"
+                (sprintf "%s:" "Defaulted")
 
                 (sprintf
                     "  %s  %s%s%s"
@@ -1843,7 +1843,7 @@ module DuWithDefaultArgs =
                     (DefaultedArgs.DefaultRetries().ToString () |> sprintf " (default value: %s)")
                     "")
 
-                "Plain:"
+                (sprintf "%s:" "Plain")
                 (sprintf "  %s  %s%s%s" (sprintf "--%s" "value") "int32" "" "")
             ]
             |> String.concat "\n"
@@ -2007,9 +2007,9 @@ module WithModeHelpArgs =
                 (sprintf "%s  %s%s%s" (sprintf "--%s" "verbose") "bool" "" "")
                 (sprintf "%s: %s" "Mode" ("How loud to be"))
                 "  exactly one of the following sets of arguments:"
-                "  Auto:"
+                (sprintf "%s:" "  Auto")
                 (sprintf "    %s  %s%s%s" (sprintf "--%s" "quiet") "bool" " (optional)" "")
-                "  Manual:"
+                (sprintf "%s:" "  Manual")
                 (sprintf "    %s  %s%s%s" (sprintf "--%s" "level") "int32" "" "")
             ]
             |> String.concat "\n"
@@ -2215,15 +2215,15 @@ module WithTransportArgs =
             [
                 (sprintf "%s: %s" "Preferred" ("Try this one first"))
                 "  exactly one of the following sets of arguments:"
-                "  Tcp:"
+                (sprintf "%s:" "  Tcp")
                 (sprintf "    %s  %s%s%s" (sprintf "--%s" "preferred-tcp-port") "int32" "" "")
-                "  Unix:"
+                (sprintf "%s:" "  Unix")
                 (sprintf "    %s  %s%s%s" (sprintf "--%s" "preferred-socket-path") "string" "" "")
                 (sprintf "%s: %s" "Fallback" ("Which transport to use"))
                 "  exactly one of the following sets of arguments:"
-                "  Tcp:"
+                (sprintf "%s:" "  Tcp")
                 (sprintf "    %s  %s%s%s" (sprintf "--%s" "fallback-tcp-port") "int32" "" "")
-                "  Unix:"
+                (sprintf "%s:" "  Unix")
                 (sprintf "    %s  %s%s%s" (sprintf "--%s" "fallback-socket-path") "string" "" "")
             ]
             |> String.concat "\n"
@@ -2485,6 +2485,166 @@ namespace ConsumePlugin
 
 open WoofWare.Myriad.Plugins
 
+/// Methods to parse arguments for the type CommandWithHelp
+[<RequireQualifiedAccess ; CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+module CommandWithHelp =
+    let parse' (getEnvironmentVariable : string -> string option) (args : string list) : CommandWithHelp =
+        let helpText () =
+            [
+                "exactly one of the following sets of arguments:"
+                (sprintf "%s: %s" "FetchCase" ("Fetch a URL"))
+                (sprintf "  %s  %s%s%s" (sprintf "--%s" "url") "string" "" "")
+                (sprintf "%s: %s" "PushCase" ("Push to a remote"))
+                (sprintf "  %s  %s%s%s" (sprintf "--%s" "remote") "string" "" "")
+            ]
+            |> String.concat "\n"
+
+        let parser_LeftoverArgs : string ResizeArray = ResizeArray ()
+        let mutable arg_1 : string option = None
+        let mutable arg_2 : string option = None
+
+        let parser_schema : ArgParserRuntime_DuArgs.ErasedSchema =
+            {
+                Leaves =
+                    [
+                        {
+                            Id = 0
+                            Forms = [ "url" ]
+                            AcceptsNegation = false
+                            Arity = ArgParserRuntime_DuArgs.ErasedArity.One
+                            Repeatable = false
+                            Requirement = ArgParserRuntime_DuArgs.ErasedRequirement.Required
+                            TypeDescription = ""
+                            Help = None
+                        }
+                        {
+                            Id = 1
+                            Forms = [ "remote" ]
+                            AcceptsNegation = false
+                            Arity = ArgParserRuntime_DuArgs.ErasedArity.One
+                            Repeatable = false
+                            Requirement = ArgParserRuntime_DuArgs.ErasedRequirement.Required
+                            TypeDescription = ""
+                            Help = None
+                        }
+                    ]
+                Tree =
+                    (ArgParserRuntime_DuArgs.ErasedTree.Sum (
+                        (0,
+                         [
+                             ("FetchCase",
+                              ArgParserRuntime_DuArgs.ErasedTree.Product ([ ArgParserRuntime_DuArgs.ErasedTree.Leaf 0 ]))
+                             ("PushCase",
+                              ArgParserRuntime_DuArgs.ErasedTree.Product ([ ArgParserRuntime_DuArgs.ErasedTree.Leaf 1 ]))
+                         ])
+                    ))
+                Positionals = List.empty
+            }
+
+        let parser_storeOccurrence (occurrence : ArgParserRuntime_DuArgs.ErasedOccurrence) : string option =
+            match occurrence.LeafId with
+            | 0 ->
+                match arg_1 with
+                | Some _ -> None
+                | None ->
+                    match occurrence.Value with
+                    | Some value ->
+                        try
+                            arg_1 <- Some (value |> (fun x -> x))
+                            None
+                        with _ as exc ->
+                            (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                    | None ->
+                        failwith
+                            "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
+            | 1 ->
+                match arg_2 with
+                | Some _ -> None
+                | None ->
+                    match occurrence.Value with
+                    | Some value ->
+                        try
+                            arg_2 <- Some (value |> (fun x -> x))
+                            None
+                        with _ as exc ->
+                            (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                    | None ->
+                        failwith
+                            "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
+            | _ -> failwith "WoofWare.Myriad internal error in generated parser: unknown argument id"
+
+        let parser_storePositional (positionalId : int) (value : string) (afterSeparator : bool) : string option =
+            failwith "WoofWare.Myriad internal error in generated parser: no positional sink exists"
+
+        let parser_renderStored (leafId : int) : string =
+            match leafId with
+            | 0 ->
+                match arg_1 with
+                | Some x -> x.ToString ()
+                | None -> "<no value>"
+            | 1 ->
+                match arg_2 with
+                | Some x -> x.ToString ()
+                | None -> "<no value>"
+            | _ -> "<no value>"
+
+        let parser_applyDefault (leafId : int) : string option =
+            match leafId with
+            | _ -> failwith "WoofWare.Myriad internal error in generated parser: unknown defaulted argument id"
+
+        let parser_callbacks : ArgParserRuntime_DuArgs.TypedCallbacks =
+            {
+                StoreOccurrence = parser_storeOccurrence
+                StorePositional = parser_storePositional
+                HelpText = helpText
+                RenderStored = parser_renderStored
+                ApplyDefault = parser_applyDefault
+            }
+
+        match
+            ArgParserRuntime_DuArgs.runParse
+                (ArgParserRuntime_DuArgs.WellFormedSchema.checkOrFail parser_schema)
+                parser_callbacks
+                args
+        with
+        | ArgParserRuntime_DuArgs.ParseOutcome.Success parser_selection ->
+            match Map.tryFind 0 parser_selection.Choices with
+            | Some 0 ->
+                CommandWithHelp.FetchCase (
+                    {
+                        Url =
+                            (match arg_1 with
+                             | Some x -> x
+                             | None ->
+                                 failwith
+                                     "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
+                    }
+                )
+            | Some 1 ->
+                CommandWithHelp.PushCase (
+                    {
+                        Remote =
+                            (match arg_2 with
+                             | Some x -> x
+                             | None ->
+                                 failwith
+                                     "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
+                    }
+                )
+            | _ ->
+                failwith
+                    "WoofWare.Myriad internal error in generated parser: no case selected despite a successful parse"
+        | ArgParserRuntime_DuArgs.ParseOutcome.HelpRequested -> helpText () |> failwithf "Help text requested.\n%s"
+        | ArgParserRuntime_DuArgs.ParseOutcome.Fatal message -> failwith message
+        | ArgParserRuntime_DuArgs.ParseOutcome.Errors errors ->
+            errors |> String.concat "\n" |> failwithf "Errors during parse!\n%s"
+
+    let parse (args : string list) : CommandWithHelp =
+        parse' (System.Environment.GetEnvironmentVariable >> Option.ofObj) args
+namespace ConsumePlugin
+
+open WoofWare.Myriad.Plugins
+
 /// Methods to parse arguments for the type ModeAndPositionals
 [<RequireQualifiedAccess ; CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module ModeAndPositionals =
@@ -2493,9 +2653,9 @@ module ModeAndPositionals =
             [
                 (sprintf "%s:" "Mode")
                 "  exactly one of the following sets of arguments:"
-                "  Auto:"
+                (sprintf "%s:" "  Auto")
                 (sprintf "    %s  %s%s%s" (sprintf "--%s" "quiet") "bool" " (optional)" "")
-                "  Manual:"
+                (sprintf "%s:" "  Manual")
                 (sprintf "    %s  %s%s%s" (sprintf "--%s" "level") "int32" "" "")
                 (sprintf "%s  %s%s%s" (sprintf "--%s" "rest") "int32" " (positional args) (can be repeated)" "")
             ]
@@ -2681,9 +2841,9 @@ module CommandAndPositionals =
             [
                 (sprintf "%s:" "Command")
                 "  exactly one of the following sets of arguments:"
-                "  Fetch:"
+                (sprintf "%s:" "  Fetch")
                 (sprintf "    %s  %s%s%s" (sprintf "--%s" "url") "string" "" "")
-                "  Push:"
+                (sprintf "%s:" "  Push")
                 (sprintf "    %s  %s%s%s" (sprintf "--%s" "remote") "string" "" "")
                 (sprintf "    %s  %s%s%s" (sprintf "--%s" "force") "bool" "" "")
                 (sprintf "%s  %s%s%s" (sprintf "--%s" "paths") "string" " (positional args) (can be repeated)" "")
@@ -2917,10 +3077,10 @@ module FooBarMode =
         let helpText () =
             [
                 "exactly one of the following sets of arguments:"
-                "FooMode:"
+                (sprintf "%s:" "FooMode")
                 (sprintf "  %s  %s%s%s" (sprintf "--%s" "foo") "int32" "" "")
                 (sprintf "  %s  %s%s%s" (sprintf "--%s" "rest") "int32" " (positional args) (can be repeated)" "")
-                "BarMode:"
+                (sprintf "%s:" "BarMode")
                 (sprintf "  %s  %s%s%s" (sprintf "--%s" "bar") "int32" "" "")
                 (sprintf "  %s  %s%s%s" (sprintf "--%s" "rest") "string" " (positional args) (can be repeated)" "")
             ]
@@ -3121,10 +3281,10 @@ module GitLike =
         let helpText () =
             [
                 "exactly one of the following sets of arguments:"
-                "Pull:"
+                (sprintf "%s:" "Pull")
                 (sprintf "  %s  %s%s%s" (sprintf "--%s" "source") "string" "" "")
                 (sprintf "  %s  %s%s%s" (sprintf "--%s" "refs") "string" " (positional args) (can be repeated)" "")
-                "Status:"
+                (sprintf "%s:" "Status")
                 (sprintf "  %s  %s%s%s" (sprintf "--%s" "verbose") "bool" " (optional)" "")
             ]
             |> String.concat "\n"
@@ -3946,7 +4106,7 @@ module EnumInUnion =
         let helpText () =
             [
                 "exactly one of the following sets of arguments:"
-                "Build:"
+                (sprintf "%s:" "Build")
 
                 (sprintf
                     "  %s  %s%s%s"
@@ -3955,7 +4115,7 @@ module EnumInUnion =
                     ""
                     "")
 
-                "Clean:"
+                (sprintf "%s:" "Clean")
                 (sprintf "  %s  %s%s%s" (sprintf "--%s" "force") "bool" " (optional)" "")
             ]
             |> String.concat "\n"

--- a/ConsumePlugin/GeneratedDuArgs.fs
+++ b/ConsumePlugin/GeneratedDuArgs.fs
@@ -2207,6 +2207,284 @@ namespace ConsumePlugin
 
 open WoofWare.Myriad.Plugins
 
+/// Methods to parse arguments for the type WithTransportArgs
+[<RequireQualifiedAccess ; CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+module WithTransportArgs =
+    let parse' (getEnvironmentVariable : string -> string option) (args : string list) : WithTransportArgs =
+        let helpText () =
+            [
+                (sprintf "%s: %s" "Preferred" ("Try this one first"))
+                "  exactly one of the following sets of arguments:"
+                "  Tcp:"
+                (sprintf "    %s  %s%s%s" (sprintf "--%s" "preferred-tcp-port") "int32" "" "")
+                "  Unix:"
+                (sprintf "    %s  %s%s%s" (sprintf "--%s" "preferred-socket-path") "string" "" "")
+                (sprintf "%s: %s" "Fallback" ("Which transport to use"))
+                "  exactly one of the following sets of arguments:"
+                "  Tcp:"
+                (sprintf "    %s  %s%s%s" (sprintf "--%s" "fallback-tcp-port") "int32" "" "")
+                "  Unix:"
+                (sprintf "    %s  %s%s%s" (sprintf "--%s" "fallback-socket-path") "string" "" "")
+            ]
+            |> String.concat "\n"
+
+        let parser_LeftoverArgs : string ResizeArray = ResizeArray ()
+        let mutable arg_1 : int option = None
+        let mutable arg_2 : string option = None
+        let mutable arg_4 : int option = None
+        let mutable arg_5 : string option = None
+
+        let parser_schema : ArgParserRuntime_DuArgs.ErasedSchema =
+            {
+                Leaves =
+                    [
+                        {
+                            Id = 0
+                            Forms = [ "preferred-tcp-port" ]
+                            AcceptsNegation = false
+                            Arity = ArgParserRuntime_DuArgs.ErasedArity.One
+                            Repeatable = false
+                            Requirement = ArgParserRuntime_DuArgs.ErasedRequirement.Required
+                            TypeDescription = ""
+                            Help = None
+                        }
+
+                        {
+                            Id = 1
+                            Forms = [ "preferred-socket-path" ]
+                            AcceptsNegation = false
+                            Arity = ArgParserRuntime_DuArgs.ErasedArity.One
+                            Repeatable = false
+                            Requirement = ArgParserRuntime_DuArgs.ErasedRequirement.Required
+                            TypeDescription = ""
+                            Help = None
+                        }
+
+                        {
+                            Id = 2
+                            Forms = [ "fallback-tcp-port" ]
+                            AcceptsNegation = false
+                            Arity = ArgParserRuntime_DuArgs.ErasedArity.One
+                            Repeatable = false
+                            Requirement = ArgParserRuntime_DuArgs.ErasedRequirement.Required
+                            TypeDescription = ""
+                            Help = None
+                        }
+                        {
+                            Id = 3
+                            Forms = [ "fallback-socket-path" ]
+                            AcceptsNegation = false
+                            Arity = ArgParserRuntime_DuArgs.ErasedArity.One
+                            Repeatable = false
+                            Requirement = ArgParserRuntime_DuArgs.ErasedRequirement.Required
+                            TypeDescription = ""
+                            Help = None
+                        }
+                    ]
+                Tree =
+                    (ArgParserRuntime_DuArgs.ErasedTree.Product (
+                        [
+                            ArgParserRuntime_DuArgs.ErasedTree.Sum (
+                                (0,
+                                 [
+                                     ("Tcp",
+                                      ArgParserRuntime_DuArgs.ErasedTree.Product (
+                                          [ ArgParserRuntime_DuArgs.ErasedTree.Leaf 0 ]
+                                      ))
+                                     ("Unix",
+                                      ArgParserRuntime_DuArgs.ErasedTree.Product (
+                                          [ ArgParserRuntime_DuArgs.ErasedTree.Leaf 1 ]
+                                      ))
+                                 ])
+                            )
+                            ArgParserRuntime_DuArgs.ErasedTree.Sum (
+                                (3,
+                                 [
+                                     ("Tcp",
+                                      ArgParserRuntime_DuArgs.ErasedTree.Product (
+                                          [ ArgParserRuntime_DuArgs.ErasedTree.Leaf 2 ]
+                                      ))
+                                     ("Unix",
+                                      ArgParserRuntime_DuArgs.ErasedTree.Product (
+                                          [ ArgParserRuntime_DuArgs.ErasedTree.Leaf 3 ]
+                                      ))
+                                 ])
+                            )
+                        ]
+                    ))
+                Positionals = List.empty
+            }
+
+        let parser_storeOccurrence (occurrence : ArgParserRuntime_DuArgs.ErasedOccurrence) : string option =
+            match occurrence.LeafId with
+            | 0 ->
+                match arg_1 with
+                | Some _ -> None
+                | None ->
+                    match occurrence.Value with
+                    | Some value ->
+                        try
+                            arg_1 <- Some (value |> (fun x -> System.Int32.Parse x))
+                            None
+                        with _ as exc ->
+                            (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                    | None ->
+                        failwith
+                            "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
+            | 1 ->
+                match arg_2 with
+                | Some _ -> None
+                | None ->
+                    match occurrence.Value with
+                    | Some value ->
+                        try
+                            arg_2 <- Some (value |> (fun x -> x))
+                            None
+                        with _ as exc ->
+                            (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                    | None ->
+                        failwith
+                            "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
+            | 2 ->
+                match arg_4 with
+                | Some _ -> None
+                | None ->
+                    match occurrence.Value with
+                    | Some value ->
+                        try
+                            arg_4 <- Some (value |> (fun x -> System.Int32.Parse x))
+                            None
+                        with _ as exc ->
+                            (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                    | None ->
+                        failwith
+                            "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
+            | 3 ->
+                match arg_5 with
+                | Some _ -> None
+                | None ->
+                    match occurrence.Value with
+                    | Some value ->
+                        try
+                            arg_5 <- Some (value |> (fun x -> x))
+                            None
+                        with _ as exc ->
+                            (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                    | None ->
+                        failwith
+                            "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
+            | _ -> failwith "WoofWare.Myriad internal error in generated parser: unknown argument id"
+
+        let parser_storePositional (positionalId : int) (value : string) (afterSeparator : bool) : string option =
+            failwith "WoofWare.Myriad internal error in generated parser: no positional sink exists"
+
+        let parser_renderStored (leafId : int) : string =
+            match leafId with
+            | 0 ->
+                match arg_1 with
+                | Some x -> x.ToString ()
+                | None -> "<no value>"
+            | 1 ->
+                match arg_2 with
+                | Some x -> x.ToString ()
+                | None -> "<no value>"
+            | 2 ->
+                match arg_4 with
+                | Some x -> x.ToString ()
+                | None -> "<no value>"
+            | 3 ->
+                match arg_5 with
+                | Some x -> x.ToString ()
+                | None -> "<no value>"
+            | _ -> "<no value>"
+
+        let parser_applyDefault (leafId : int) : string option =
+            match leafId with
+            | _ -> failwith "WoofWare.Myriad internal error in generated parser: unknown defaulted argument id"
+
+        let parser_callbacks : ArgParserRuntime_DuArgs.TypedCallbacks =
+            {
+                StoreOccurrence = parser_storeOccurrence
+                StorePositional = parser_storePositional
+                HelpText = helpText
+                RenderStored = parser_renderStored
+                ApplyDefault = parser_applyDefault
+            }
+
+        match
+            ArgParserRuntime_DuArgs.runParse
+                (ArgParserRuntime_DuArgs.WellFormedSchema.checkOrFail parser_schema)
+                parser_callbacks
+                args
+        with
+        | ArgParserRuntime_DuArgs.ParseOutcome.Success parser_selection ->
+            {
+                Fallback =
+                    match Map.tryFind 3 parser_selection.Choices with
+                    | Some 0 ->
+                        Transport.Tcp (
+                            {
+                                TcpPort =
+                                    (match arg_4 with
+                                     | Some x -> x
+                                     | None ->
+                                         failwith
+                                             "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
+                            }
+                        )
+                    | Some 1 ->
+                        Transport.Unix (
+                            {
+                                SocketPath =
+                                    (match arg_5 with
+                                     | Some x -> x
+                                     | None ->
+                                         failwith
+                                             "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
+                            }
+                        )
+                    | _ ->
+                        failwith
+                            "WoofWare.Myriad internal error in generated parser: no case selected despite a successful parse"
+                Preferred =
+                    match Map.tryFind 0 parser_selection.Choices with
+                    | Some 0 ->
+                        Transport.Tcp (
+                            {
+                                TcpPort =
+                                    (match arg_1 with
+                                     | Some x -> x
+                                     | None ->
+                                         failwith
+                                             "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
+                            }
+                        )
+                    | Some 1 ->
+                        Transport.Unix (
+                            {
+                                SocketPath =
+                                    (match arg_2 with
+                                     | Some x -> x
+                                     | None ->
+                                         failwith
+                                             "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
+                            }
+                        )
+                    | _ ->
+                        failwith
+                            "WoofWare.Myriad internal error in generated parser: no case selected despite a successful parse"
+            }
+        | ArgParserRuntime_DuArgs.ParseOutcome.HelpRequested -> helpText () |> failwithf "Help text requested.\n%s"
+        | ArgParserRuntime_DuArgs.ParseOutcome.Fatal message -> failwith message
+        | ArgParserRuntime_DuArgs.ParseOutcome.Errors errors ->
+            errors |> String.concat "\n" |> failwithf "Errors during parse!\n%s"
+
+    let parse (args : string list) : WithTransportArgs =
+        parse' (System.Environment.GetEnvironmentVariable >> Option.ofObj) args
+namespace ConsumePlugin
+
+open WoofWare.Myriad.Plugins
+
 /// Methods to parse arguments for the type ModeAndPositionals
 [<RequireQualifiedAccess ; CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module ModeAndPositionals =

--- a/ConsumePlugin/GeneratedMapArgs.fs
+++ b/ConsumePlugin/GeneratedMapArgs.fs
@@ -2054,9 +2054,9 @@ module MapInUnion =
         let helpText () =
             [
                 "exactly one of the following sets of arguments:"
-                "Deploy:"
+                (sprintf "%s:" "Deploy")
                 (sprintf "  %s  %s%s%s" (sprintf "--%s" "tags") "map<string, string>" " (KEY:VALUE; can be repeated)" "")
-                "Rollback:"
+                (sprintf "%s:" "Rollback")
                 (sprintf "  %s  %s%s%s" (sprintf "--%s" "to") "string" "" "")
             ]
             |> String.concat "\n"

--- a/ConsumePlugin/GeneratedPrefixArgs.fs
+++ b/ConsumePlugin/GeneratedPrefixArgs.fs
@@ -3079,9 +3079,9 @@ module PrefixedUnionArgParse =
                 [
                     (sprintf "%s:" "Mode")
                     "  exactly one of the following sets of arguments:"
-                    "  Auto:"
+                    (sprintf "%s:" "  Auto")
                     (sprintf "    %s  %s%s%s" (sprintf "--%s" "mode-quiet") "bool" " (optional)" "")
-                    "  Manual:"
+                    (sprintf "%s:" "  Manual")
                     (sprintf "    %s  %s%s%s" (sprintf "--%s" "mode-level") "int32" "" "")
                 ]
                 |> String.concat "\n"

--- a/WoofWare.Myriad.Plugins.Attributes/ArgParserAttributes.fs
+++ b/WoofWare.Myriad.Plugins.Attributes/ArgParserAttributes.fs
@@ -95,6 +95,12 @@ type ArgumentDefaultValueAttribute (defaultValue : obj) =
 /// alternative argument sets, the help text describes the whole group of arguments that field
 /// contributes: it appears on the header line which introduces that group, above the indented list
 /// of the arguments themselves. (That header is written whether or not you supply any help text.)
+///
+/// When applied to a nested argument record or union -- one which is not itself [<ArgParser>]-tagged,
+/// but is reached through a field of one -- the help text describes that type wherever it is
+/// embedded, and so heads the group in each place. If the field which embeds it carries an
+/// [<ArgumentHelpText>] of its own, the field's wins: it is the more specific placement, and one type
+/// may be embedded at several sites for different purposes.
 type ArgumentHelpTextAttribute (helpText : string) =
     inherit Attribute ()
 

--- a/WoofWare.Myriad.Plugins.Attributes/ArgParserAttributes.fs
+++ b/WoofWare.Myriad.Plugins.Attributes/ArgParserAttributes.fs
@@ -96,11 +96,9 @@ type ArgumentDefaultValueAttribute (defaultValue : obj) =
 /// contributes: it appears on the header line which introduces that group, above the indented list
 /// of the arguments themselves. (That header is written whether or not you supply any help text.)
 ///
-/// When applied to a nested argument record or union -- one which is not itself [<ArgParser>]-tagged,
-/// but is reached through a field of one -- the help text describes that type wherever it is
-/// embedded, and so heads the group in each place. If the field which embeds it carries an
-/// [<ArgumentHelpText>] of its own, the field's wins: it is the more specific placement, and one type
-/// may be embedded at several sites for different purposes.
+/// When applied to a nested argument record or union, the help text instead heads the group of
+/// arguments the nesting causes. If the field which embeds it carries an `[<ArgumentHelpText>]`
+/// of its own, the field's wins, on the grounds that it's the more specific text.
 type ArgumentHelpTextAttribute (helpText : string) =
     inherit Attribute ()
 

--- a/WoofWare.Myriad.Plugins.Attributes/ArgParserAttributes.fs
+++ b/WoofWare.Myriad.Plugins.Attributes/ArgParserAttributes.fs
@@ -101,6 +101,12 @@ type ArgumentDefaultValueAttribute (defaultValue : obj) =
 /// embedded, and so heads the group in each place. If the field which embeds it carries an
 /// [<ArgumentHelpText>] of its own, the field's wins: it is the more specific placement, and one type
 /// may be embedded at several sites for different purposes.
+///
+/// When applied to a case of a discriminated union of alternative argument sets, the help text
+/// describes that case's set of arguments, and appears on the header line naming the case. A case
+/// is not reached through a field, so its payload record's own [<ArgumentHelpText>] (if the payload
+/// is used in only that one case) is the fallback instead; the case, being the more specific
+/// placement, overrides it.
 type ArgumentHelpTextAttribute (helpText : string) =
     inherit Attribute ()
 

--- a/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParser.fs
+++ b/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParser.fs
@@ -503,6 +503,24 @@ Secondary: Where to fail over to
   --secondary-host  string
   --secondary-port  int32"""
 
+    /// FCS hands the generator the *decoded* string, so a help text containing a backslash, a
+    /// quote, or a control character must be re-escaped before it is reproduced in the generated
+    /// file, or Fantomas (which escapes only quotes) would emit it wrong: `\t` would come out of
+    /// the quotes as a literal tab, silently changing what the help text displays.
+    [<Test>]
+    let ``Help text needing escaping round-trips through the generated file`` () =
+        let getEnvVar (_ : string) = failwith "should not call"
+
+        let exc =
+            Assert.Throws<exn> (fun () ->
+                ParentRecordWithEscapedHelp.parse' getEnvVar [ "--help" ]
+                |> ignore<ParentRecordWithEscapedHelp>
+            )
+
+        exc.Message
+        |> shouldEqual
+            "Help text requested.\nChild: Path is C:\\temp, quote is \" and tab is \t.\n  --thing1  int32\n  --thing2  string"
+
     [<Test>]
     let ``Positionals are tagged with Choice`` () =
         let getEnvVar (_ : string) = failwith "should not call"

--- a/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParser.fs
+++ b/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParser.fs
@@ -481,6 +481,28 @@ Child: Settings for the child thing
   --thing2  string
 --and-another  bool : Whether to and-another"""
 
+    /// A nested type describes itself for every site which embeds it; a field which has something
+    /// more specific to say overrides that, because one type may be embedded for several purposes.
+    [<Test>]
+    let ``A nested record's own help text heads the group, and the field's overrides it`` () =
+        let getEnvVar (_ : string) = failwith "should not call"
+
+        let exc =
+            Assert.Throws<exn> (fun () ->
+                ParentRecordWithTypeHelp.parse' getEnvVar [ "--help" ]
+                |> ignore<ParentRecordWithTypeHelp>
+            )
+
+        exc.Message
+        |> shouldEqual
+            """Help text requested.
+Primary: How to talk to the database
+  --primary-host  string
+  --primary-port  int32
+Secondary: Where to fail over to
+  --secondary-host  string
+  --secondary-port  int32"""
+
     [<Test>]
     let ``Positionals are tagged with Choice`` () =
         let getEnvVar (_ : string) = failwith "should not call"

--- a/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParserDu.fs
+++ b/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParserDu.fs
@@ -201,3 +201,26 @@ Mode: How loud to be
     --quiet  bool (optional)
   Manual:
     --level  int32"""
+
+    /// As for a nested record: the union describes itself for every site which embeds it, and a
+    /// field with something more specific to say overrides that.
+    [<Test>]
+    let ``A union's own help text heads the group, and the field's overrides it`` () =
+        let exc =
+            Assert.Throws<exn> (fun () -> WithTransportArgs.parse' noEnv [ "--help" ] |> ignore<WithTransportArgs>)
+
+        exc.Message
+        |> shouldEqual
+            """Help text requested.
+Preferred: Try this one first
+  exactly one of the following sets of arguments:
+  Tcp:
+    --preferred-tcp-port  int32
+  Unix:
+    --preferred-socket-path  string
+Fallback: Which transport to use
+  exactly one of the following sets of arguments:
+  Tcp:
+    --fallback-tcp-port  int32
+  Unix:
+    --fallback-socket-path  string"""

--- a/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParserDu.fs
+++ b/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParserDu.fs
@@ -202,6 +202,22 @@ Mode: How loud to be
   Manual:
     --level  int32"""
 
+    /// A case's payload record has no field of its own to be embedded through, so it can only
+    /// describe itself and be overridden by the case: there is no third, more specific layer.
+    [<Test>]
+    let ``A case's payload record describes itself, and the case's own help text overrides it`` () =
+        let exc =
+            Assert.Throws<exn> (fun () -> CommandWithHelp.parse' noEnv [ "--help" ] |> ignore<CommandWithHelp>)
+
+        exc.Message
+        |> shouldEqual
+            """Help text requested.
+exactly one of the following sets of arguments:
+FetchCase: Fetch a URL
+  --url  string
+PushCase: Push to a remote
+  --remote  string"""
+
     /// As for a nested record: the union describes itself for every site which embeds it, and a
     /// field with something more specific to say overrides that.
     [<Test>]

--- a/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
+++ b/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
@@ -259,10 +259,14 @@ type private ParseTree =
     /// which were supplied. `sumId` ties this node to the erased schema's Sum node; `assemble`
     /// builds the union value from the selected case's name and its assembled payload.
     /// Positional args are not yet permitted inside union cases.
+    ///
+    /// Each case carries its own optional help text -- `[<ArgumentHelpText>]` on the case itself,
+    /// falling back to the same attribute on its payload record's definition -- since a case's
+    /// payload record introduces no `Branch` header of its own for it to live on (see above).
     | Sum of
         sumId : int *
         header : GroupHeader option *
-        cases : (Ident * ParseTree) list *
+        cases : (Ident * SynExpr option * ParseTree) list *
         assemble : (Ident -> SynExpr -> SynExpr)
 
 [<RequireQualifiedAccess>]
@@ -274,7 +278,7 @@ module private ParseTree =
         | ParseTree.NonPositionalLeaf _ -> false
         | ParseTree.PositionalLeaf _ -> true
         | ParseTree.Branch (_, fields, _) -> fields |> List.exists (fun (_, child) -> containsPositional child)
-        | ParseTree.Sum (_, _, cases, _) -> cases |> List.exists (fun (_, case) -> containsPositional case)
+        | ParseTree.Sum (_, _, cases, _) -> cases |> List.exists (fun (_, _, case) -> containsPositional case)
 
     /// The `Ident` here is the field name. Moves the positional-claiming field (at most one
     /// is permitted) after its siblings.
@@ -309,7 +313,7 @@ module private ParseTree =
                 )
             | ParseTree.Sum (_, _, cases, _) ->
                 (([], []), cases)
-                ||> List.fold (fun (nonPos, pos) (_, case) ->
+                ||> List.fold (fun (nonPos, pos) (_, _, case) ->
                     let caseNonPos, casePos = go case
                     nonPos @ caseNonPos, pos @ casePos
                 )
@@ -481,7 +485,7 @@ module private ParseTree =
             | Accumulation.Map _ -> true
         | ParseTree.PositionalLeaf _ -> true
         | ParseTree.Branch (_, fields, _) -> fields |> List.forall (fun (_, child) -> emptySatisfiable child)
-        | ParseTree.Sum (_, _, cases, _) -> cases |> List.exists (fun (_, case) -> emptySatisfiable case)
+        | ParseTree.Sum (_, _, cases, _) -> cases |> List.exists (fun (_, _, case) -> emptySatisfiable case)
 
     /// For every union node in the tree, at most one case may be satisfiable with no arguments:
     /// were two cases so satisfiable, an empty command line could not choose between them.
@@ -491,14 +495,14 @@ module private ParseTree =
         | ParseTree.PositionalLeaf _ -> ()
         | ParseTree.Branch (_, fields, _) -> fields |> List.iter (fun (_, child) -> checkSumAmbiguity child)
         | ParseTree.Sum (_, _, cases, _) ->
-            cases |> List.iter (fun (_, case) -> checkSumAmbiguity case)
+            cases |> List.iter (fun (_, _, case) -> checkSumAmbiguity case)
 
-            match cases |> List.filter (fun (_, case) -> emptySatisfiable case) with
+            match cases |> List.filter (fun (_, _, case) -> emptySatisfiable case) with
             | []
             | [ _ ] -> ()
             | ambiguous ->
                 let names =
-                    ambiguous |> List.map (fun (name, _) -> name.idText) |> String.concat ", "
+                    ambiguous |> List.map (fun (name, _, _) -> name.idText) |> String.concat ", "
 
                 failwith
                     $"Cases %s{names} can all be satisfied without supplying any arguments, so an empty command line cannot choose between them. Make an argument in all but one of them mandatory."
@@ -537,7 +541,7 @@ module private ParseTree =
         | ParseTree.Sum (sumId, _, cases, _) ->
             let caseExprs =
                 cases
-                |> List.map (fun (caseName, payload) ->
+                |> List.map (fun (caseName, _, payload) ->
                     let payloadExpr = toErasedTreeExpr rt listOf counter posCounter payload
 
                     SynExpr.tuple [ SynExpr.CreateConst caseName.idText ; payloadExpr ]
@@ -595,7 +599,7 @@ module private ParseTree =
 
             let clauses =
                 cases
-                |> List.mapi (fun index (caseName, payload) ->
+                |> List.mapi (fun index (caseName, _, payload) ->
                     SynMatchClause.create
                         (SynPat.nameWithArgs "Some" [ SynPat.createConst (SynConst.Int32 index) ])
                         (assemble caseName (SynExpr.paren (instantiate payload)))
@@ -1865,7 +1869,14 @@ module internal ArgParserGenerator =
                 // `sumHelp` already heads it with the case name.
                 let spec, counter = toParseSpec ancestors None prefix counter ambient payloadRecord
 
-                counter, (case.Name, spec) :: acc
+                // As for a nested record's field: the more specific placement (the case itself)
+                // overrides the more general one (the payload record's own definition), since one
+                // payload record type could in principle be reused by several cases or sites.
+                let caseHelp =
+                    helpTextAttribute case.Attributes
+                    |> Option.orElseWith (fun () -> helpTextAttribute payloadRecord.Attributes)
+
+                counter, (case.Name, caseHelp, spec) :: acc
             )
 
         let cases = List.rev cases
@@ -2028,13 +2039,18 @@ module internal ArgParserGenerator =
                 | None -> sumHelp depth cases
                 | Some header -> groupLine depth header :: sumHelp (depth + 1) cases
 
-        and sumHelp (depth : int) (cases : (Ident * ParseTree) list) : SynExpr list =
+        and sumHelp (depth : int) (cases : (Ident * SynExpr option * ParseTree) list) : SynExpr list =
             let indent = String.replicate depth "  "
 
             SynExpr.CreateConst (indent + "exactly one of the following sets of arguments:")
             :: (cases
-                |> List.collect (fun (caseName, case) ->
-                    SynExpr.CreateConst (indent + caseName.idText + ":")
+                |> List.collect (fun (caseName, help, case) ->
+                    groupLine
+                        depth
+                        {
+                            GroupHeader.Label = caseName.idText
+                            GroupHeader.Help = help
+                        }
                     :: fieldHelp (depth + 1) case
                 ))
 

--- a/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
+++ b/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
@@ -1314,15 +1314,36 @@ module internal ArgParserGenerator =
             | Some enumDu -> createEnumParser enumDu, Accumulation.Required, ty
             | None -> failwith $"Could not decide how to parse arguments for field %s{fieldName.idText} of type %O{ty}"
 
-    /// The `[<ArgumentHelpText>]` carried here, if any. The same attribute serves a field, a nested
-    /// type, and the tagged root, so they all read it through this.
-    let private helpTextAttribute (attrs : SynAttribute list) : SynExpr option =
+    /// The `[<ArgumentHelpText>]` carried here, if any, ready to be reproduced in the generated
+    /// file. The same attribute serves a field, a nested type, and the tagged root, so they all
+    /// read it through this; `context` names the placement, for the sake of any error message.
+    ///
+    /// As for `[<ArgumentDefaultValue>]` above, only a literal is safe to carry into the generated
+    /// file: a bare name might resolve to a different binding there, since that file hoists every
+    /// `open` in the source above the parser, and a decoded string constant needs its escapes
+    /// rebuilt or Fantomas will emit them wrong (a `\t` would come out of the quotes as a literal
+    /// tab).
+    let private helpTextAttribute (context : string) (attrs : SynAttribute list) : SynExpr option =
         attrs
         |> List.tryPick (fun attr ->
             match (List.last attr.TypeName.LongIdent).idText with
             | "ArgumentHelpTextAttribute"
             | "ArgumentHelpText" -> Some attr.ArgExpr
             | _ -> None
+        )
+        |> Option.map (fun expr ->
+            match classifyDefaultValue expr with
+            | DefaultValueExpr.Constant c -> defaultValueExpr c
+            | DefaultValueExpr.Null -> SynExpr.Null range0
+            | DefaultValueExpr.ContextSensitive name ->
+                failwith
+                    $"The [<ArgumentHelpText>] on %s{context} uses the context-sensitive constant %s{name}. Its value depends on where it is written, and we reproduce it in the generated file rather than evaluating it at your attribute, so it would not mean there what it means in your source. Write the help text out as a literal string."
+            | DefaultValueExpr.Identifier name ->
+                failwith
+                    $"The [<ArgumentHelpText>] on %s{context} names something (%s{name}) rather than writing out a literal string. We reproduce the value in the generated file rather than evaluating it at your attribute, and that file hoists every `open` in your source above the parser, so the name need not resolve to the same binding there as here. Write the help text out as a literal string."
+            | DefaultValueExpr.Unrecognised ->
+                failwith
+                    $"The [<ArgumentHelpText>] on %s{context} was not recognised as a literal. We reproduce the value in the generated file rather than evaluating it at your attribute, so we accept only a string literal written out in full (optionally parenthesised)."
         )
 
     /// The `[<ArgumentPrefix>]` this field carries, if any.
@@ -1457,10 +1478,15 @@ module internal ArgParserGenerator =
                         | _ -> None
                     )
 
+                let ident =
+                    match identOption with
+                    | None -> failwith "expected args field to have a name, but it did not"
+                    | Some i -> i
+
                 // Kept separate from the `helpText` below, which folds in the parse format: a
                 // structural field's help introduces a whole group of arguments rather than
                 // describing one, so it must not pick up a leaf's parsing note.
-                let helpTextAttr = helpTextAttribute attrs
+                let helpTextAttr = helpTextAttribute $"field '%s{ident.idText}'" attrs
 
                 let helpText =
                     match parseExactModifier, helpTextAttr with
@@ -1476,11 +1502,6 @@ module internal ArgParserGenerator =
                         |> SynExpr.applyTo ht
                         |> SynExpr.applyTo pe
                         |> Some
-
-                let ident =
-                    match identOption with
-                    | None -> failwith "expected args field to have a name, but it did not"
-                    | Some i -> i
 
                 let longForms =
                     attrs
@@ -1558,10 +1579,12 @@ module internal ArgParserGenerator =
                 // The field's own attribute wins over the nested type's, which is the fallback: one
                 // type may be nested at several sites, and the field is the more specific placement,
                 // so it is the one which can say what this occurrence is for.
-                let groupHeader (typeAttrs : SynAttribute list) : GroupHeader =
+                let groupHeader (typeName : string) (typeAttrs : SynAttribute list) : GroupHeader =
                     {
                         GroupHeader.Label = ident.idText
-                        GroupHeader.Help = helpTextAttr |> Option.orElseWith (fun () -> helpTextAttribute typeAttrs)
+                        GroupHeader.Help =
+                            helpTextAttr
+                            |> Option.orElseWith (fun () -> helpTextAttribute $"type %s{typeName}" typeAttrs)
                     }
 
                 match ambientRecordMatch with
@@ -1581,7 +1604,7 @@ module internal ArgParserGenerator =
                     let spec, counter =
                         toParseSpec
                             ancestors
-                            (Some (groupHeader childRecord.Attributes))
+                            (Some (groupHeader childRecord.Name.idText childRecord.Attributes))
                             childPrefix
                             counter
                             ambient
@@ -1606,7 +1629,7 @@ module internal ArgParserGenerator =
                     let spec, counter =
                         unionToParseSpec
                             ancestors
-                            (Some (groupHeader union.Attributes))
+                            (Some (groupHeader union.Name.idText union.Attributes))
                             childPrefix
                             counter
                             ambient
@@ -1873,8 +1896,10 @@ module internal ArgParserGenerator =
                 // overrides the more general one (the payload record's own definition), since one
                 // payload record type could in principle be reused by several cases or sites.
                 let caseHelp =
-                    helpTextAttribute case.Attributes
-                    |> Option.orElseWith (fun () -> helpTextAttribute payloadRecord.Attributes)
+                    helpTextAttribute $"case %s{case.Name.idText}" case.Attributes
+                    |> Option.orElseWith (fun () ->
+                        helpTextAttribute $"type %s{payloadRecord.Name.idText}" payloadRecord.Attributes
+                    )
 
                 counter, (case.Name, caseHelp, spec) :: acc
             )
@@ -3077,9 +3102,6 @@ module internal ArgParserGenerator =
             }
 
         let taggedTypeName, typeHelpText, parseSpec =
-            let typeHelp (attrs : SynAttributes) =
-                attrs |> SynAttributes.toAttrs |> helpTextAttribute
-
             match taggedType with
             | SynTypeDefn.SynTypeDefn (SynComponentInfo.SynComponentInfo (attributes = attrs) as sci,
                                        SynTypeDefnRepr.Simple (SynTypeDefnSimpleRepr.Record (access, fields, _), _),
@@ -3094,7 +3116,12 @@ module internal ArgParserGenerator =
                 // help, which `helpText` prints above everything.
                 let spec, _ = toParseSpec [] None "" 0 ambient record
 
-                record.Name, typeHelp attrs, spec
+                let typeHelp =
+                    attrs
+                    |> SynAttributes.toAttrs
+                    |> helpTextAttribute $"type %s{record.Name.idText}"
+
+                record.Name, typeHelp, spec
             | SynTypeDefn.SynTypeDefn (SynComponentInfo.SynComponentInfo (attributes = attrs) as sci,
                                        SynTypeDefnRepr.Simple (SynTypeDefnSimpleRepr.Union (access, cases, _), _),
                                        smd,
@@ -3111,7 +3138,12 @@ module internal ArgParserGenerator =
 
                 let spec, _ = unionToParseSpec [] None "" 0 ambient union
 
-                union.Name, typeHelp attrs, spec
+                let typeHelp =
+                    attrs
+                    |> SynAttributes.toAttrs
+                    |> helpTextAttribute $"type %s{union.Name.idText}"
+
+                union.Name, typeHelp, spec
             | _ ->
                 failwith
                     "[<ArgParser>] may only be placed on a record, or on a discriminated union whose cases each hold one record."

--- a/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
+++ b/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
@@ -1310,6 +1310,17 @@ module internal ArgParserGenerator =
             | Some enumDu -> createEnumParser enumDu, Accumulation.Required, ty
             | None -> failwith $"Could not decide how to parse arguments for field %s{fieldName.idText} of type %O{ty}"
 
+    /// The `[<ArgumentHelpText>]` carried here, if any. The same attribute serves a field, a nested
+    /// type, and the tagged root, so they all read it through this.
+    let private helpTextAttribute (attrs : SynAttribute list) : SynExpr option =
+        attrs
+        |> List.tryPick (fun attr ->
+            match (List.last attr.TypeName.LongIdent).idText with
+            | "ArgumentHelpTextAttribute"
+            | "ArgumentHelpText" -> Some attr.ArgExpr
+            | _ -> None
+        )
+
     /// The `[<ArgumentPrefix>]` this field carries, if any.
     let private prefixAttribute (attrs : SynAttribute list) : SynExpr option =
         attrs
@@ -1445,14 +1456,7 @@ module internal ArgParserGenerator =
                 // Kept separate from the `helpText` below, which folds in the parse format: a
                 // structural field's help introduces a whole group of arguments rather than
                 // describing one, so it must not pick up a leaf's parsing note.
-                let helpTextAttr =
-                    attrs
-                    |> List.tryPick (fun a ->
-                        match (List.last a.TypeName.LongIdent).idText with
-                        | "ArgumentHelpTextAttribute"
-                        | "ArgumentHelpText" -> Some a.ArgExpr
-                        | _ -> None
-                    )
+                let helpTextAttr = helpTextAttribute attrs
 
                 let helpText =
                     match parseExactModifier, helpTextAttr with
@@ -1546,10 +1550,14 @@ module internal ArgParserGenerator =
                 // help text introduces that group rather than describing a single argument. The
                 // group exists whether or not the author wrote any help: the reader must be able to
                 // see which arguments were declared together, exactly as for a union's cases.
-                let groupHeader =
+                //
+                // The field's own attribute wins over the nested type's, which is the fallback: one
+                // type may be nested at several sites, and the field is the more specific placement,
+                // so it is the one which can say what this occurrence is for.
+                let groupHeader (typeAttrs : SynAttribute list) : GroupHeader =
                     {
                         GroupHeader.Label = ident.idText
-                        GroupHeader.Help = helpTextAttr
+                        GroupHeader.Help = helpTextAttr |> Option.orElseWith (fun () -> helpTextAttribute typeAttrs)
                     }
 
                 match ambientRecordMatch with
@@ -1567,7 +1575,13 @@ module internal ArgParserGenerator =
                         | Some attrExpr -> extendPrefix ident prefix attrExpr
 
                     let spec, counter =
-                        toParseSpec ancestors (Some groupHeader) childPrefix counter ambient childRecord
+                        toParseSpec
+                            ancestors
+                            (Some (groupHeader childRecord.Attributes))
+                            childPrefix
+                            counter
+                            ambient
+                            childRecord
 
                     counter, (ident, spec) :: acc
                 | None ->
@@ -1586,7 +1600,13 @@ module internal ArgParserGenerator =
                         | Some attrExpr -> extendPrefix ident prefix attrExpr
 
                     let spec, counter =
-                        unionToParseSpec ancestors (Some groupHeader) childPrefix counter ambient union
+                        unionToParseSpec
+                            ancestors
+                            (Some (groupHeader union.Attributes))
+                            childPrefix
+                            counter
+                            ambient
+                            union
 
                     counter, (ident, spec) :: acc
                 | None ->
@@ -3042,14 +3062,7 @@ module internal ArgParserGenerator =
 
         let taggedTypeName, typeHelpText, parseSpec =
             let typeHelp (attrs : SynAttributes) =
-                attrs
-                |> SynAttributes.toAttrs
-                |> List.tryPick (fun a ->
-                    match (List.last a.TypeName.LongIdent).idText with
-                    | "ArgumentHelpTextAttribute"
-                    | "ArgumentHelpText" -> Some a.ArgExpr
-                    | _ -> None
-                )
+                attrs |> SynAttributes.toAttrs |> helpTextAttribute
 
             match taggedType with
             | SynTypeDefn.SynTypeDefn (SynComponentInfo.SynComponentInfo (attributes = attrs) as sci,

--- a/WoofWare.Myriad.Plugins/Test/TestArgParserRejection.fs
+++ b/WoofWare.Myriad.Plugins/Test/TestArgParserRejection.fs
@@ -1365,6 +1365,109 @@ type ComputedDefault =
         |> shouldRejectWith
             "Field 'Count' has an [<ArgumentDefaultValue>] whose value we do not recognise as a constant. We reproduce the value in the generated file rather than evaluating it at your attribute, so we accept only a literal written out in full (optionally parenthesised). Use [<ArgumentDefaultFunction>] for anything else: that function is evaluated in your own file."
 
+    /// `[<ArgumentHelpText>]` is reproduced in the generated file exactly as `[<ArgumentDefaultValue>]`
+    /// is, and for the same reason: the generated file hoists every `open` in the source above the
+    /// parser, so a bare name need not resolve to the same binding there as here. This checks every
+    /// placement the attribute can now reach: a leaf field, the field which names a nested record or
+    /// union, the nested type's own definition, and a union case.
+    [<Test>]
+    let ``ArgumentHelpText naming a constant is rejected on a leaf field`` () =
+        """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+[<ArgParser>]
+type Args =
+    {
+        [<ArgumentHelpText(Sentinel)>]
+        Count : int
+    }
+"""
+        |> shouldRejectWith
+            "The [<ArgumentHelpText>] on field 'Count' names something (Sentinel) rather than writing out a literal string. We reproduce the value in the generated file rather than evaluating it at your attribute, and that file hoists every `open` in your source above the parser, so the name need not resolve to the same binding there as here. Write the help text out as a literal string."
+
+    [<Test>]
+    let ``ArgumentHelpText naming a constant is rejected on a nested-record field`` () =
+        """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+type Child =
+    {
+        Thing : int
+    }
+
+[<ArgParser>]
+type Args =
+    {
+        [<ArgumentHelpText(Sentinel)>]
+        Child : Child
+    }
+"""
+        |> shouldRejectWith
+            "The [<ArgumentHelpText>] on field 'Child' names something (Sentinel) rather than writing out a literal string. We reproduce the value in the generated file rather than evaluating it at your attribute, and that file hoists every `open` in your source above the parser, so the name need not resolve to the same binding there as here. Write the help text out as a literal string."
+
+    [<Test>]
+    let ``ArgumentHelpText naming a constant is rejected on a nested type's own definition`` () =
+        """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+[<ArgumentHelpText(Sentinel)>]
+type Child =
+    {
+        Thing : int
+    }
+
+[<ArgParser>]
+type Args =
+    {
+        Child : Child
+    }
+"""
+        |> shouldRejectWith
+            "The [<ArgumentHelpText>] on type Child names something (Sentinel) rather than writing out a literal string. We reproduce the value in the generated file rather than evaluating it at your attribute, and that file hoists every `open` in your source above the parser, so the name need not resolve to the same binding there as here. Write the help text out as a literal string."
+
+    [<Test>]
+    let ``ArgumentHelpText naming a constant is rejected on a union case`` () =
+        """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+type TcpArgs =
+    {
+        Port : int
+    }
+
+[<ArgParser>]
+type Transport =
+    | [<ArgumentHelpText(Sentinel)>] Tcp of TcpArgs
+
+[<ArgParser>]
+type Args =
+    {
+        Transport : Transport
+    }
+"""
+        |> shouldRejectWith
+            "The [<ArgumentHelpText>] on case Tcp names something (Sentinel) rather than writing out a literal string. We reproduce the value in the generated file rather than evaluating it at your attribute, and that file hoists every `open` in your source above the parser, so the name need not resolve to the same binding there as here. Write the help text out as a literal string."
+
+    [<Test>]
+    let ``ArgumentHelpText naming a constant is rejected on the tagged root type`` () =
+        """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+[<ArgParser>]
+[<ArgumentHelpText(Sentinel)>]
+type Args =
+    {
+        Count : int
+    }
+"""
+        |> shouldRejectWith
+            "The [<ArgumentHelpText>] on type Args names something (Sentinel) rather than writing out a literal string. We reproduce the value in the generated file rather than evaluating it at your attribute, and that file hoists every `open` in your source above the parser, so the name need not resolve to the same binding there as here. Write the help text out as a literal string."
+
     // Exactly one source may supply a field's default. With two, the generator would have to
     // invent a precedence order which is invisible at the use site, so it refuses instead.
 


### PR DESCRIPTION
The type-level help lookup ran only against the `[<ArgParser>]`-tagged root, so an `[<ArgumentHelpText>]` on a nested argument record or union was silently ignored, despite the attribute documenting itself as applying to a record type generally. `RecordType.Attributes` and `UnionType.Attributes` were already to hand at the nesting site, but nothing was reading them.

The nested type's help now heads the group its arguments form, wherever that type is embedded:

```fsharp
[<ArgumentHelpText "How to talk to the database">]
type DescribedChild = { Host : string ; Port : int }

[<ArgParser true>]
type ParentRecordWithTypeHelp =
    {
        [<ArgumentPrefix "primary">]
        Primary : DescribedChild
        [<ArgumentPrefix "secondary">]
        [<ArgumentHelpText "Where to fail over to">]
        Secondary : DescribedChild
    }
```

```
Primary: How to talk to the database
  --primary-host  string
  --primary-port  int32
Secondary: Where to fail over to
  --secondary-host  string
  --secondary-port  int32
```

## Precedence

A field's own `[<ArgumentHelpText>]` overrides the one on the type it refers to. The field is the more specific placement, and one type may be embedded at several sites for different purposes, so it is the one which can say what a particular occurrence is for. The type-level text is the fallback that describes the type in general.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
