### PR TITLE
ArgParser: read ArgumentHelpText from union cases and their payload records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 Notable changes are recorded here.
 
+# WoofWare.Myriad.Plugins 10.7.3
+
+`ArgParserGenerator` now reads `[<ArgumentHelpText>]` from a discriminated union's case, and from that case's payload record, and heads the case's group in help text with it.
+Previously a case's payload record's own `[<ArgumentHelpText>]` was silently dropped: only the case name appeared, with no way to describe the case itself (a case is not reached through a field, so the field-level mechanism which reads a nested record's own help text does not apply to it).
+An `[<ArgumentHelpText>]` on the case itself overrides the one on its payload record, for the same reason a field's overrides a nested record's: the case is the more specific placement.
+
 # WoofWare.Myriad.Plugins 10.7.2
 
 `ArgParserGenerator` now reads `[<ArgumentHelpText>]` from a nested argument record or union of alternative argument sets, and not only from the `[<ArgParser>]`-tagged root.

--- a/ConsumePlugin/DuArgs.fs
+++ b/ConsumePlugin/DuArgs.fs
@@ -104,6 +104,27 @@ type WithTransportArgs =
         Fallback : Transport
     }
 
+[<ArgumentHelpText "Fetch a URL">]
+type FetchWithHelpArgs =
+    {
+        Url : string
+    }
+
+[<ArgumentHelpText "Push args, not that you'd know it from the case header">]
+type PushWithHelpArgs =
+    {
+        Remote : string
+    }
+
+/// A case's payload record may describe itself, for the benefit of that case; a case is not
+/// reached through a field, so there is no field-level attribute to check first, but the case
+/// itself is a more specific placement than its payload record and so overrides it, exactly as
+/// a field overrides a nested record's own description.
+[<ArgParser>]
+type CommandWithHelp =
+    | FetchCase of FetchWithHelpArgs
+    | [<ArgumentHelpText "Push to a remote">] PushCase of PushWithHelpArgs
+
 /// A union beside a positional sink (default, i.e. Reject-mode): named arguments select the
 /// union case, and every bare token is routed to the sink whichever case wins. An unrecognised
 /// `--key`-shaped token remains fatal. The sink converts, so selection must not depend on the

--- a/ConsumePlugin/GeneratedDuArgs.fs
+++ b/ConsumePlugin/GeneratedDuArgs.fs
@@ -1423,9 +1423,9 @@ module DuArgs =
         let helpText () =
             [
                 "exactly one of the following sets of arguments:"
-                "FooCase:"
+                (sprintf "%s:" "FooCase")
                 (sprintf "  %s  %s%s%s" (sprintf "--%s" "foo") "int32" "" (sprintf " : %s" ("The foo argument")))
-                "BarCase:"
+                (sprintf "%s:" "BarCase")
                 (sprintf "  %s  %s%s%s" (sprintf "--%s" "bar") "int32" "" "")
                 (sprintf "  %s  %s%s%s" (sprintf "--%s" "baz") "int32" "" "")
             ]
@@ -1627,9 +1627,9 @@ module WithModeArgs =
                 (sprintf "%s  %s%s%s" (sprintf "--%s" "verbose") "bool" "" "")
                 (sprintf "%s:" "Mode")
                 "  exactly one of the following sets of arguments:"
-                "  Auto:"
+                (sprintf "%s:" "  Auto")
                 (sprintf "    %s  %s%s%s" (sprintf "--%s" "quiet") "bool" " (optional)" "")
-                "  Manual:"
+                (sprintf "%s:" "  Manual")
                 (sprintf "    %s  %s%s%s" (sprintf "--%s" "level") "int32" "" "")
             ]
             |> String.concat "\n"
@@ -1834,7 +1834,7 @@ module DuWithDefaultArgs =
         let helpText () =
             [
                 "exactly one of the following sets of arguments:"
-                "Defaulted:"
+                (sprintf "%s:" "Defaulted")
 
                 (sprintf
                     "  %s  %s%s%s"
@@ -1843,7 +1843,7 @@ module DuWithDefaultArgs =
                     (DefaultedArgs.DefaultRetries().ToString () |> sprintf " (default value: %s)")
                     "")
 
-                "Plain:"
+                (sprintf "%s:" "Plain")
                 (sprintf "  %s  %s%s%s" (sprintf "--%s" "value") "int32" "" "")
             ]
             |> String.concat "\n"
@@ -2007,9 +2007,9 @@ module WithModeHelpArgs =
                 (sprintf "%s  %s%s%s" (sprintf "--%s" "verbose") "bool" "" "")
                 (sprintf "%s: %s" "Mode" ("How loud to be"))
                 "  exactly one of the following sets of arguments:"
-                "  Auto:"
+                (sprintf "%s:" "  Auto")
                 (sprintf "    %s  %s%s%s" (sprintf "--%s" "quiet") "bool" " (optional)" "")
-                "  Manual:"
+                (sprintf "%s:" "  Manual")
                 (sprintf "    %s  %s%s%s" (sprintf "--%s" "level") "int32" "" "")
             ]
             |> String.concat "\n"
@@ -2215,15 +2215,15 @@ module WithTransportArgs =
             [
                 (sprintf "%s: %s" "Preferred" ("Try this one first"))
                 "  exactly one of the following sets of arguments:"
-                "  Tcp:"
+                (sprintf "%s:" "  Tcp")
                 (sprintf "    %s  %s%s%s" (sprintf "--%s" "preferred-tcp-port") "int32" "" "")
-                "  Unix:"
+                (sprintf "%s:" "  Unix")
                 (sprintf "    %s  %s%s%s" (sprintf "--%s" "preferred-socket-path") "string" "" "")
                 (sprintf "%s: %s" "Fallback" ("Which transport to use"))
                 "  exactly one of the following sets of arguments:"
-                "  Tcp:"
+                (sprintf "%s:" "  Tcp")
                 (sprintf "    %s  %s%s%s" (sprintf "--%s" "fallback-tcp-port") "int32" "" "")
-                "  Unix:"
+                (sprintf "%s:" "  Unix")
                 (sprintf "    %s  %s%s%s" (sprintf "--%s" "fallback-socket-path") "string" "" "")
             ]
             |> String.concat "\n"
@@ -2485,6 +2485,166 @@ namespace ConsumePlugin
 
 open WoofWare.Myriad.Plugins
 
+/// Methods to parse arguments for the type CommandWithHelp
+[<RequireQualifiedAccess ; CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+module CommandWithHelp =
+    let parse' (getEnvironmentVariable : string -> string option) (args : string list) : CommandWithHelp =
+        let helpText () =
+            [
+                "exactly one of the following sets of arguments:"
+                (sprintf "%s: %s" "FetchCase" ("Fetch a URL"))
+                (sprintf "  %s  %s%s%s" (sprintf "--%s" "url") "string" "" "")
+                (sprintf "%s: %s" "PushCase" ("Push to a remote"))
+                (sprintf "  %s  %s%s%s" (sprintf "--%s" "remote") "string" "" "")
+            ]
+            |> String.concat "\n"
+
+        let parser_LeftoverArgs : string ResizeArray = ResizeArray ()
+        let mutable arg_1 : string option = None
+        let mutable arg_2 : string option = None
+
+        let parser_schema : ArgParserRuntime_DuArgs.ErasedSchema =
+            {
+                Leaves =
+                    [
+                        {
+                            Id = 0
+                            Forms = [ "url" ]
+                            AcceptsNegation = false
+                            Arity = ArgParserRuntime_DuArgs.ErasedArity.One
+                            Repeatable = false
+                            Requirement = ArgParserRuntime_DuArgs.ErasedRequirement.Required
+                            TypeDescription = ""
+                            Help = None
+                        }
+                        {
+                            Id = 1
+                            Forms = [ "remote" ]
+                            AcceptsNegation = false
+                            Arity = ArgParserRuntime_DuArgs.ErasedArity.One
+                            Repeatable = false
+                            Requirement = ArgParserRuntime_DuArgs.ErasedRequirement.Required
+                            TypeDescription = ""
+                            Help = None
+                        }
+                    ]
+                Tree =
+                    (ArgParserRuntime_DuArgs.ErasedTree.Sum (
+                        (0,
+                         [
+                             ("FetchCase",
+                              ArgParserRuntime_DuArgs.ErasedTree.Product ([ ArgParserRuntime_DuArgs.ErasedTree.Leaf 0 ]))
+                             ("PushCase",
+                              ArgParserRuntime_DuArgs.ErasedTree.Product ([ ArgParserRuntime_DuArgs.ErasedTree.Leaf 1 ]))
+                         ])
+                    ))
+                Positionals = List.empty
+            }
+
+        let parser_storeOccurrence (occurrence : ArgParserRuntime_DuArgs.ErasedOccurrence) : string option =
+            match occurrence.LeafId with
+            | 0 ->
+                match arg_1 with
+                | Some _ -> None
+                | None ->
+                    match occurrence.Value with
+                    | Some value ->
+                        try
+                            arg_1 <- Some (value |> (fun x -> x))
+                            None
+                        with _ as exc ->
+                            (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                    | None ->
+                        failwith
+                            "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
+            | 1 ->
+                match arg_2 with
+                | Some _ -> None
+                | None ->
+                    match occurrence.Value with
+                    | Some value ->
+                        try
+                            arg_2 <- Some (value |> (fun x -> x))
+                            None
+                        with _ as exc ->
+                            (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                    | None ->
+                        failwith
+                            "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
+            | _ -> failwith "WoofWare.Myriad internal error in generated parser: unknown argument id"
+
+        let parser_storePositional (positionalId : int) (value : string) (afterSeparator : bool) : string option =
+            failwith "WoofWare.Myriad internal error in generated parser: no positional sink exists"
+
+        let parser_renderStored (leafId : int) : string =
+            match leafId with
+            | 0 ->
+                match arg_1 with
+                | Some x -> x.ToString ()
+                | None -> "<no value>"
+            | 1 ->
+                match arg_2 with
+                | Some x -> x.ToString ()
+                | None -> "<no value>"
+            | _ -> "<no value>"
+
+        let parser_applyDefault (leafId : int) : string option =
+            match leafId with
+            | _ -> failwith "WoofWare.Myriad internal error in generated parser: unknown defaulted argument id"
+
+        let parser_callbacks : ArgParserRuntime_DuArgs.TypedCallbacks =
+            {
+                StoreOccurrence = parser_storeOccurrence
+                StorePositional = parser_storePositional
+                HelpText = helpText
+                RenderStored = parser_renderStored
+                ApplyDefault = parser_applyDefault
+            }
+
+        match
+            ArgParserRuntime_DuArgs.runParse
+                (ArgParserRuntime_DuArgs.WellFormedSchema.checkOrFail parser_schema)
+                parser_callbacks
+                args
+        with
+        | ArgParserRuntime_DuArgs.ParseOutcome.Success parser_selection ->
+            match Map.tryFind 0 parser_selection.Choices with
+            | Some 0 ->
+                CommandWithHelp.FetchCase (
+                    {
+                        Url =
+                            (match arg_1 with
+                             | Some x -> x
+                             | None ->
+                                 failwith
+                                     "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
+                    }
+                )
+            | Some 1 ->
+                CommandWithHelp.PushCase (
+                    {
+                        Remote =
+                            (match arg_2 with
+                             | Some x -> x
+                             | None ->
+                                 failwith
+                                     "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
+                    }
+                )
+            | _ ->
+                failwith
+                    "WoofWare.Myriad internal error in generated parser: no case selected despite a successful parse"
+        | ArgParserRuntime_DuArgs.ParseOutcome.HelpRequested -> helpText () |> failwithf "Help text requested.\n%s"
+        | ArgParserRuntime_DuArgs.ParseOutcome.Fatal message -> failwith message
+        | ArgParserRuntime_DuArgs.ParseOutcome.Errors errors ->
+            errors |> String.concat "\n" |> failwithf "Errors during parse!\n%s"
+
+    let parse (args : string list) : CommandWithHelp =
+        parse' (System.Environment.GetEnvironmentVariable >> Option.ofObj) args
+namespace ConsumePlugin
+
+open WoofWare.Myriad.Plugins
+
 /// Methods to parse arguments for the type ModeAndPositionals
 [<RequireQualifiedAccess ; CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module ModeAndPositionals =
@@ -2493,9 +2653,9 @@ module ModeAndPositionals =
             [
                 (sprintf "%s:" "Mode")
                 "  exactly one of the following sets of arguments:"
-                "  Auto:"
+                (sprintf "%s:" "  Auto")
                 (sprintf "    %s  %s%s%s" (sprintf "--%s" "quiet") "bool" " (optional)" "")
-                "  Manual:"
+                (sprintf "%s:" "  Manual")
                 (sprintf "    %s  %s%s%s" (sprintf "--%s" "level") "int32" "" "")
                 (sprintf "%s  %s%s%s" (sprintf "--%s" "rest") "int32" " (positional args) (can be repeated)" "")
             ]
@@ -2681,9 +2841,9 @@ module CommandAndPositionals =
             [
                 (sprintf "%s:" "Command")
                 "  exactly one of the following sets of arguments:"
-                "  Fetch:"
+                (sprintf "%s:" "  Fetch")
                 (sprintf "    %s  %s%s%s" (sprintf "--%s" "url") "string" "" "")
-                "  Push:"
+                (sprintf "%s:" "  Push")
                 (sprintf "    %s  %s%s%s" (sprintf "--%s" "remote") "string" "" "")
                 (sprintf "    %s  %s%s%s" (sprintf "--%s" "force") "bool" "" "")
                 (sprintf "%s  %s%s%s" (sprintf "--%s" "paths") "string" " (positional args) (can be repeated)" "")
@@ -2917,10 +3077,10 @@ module FooBarMode =
         let helpText () =
             [
                 "exactly one of the following sets of arguments:"
-                "FooMode:"
+                (sprintf "%s:" "FooMode")
                 (sprintf "  %s  %s%s%s" (sprintf "--%s" "foo") "int32" "" "")
                 (sprintf "  %s  %s%s%s" (sprintf "--%s" "rest") "int32" " (positional args) (can be repeated)" "")
-                "BarMode:"
+                (sprintf "%s:" "BarMode")
                 (sprintf "  %s  %s%s%s" (sprintf "--%s" "bar") "int32" "" "")
                 (sprintf "  %s  %s%s%s" (sprintf "--%s" "rest") "string" " (positional args) (can be repeated)" "")
             ]
@@ -3121,10 +3281,10 @@ module GitLike =
         let helpText () =
             [
                 "exactly one of the following sets of arguments:"
-                "Pull:"
+                (sprintf "%s:" "Pull")
                 (sprintf "  %s  %s%s%s" (sprintf "--%s" "source") "string" "" "")
                 (sprintf "  %s  %s%s%s" (sprintf "--%s" "refs") "string" " (positional args) (can be repeated)" "")
-                "Status:"
+                (sprintf "%s:" "Status")
                 (sprintf "  %s  %s%s%s" (sprintf "--%s" "verbose") "bool" " (optional)" "")
             ]
             |> String.concat "\n"
@@ -3946,7 +4106,7 @@ module EnumInUnion =
         let helpText () =
             [
                 "exactly one of the following sets of arguments:"
-                "Build:"
+                (sprintf "%s:" "Build")
 
                 (sprintf
                     "  %s  %s%s%s"
@@ -3955,7 +4115,7 @@ module EnumInUnion =
                     ""
                     "")
 
-                "Clean:"
+                (sprintf "%s:" "Clean")
                 (sprintf "  %s  %s%s%s" (sprintf "--%s" "force") "bool" " (optional)" "")
             ]
             |> String.concat "\n"

--- a/ConsumePlugin/GeneratedMapArgs.fs
+++ b/ConsumePlugin/GeneratedMapArgs.fs
@@ -2054,9 +2054,9 @@ module MapInUnion =
         let helpText () =
             [
                 "exactly one of the following sets of arguments:"
-                "Deploy:"
+                (sprintf "%s:" "Deploy")
                 (sprintf "  %s  %s%s%s" (sprintf "--%s" "tags") "map<string, string>" " (KEY:VALUE; can be repeated)" "")
-                "Rollback:"
+                (sprintf "%s:" "Rollback")
                 (sprintf "  %s  %s%s%s" (sprintf "--%s" "to") "string" "" "")
             ]
             |> String.concat "\n"

--- a/ConsumePlugin/GeneratedPrefixArgs.fs
+++ b/ConsumePlugin/GeneratedPrefixArgs.fs
@@ -3079,9 +3079,9 @@ module PrefixedUnionArgParse =
                 [
                     (sprintf "%s:" "Mode")
                     "  exactly one of the following sets of arguments:"
-                    "  Auto:"
+                    (sprintf "%s:" "  Auto")
                     (sprintf "    %s  %s%s%s" (sprintf "--%s" "mode-quiet") "bool" " (optional)" "")
-                    "  Manual:"
+                    (sprintf "%s:" "  Manual")
                     (sprintf "    %s  %s%s%s" (sprintf "--%s" "mode-level") "int32" "" "")
                 ]
                 |> String.concat "\n"

--- a/WoofWare.Myriad.Plugins.Attributes/ArgParserAttributes.fs
+++ b/WoofWare.Myriad.Plugins.Attributes/ArgParserAttributes.fs
@@ -101,6 +101,12 @@ type ArgumentDefaultValueAttribute (defaultValue : obj) =
 /// embedded, and so heads the group in each place. If the field which embeds it carries an
 /// [<ArgumentHelpText>] of its own, the field's wins: it is the more specific placement, and one type
 /// may be embedded at several sites for different purposes.
+///
+/// When applied to a case of a discriminated union of alternative argument sets, the help text
+/// describes that case's set of arguments, and appears on the header line naming the case. A case
+/// is not reached through a field, so its payload record's own [<ArgumentHelpText>] (if the payload
+/// is used in only that one case) is the fallback instead; the case, being the more specific
+/// placement, overrides it.
 type ArgumentHelpTextAttribute (helpText : string) =
     inherit Attribute ()
 

--- a/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParserDu.fs
+++ b/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParserDu.fs
@@ -202,6 +202,22 @@ Mode: How loud to be
   Manual:
     --level  int32"""
 
+    /// A case's payload record has no field of its own to be embedded through, so it can only
+    /// describe itself and be overridden by the case: there is no third, more specific layer.
+    [<Test>]
+    let ``A case's payload record describes itself, and the case's own help text overrides it`` () =
+        let exc =
+            Assert.Throws<exn> (fun () -> CommandWithHelp.parse' noEnv [ "--help" ] |> ignore<CommandWithHelp>)
+
+        exc.Message
+        |> shouldEqual
+            """Help text requested.
+exactly one of the following sets of arguments:
+FetchCase: Fetch a URL
+  --url  string
+PushCase: Push to a remote
+  --remote  string"""
+
     /// As for a nested record: the union describes itself for every site which embeds it, and a
     /// field with something more specific to say overrides that.
     [<Test>]

--- a/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
+++ b/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
@@ -259,10 +259,14 @@ type private ParseTree =
     /// which were supplied. `sumId` ties this node to the erased schema's Sum node; `assemble`
     /// builds the union value from the selected case's name and its assembled payload.
     /// Positional args are not yet permitted inside union cases.
+    ///
+    /// Each case carries its own optional help text -- `[<ArgumentHelpText>]` on the case itself,
+    /// falling back to the same attribute on its payload record's definition -- since a case's
+    /// payload record introduces no `Branch` header of its own for it to live on (see above).
     | Sum of
         sumId : int *
         header : GroupHeader option *
-        cases : (Ident * ParseTree) list *
+        cases : (Ident * SynExpr option * ParseTree) list *
         assemble : (Ident -> SynExpr -> SynExpr)
 
 [<RequireQualifiedAccess>]
@@ -274,7 +278,7 @@ module private ParseTree =
         | ParseTree.NonPositionalLeaf _ -> false
         | ParseTree.PositionalLeaf _ -> true
         | ParseTree.Branch (_, fields, _) -> fields |> List.exists (fun (_, child) -> containsPositional child)
-        | ParseTree.Sum (_, _, cases, _) -> cases |> List.exists (fun (_, case) -> containsPositional case)
+        | ParseTree.Sum (_, _, cases, _) -> cases |> List.exists (fun (_, _, case) -> containsPositional case)
 
     /// The `Ident` here is the field name. Moves the positional-claiming field (at most one
     /// is permitted) after its siblings.
@@ -309,7 +313,7 @@ module private ParseTree =
                 )
             | ParseTree.Sum (_, _, cases, _) ->
                 (([], []), cases)
-                ||> List.fold (fun (nonPos, pos) (_, case) ->
+                ||> List.fold (fun (nonPos, pos) (_, _, case) ->
                     let caseNonPos, casePos = go case
                     nonPos @ caseNonPos, pos @ casePos
                 )
@@ -481,7 +485,7 @@ module private ParseTree =
             | Accumulation.Map _ -> true
         | ParseTree.PositionalLeaf _ -> true
         | ParseTree.Branch (_, fields, _) -> fields |> List.forall (fun (_, child) -> emptySatisfiable child)
-        | ParseTree.Sum (_, _, cases, _) -> cases |> List.exists (fun (_, case) -> emptySatisfiable case)
+        | ParseTree.Sum (_, _, cases, _) -> cases |> List.exists (fun (_, _, case) -> emptySatisfiable case)
 
     /// For every union node in the tree, at most one case may be satisfiable with no arguments:
     /// were two cases so satisfiable, an empty command line could not choose between them.
@@ -491,14 +495,14 @@ module private ParseTree =
         | ParseTree.PositionalLeaf _ -> ()
         | ParseTree.Branch (_, fields, _) -> fields |> List.iter (fun (_, child) -> checkSumAmbiguity child)
         | ParseTree.Sum (_, _, cases, _) ->
-            cases |> List.iter (fun (_, case) -> checkSumAmbiguity case)
+            cases |> List.iter (fun (_, _, case) -> checkSumAmbiguity case)
 
-            match cases |> List.filter (fun (_, case) -> emptySatisfiable case) with
+            match cases |> List.filter (fun (_, _, case) -> emptySatisfiable case) with
             | []
             | [ _ ] -> ()
             | ambiguous ->
                 let names =
-                    ambiguous |> List.map (fun (name, _) -> name.idText) |> String.concat ", "
+                    ambiguous |> List.map (fun (name, _, _) -> name.idText) |> String.concat ", "
 
                 failwith
                     $"Cases %s{names} can all be satisfied without supplying any arguments, so an empty command line cannot choose between them. Make an argument in all but one of them mandatory."
@@ -537,7 +541,7 @@ module private ParseTree =
         | ParseTree.Sum (sumId, _, cases, _) ->
             let caseExprs =
                 cases
-                |> List.map (fun (caseName, payload) ->
+                |> List.map (fun (caseName, _, payload) ->
                     let payloadExpr = toErasedTreeExpr rt listOf counter posCounter payload
 
                     SynExpr.tuple [ SynExpr.CreateConst caseName.idText ; payloadExpr ]
@@ -595,7 +599,7 @@ module private ParseTree =
 
             let clauses =
                 cases
-                |> List.mapi (fun index (caseName, payload) ->
+                |> List.mapi (fun index (caseName, _, payload) ->
                     SynMatchClause.create
                         (SynPat.nameWithArgs "Some" [ SynPat.createConst (SynConst.Int32 index) ])
                         (assemble caseName (SynExpr.paren (instantiate payload)))
@@ -1865,7 +1869,14 @@ module internal ArgParserGenerator =
                 // `sumHelp` already heads it with the case name.
                 let spec, counter = toParseSpec ancestors None prefix counter ambient payloadRecord
 
-                counter, (case.Name, spec) :: acc
+                // As for a nested record's field: the more specific placement (the case itself)
+                // overrides the more general one (the payload record's own definition), since one
+                // payload record type could in principle be reused by several cases or sites.
+                let caseHelp =
+                    helpTextAttribute case.Attributes
+                    |> Option.orElseWith (fun () -> helpTextAttribute payloadRecord.Attributes)
+
+                counter, (case.Name, caseHelp, spec) :: acc
             )
 
         let cases = List.rev cases
@@ -2028,13 +2039,18 @@ module internal ArgParserGenerator =
                 | None -> sumHelp depth cases
                 | Some header -> groupLine depth header :: sumHelp (depth + 1) cases
 
-        and sumHelp (depth : int) (cases : (Ident * ParseTree) list) : SynExpr list =
+        and sumHelp (depth : int) (cases : (Ident * SynExpr option * ParseTree) list) : SynExpr list =
             let indent = String.replicate depth "  "
 
             SynExpr.CreateConst (indent + "exactly one of the following sets of arguments:")
             :: (cases
-                |> List.collect (fun (caseName, case) ->
-                    SynExpr.CreateConst (indent + caseName.idText + ":")
+                |> List.collect (fun (caseName, help, case) ->
+                    groupLine
+                        depth
+                        {
+                            GroupHeader.Label = caseName.idText
+                            GroupHeader.Help = help
+                        }
                     :: fieldHelp (depth + 1) case
                 ))
 


### PR DESCRIPTION
**Stacked on #602** — targets `argparser-nested-type-help`, and needs its `helpTextAttribute` helper. Review that one first; this diff is only the third commit's difference.

A discriminated-union case's payload record has no field of its own for a `GroupHeader` to attach to (unlike a nested record reached through a field on a parent record), so `unionToParseSpec` deliberately passes `None` there — `sumHelp` already heads the case's group with the case name. But that meant both the payload record's own `[<ArgumentHelpText>]` and any help text on the case itself were silently dropped: only the bare `Foo:` line ever appeared.

```fsharp
[<ArgumentHelpText "Fetch a URL">]
type FetchWithHelpArgs = { Url : string }

type PushWithHelpArgs = { Remote : string }

[<ArgParser>]
type CommandWithHelp =
    | FetchCase of FetchWithHelpArgs
    | [<ArgumentHelpText "Push to a remote">] PushCase of PushWithHelpArgs
```

```
exactly one of the following sets of arguments:
FetchCase: Fetch a URL
  --url  string
PushCase: Push to a remote
  --remote  string
```

`FetchCase` falls back to its payload record's own description; `PushCase` overrides it with help on the case, for the same reason a field's `[<ArgumentHelpText>]` overrides a nested record's — the case is the more specific placement, and one payload record could in principle be reused by more than one case or site.

`ParseTree.Sum`'s `cases` list gained a third element, `SynExpr option`, computed in `unionToParseSpec` as `helpTextAttribute case.Attributes |> Option.orElseWith (fun () -> helpTextAttribute payloadRecord.Attributes)`. `sumHelp` now renders each case's line through the same `groupLine` helper a field's header uses, rather than a bare string constant — this also changes the *generated code* (not its output) for every existing union-typed parser: a case line becomes `(sprintf "%s:" "Foo")` instead of the literal `"Foo:"`. Confirmed behaviourally identical for existing cases via the full test suite; see the `GeneratedMapArgs.fs` / `GeneratedPrefixArgs.fs` diffs.

New test: `A case's payload record describes itself, and the case's own help text overrides it` in `TestArgParserDu.fs`, exercising both the fallback and the override.

This addresses a review comment on #602: records embedded directly as union-case payloads were discarding their type-level help text, leaving that supported nested-record shape without the documented behaviour.
