### PR TITLE
ArgParser: backtick a record field name when constructing the parsed record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 Notable changes are recorded here.
 
+# WoofWare.Myriad.Plugins 10.7.3
+
+`ArgParserGenerator` now correctly backticks a record field name, if it needs backticks, when reproducing it in the expression which constructs that record at runtime.
+Previously the name was reproduced as a plain identifier regardless, so a field such as `` ``back tab`` `` (declared with backticks because its name is not a plain identifier) reached the generated file unbackticked, and the generated file did not compile.
+
 # WoofWare.Myriad.Plugins 10.7.2
 
 `ArgParserGenerator` now reads `[<ArgumentHelpText>]` from a nested argument record or union of alternative argument sets, and not only from the `[<ArgParser>]`-tagged root, and from a discriminated union's case (and that case's payload record).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,5 @@
 Notable changes are recorded here.
 
-# WoofWare.Myriad.Plugins 10.7.3
-
-`ArgParserGenerator` now correctly backticks a record field name, if it needs backticks, when reproducing it in the expression which constructs that record at runtime.
-Previously the name was reproduced as a plain identifier regardless, so a field such as `` ``back tab`` `` (declared with backticks because its name is not a plain identifier) reached the generated file unbackticked, and the generated file did not compile.
-
 # WoofWare.Myriad.Plugins 10.7.2
 
 `ArgParserGenerator` now reads `[<ArgumentHelpText>]` from a nested argument record or union of alternative argument sets, and not only from the `[<ArgParser>]`-tagged root, and from a discriminated union's case (and that case's payload record).

--- a/ConsumePlugin/Args.fs
+++ b/ConsumePlugin/Args.fs
@@ -396,15 +396,17 @@ type NonPositionalBoolList =
 /// constructs this type at runtime, and that reconstruction needs the backticks re-added for
 /// exactly the same reason the declaration did, or the generated file does not parse.
 ///
-/// `` ``_`` `` and `` ``|A|_|`` `` are here because the general-purpose backtick-normaliser the
-/// generator uses treats a bare `_` and a bare active-pattern-shaped name as already fine (they are
-/// meaningful bare tokens elsewhere in F#'s grammar -- the wildcard pattern and an active-pattern
-/// reference), but neither is a valid bare record label, so both need forcing into backticks by a
-/// narrower, record-label-specific check.
+/// Every field beyond `` ``back\tab`` `` here is a shape F#'s lexer treats as a meaningful bare
+/// token in some *other* grammar position, so a naive "does this need backticks" check keeps being
+/// wrong about it: `` ``_`` `` is the wildcard pattern, `` ``|A|_|`` `` is an active-pattern name,
+/// `` ``mod`` `` is a word-form operator keyword, and `` ``__LINE__`` `` is a context-sensitive
+/// constant. None of them is a valid bare record label.
 [<ArgParser true>]
 type AwkwardFieldName =
     {
         ``back\tab`` : ChildRecord
         ``_`` : int
         ``|A|_|`` : int
+        ``mod`` : int
+        ``__LINE__`` : int
     }

--- a/ConsumePlugin/Args.fs
+++ b/ConsumePlugin/Args.fs
@@ -390,3 +390,13 @@ type NonPositionalBoolList =
     {
         Flags : bool list
     }
+
+/// A record field's name must be a plain identifier at its declaration, or carry backticks; the
+/// generator reconstructs the same name as an `Ident` when it builds the expression that
+/// constructs this type at runtime, and that reconstruction needs the backticks re-added for
+/// exactly the same reason the declaration did, or the generated file does not parse.
+[<ArgParser true>]
+type AwkwardFieldName =
+    {
+        ``back\tab`` : ChildRecord
+    }

--- a/ConsumePlugin/Args.fs
+++ b/ConsumePlugin/Args.fs
@@ -399,8 +399,10 @@ type NonPositionalBoolList =
 /// Every field beyond `` ``back\tab`` `` here is a shape F#'s lexer treats as a meaningful bare
 /// token in some *other* grammar position, so a naive "does this need backticks" check keeps being
 /// wrong about it: `` ``_`` `` is the wildcard pattern, `` ``|A|_|`` `` is an active-pattern name,
-/// `` ``mod`` `` is a word-form operator keyword, and `` ``__LINE__`` `` is a context-sensitive
-/// constant. None of them is a valid bare record label.
+/// `` ``mod`` `` is a word-form operator keyword, `` ``__LINE__`` `` is a context-sensitive
+/// constant, and `` ``break`` `` is a word reserved "for future use" that parses bare but warns
+/// (FS0046) -- an error under `--warnaserror`, which this repo enables. None of them is a valid
+/// bare record label.
 [<ArgParser true>]
 type AwkwardFieldName =
     {
@@ -409,4 +411,5 @@ type AwkwardFieldName =
         ``|A|_|`` : int
         ``mod`` : int
         ``__LINE__`` : int
+        ``break`` : int
     }

--- a/ConsumePlugin/Args.fs
+++ b/ConsumePlugin/Args.fs
@@ -395,8 +395,16 @@ type NonPositionalBoolList =
 /// generator reconstructs the same name as an `Ident` when it builds the expression that
 /// constructs this type at runtime, and that reconstruction needs the backticks re-added for
 /// exactly the same reason the declaration did, or the generated file does not parse.
+///
+/// `` ``_`` `` and `` ``|A|_|`` `` are here because the general-purpose backtick-normaliser the
+/// generator uses treats a bare `_` and a bare active-pattern-shaped name as already fine (they are
+/// meaningful bare tokens elsewhere in F#'s grammar -- the wildcard pattern and an active-pattern
+/// reference), but neither is a valid bare record label, so both need forcing into backticks by a
+/// narrower, record-label-specific check.
 [<ArgParser true>]
 type AwkwardFieldName =
     {
         ``back\tab`` : ChildRecord
+        ``_`` : int
+        ``|A|_|`` : int
     }

--- a/ConsumePlugin/GeneratedArgs.fs
+++ b/ConsumePlugin/GeneratedArgs.fs
@@ -7707,6 +7707,7 @@ module AwkwardFieldNameArgParse =
                     (sprintf "%s  %s%s%s" (sprintf "--%s" "|-a|_|") "int32" "" "")
                     (sprintf "%s  %s%s%s" (sprintf "--%s" "mod") "int32" "" "")
                     (sprintf "%s  %s%s%s" (sprintf "--%s" "__-l-i-n-e__") "int32" "" "")
+                    (sprintf "%s  %s%s%s" (sprintf "--%s" "break") "int32" "" "")
                 ]
                 |> String.concat "\n"
 
@@ -7717,6 +7718,7 @@ module AwkwardFieldNameArgParse =
             let mutable arg_3 : int option = None
             let mutable arg_4 : int option = None
             let mutable arg_5 : int option = None
+            let mutable arg_6 : int option = None
 
             let parser_schema : ArgParserRuntime_BasicNoPositionals.ErasedSchema =
                 {
@@ -7776,9 +7778,20 @@ module AwkwardFieldNameArgParse =
                                 TypeDescription = ""
                                 Help = None
                             }
+
                             {
                                 Id = 5
                                 Forms = [ "__-l-i-n-e__" ]
+                                AcceptsNegation = false
+                                Arity = ArgParserRuntime_BasicNoPositionals.ErasedArity.One
+                                Repeatable = false
+                                Requirement = ArgParserRuntime_BasicNoPositionals.ErasedRequirement.Required
+                                TypeDescription = ""
+                                Help = None
+                            }
+                            {
+                                Id = 6
+                                Forms = [ "break" ]
                                 AcceptsNegation = false
                                 Arity = ArgParserRuntime_BasicNoPositionals.ErasedArity.One
                                 Repeatable = false
@@ -7801,6 +7814,7 @@ module AwkwardFieldNameArgParse =
                                 ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 3
                                 ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 4
                                 ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 5
+                                ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 6
                             ]
                         ))
                     Positionals = List.empty
@@ -7895,6 +7909,20 @@ module AwkwardFieldNameArgParse =
                         | None ->
                             failwith
                                 "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
+                | 6 ->
+                    match arg_6 with
+                    | Some _ -> None
+                    | None ->
+                        match occurrence.Value with
+                        | Some value ->
+                            try
+                                arg_6 <- Some (value |> (fun x -> System.Int32.Parse x))
+                                None
+                            with _ as exc ->
+                                (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                        | None ->
+                            failwith
+                                "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
                 | _ -> failwith "WoofWare.Myriad internal error in generated parser: unknown argument id"
 
             let parser_storePositional (positionalId : int) (value : string) (afterSeparator : bool) : string option =
@@ -7924,6 +7952,10 @@ module AwkwardFieldNameArgParse =
                     | None -> "<no value>"
                 | 5 ->
                     match arg_5 with
+                    | Some x -> x.ToString ()
+                    | None -> "<no value>"
+                | 6 ->
+                    match arg_6 with
                     | Some x -> x.ToString ()
                     | None -> "<no value>"
                 | _ -> "<no value>"
@@ -7976,6 +8008,12 @@ module AwkwardFieldNameArgParse =
                                      failwith
                                          "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
                         }
+                    ``break`` =
+                        (match arg_6 with
+                         | Some x -> x
+                         | None ->
+                             failwith
+                                 "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
                     ``mod`` =
                         (match arg_4 with
                          | Some x -> x

--- a/ConsumePlugin/GeneratedArgs.fs
+++ b/ConsumePlugin/GeneratedArgs.fs
@@ -7681,3 +7681,166 @@ module NonPositionalBoolList =
 
     let parse (args : string list) : NonPositionalBoolList =
         parse' (System.Environment.GetEnvironmentVariable >> Option.ofObj) args
+namespace ConsumePlugin
+
+open System
+open System.IO
+open WoofWare.Myriad.Plugins
+
+/// Methods to parse arguments for the type AwkwardFieldName
+[<AutoOpen>]
+module AwkwardFieldNameArgParse =
+    /// Extension methods for argument parsing
+    type AwkwardFieldName with
+
+        static member parse'
+            (getEnvironmentVariable : string -> string option)
+            (args : string list)
+            : AwkwardFieldName
+            =
+            let helpText () =
+                [
+                    (sprintf "%s:" "back\\tab")
+                    (sprintf "  %s  %s%s%s" (sprintf "--%s" "thing1") "int32" "" "")
+                    (sprintf "  %s  %s%s%s" (sprintf "--%s" "thing2") "string" "" "")
+                ]
+                |> String.concat "\n"
+
+            let parser_LeftoverArgs : string ResizeArray = ResizeArray ()
+            let mutable arg_0 : int option = None
+            let mutable arg_1 : string option = None
+
+            let parser_schema : ArgParserRuntime_BasicNoPositionals.ErasedSchema =
+                {
+                    Leaves =
+                        [
+                            {
+                                Id = 0
+                                Forms = [ "thing1" ]
+                                AcceptsNegation = false
+                                Arity = ArgParserRuntime_BasicNoPositionals.ErasedArity.One
+                                Repeatable = false
+                                Requirement = ArgParserRuntime_BasicNoPositionals.ErasedRequirement.Required
+                                TypeDescription = ""
+                                Help = None
+                            }
+                            {
+                                Id = 1
+                                Forms = [ "thing2" ]
+                                AcceptsNegation = false
+                                Arity = ArgParserRuntime_BasicNoPositionals.ErasedArity.One
+                                Repeatable = false
+                                Requirement = ArgParserRuntime_BasicNoPositionals.ErasedRequirement.Required
+                                TypeDescription = ""
+                                Help = None
+                            }
+                        ]
+                    Tree =
+                        (ArgParserRuntime_BasicNoPositionals.ErasedTree.Product (
+                            [
+                                ArgParserRuntime_BasicNoPositionals.ErasedTree.Product (
+                                    [
+                                        ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 0
+                                        ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 1
+                                    ]
+                                )
+                            ]
+                        ))
+                    Positionals = List.empty
+                }
+
+            let parser_storeOccurrence
+                (occurrence : ArgParserRuntime_BasicNoPositionals.ErasedOccurrence)
+                : string option
+                =
+                match occurrence.LeafId with
+                | 0 ->
+                    match arg_0 with
+                    | Some _ -> None
+                    | None ->
+                        match occurrence.Value with
+                        | Some value ->
+                            try
+                                arg_0 <- Some (value |> (fun x -> System.Int32.Parse x))
+                                None
+                            with _ as exc ->
+                                (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                        | None ->
+                            failwith
+                                "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
+                | 1 ->
+                    match arg_1 with
+                    | Some _ -> None
+                    | None ->
+                        match occurrence.Value with
+                        | Some value ->
+                            try
+                                arg_1 <- Some (value |> (fun x -> x))
+                                None
+                            with _ as exc ->
+                                (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                        | None ->
+                            failwith
+                                "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
+                | _ -> failwith "WoofWare.Myriad internal error in generated parser: unknown argument id"
+
+            let parser_storePositional (positionalId : int) (value : string) (afterSeparator : bool) : string option =
+                failwith "WoofWare.Myriad internal error in generated parser: no positional sink exists"
+
+            let parser_renderStored (leafId : int) : string =
+                match leafId with
+                | 0 ->
+                    match arg_0 with
+                    | Some x -> x.ToString ()
+                    | None -> "<no value>"
+                | 1 ->
+                    match arg_1 with
+                    | Some x -> x.ToString ()
+                    | None -> "<no value>"
+                | _ -> "<no value>"
+
+            let parser_applyDefault (leafId : int) : string option =
+                match leafId with
+                | _ -> failwith "WoofWare.Myriad internal error in generated parser: unknown defaulted argument id"
+
+            let parser_callbacks : ArgParserRuntime_BasicNoPositionals.TypedCallbacks =
+                {
+                    StoreOccurrence = parser_storeOccurrence
+                    StorePositional = parser_storePositional
+                    HelpText = helpText
+                    RenderStored = parser_renderStored
+                    ApplyDefault = parser_applyDefault
+                }
+
+            match
+                ArgParserRuntime_BasicNoPositionals.runParse
+                    (ArgParserRuntime_BasicNoPositionals.WellFormedSchema.checkOrFail parser_schema)
+                    parser_callbacks
+                    args
+            with
+            | ArgParserRuntime_BasicNoPositionals.ParseOutcome.Success parser_selection ->
+                {
+                    ``back\tab`` =
+                        {
+                            Thing1 =
+                                (match arg_0 with
+                                 | Some x -> x
+                                 | None ->
+                                     failwith
+                                         "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
+                            Thing2 =
+                                (match arg_1 with
+                                 | Some x -> x
+                                 | None ->
+                                     failwith
+                                         "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
+                        }
+                }
+            | ArgParserRuntime_BasicNoPositionals.ParseOutcome.HelpRequested ->
+                helpText () |> failwithf "Help text requested.\n%s"
+            | ArgParserRuntime_BasicNoPositionals.ParseOutcome.Fatal message -> failwith message
+            | ArgParserRuntime_BasicNoPositionals.ParseOutcome.Errors errors ->
+                errors |> String.concat "\n" |> failwithf "Errors during parse!\n%s"
+
+        static member parse (args : string list) : AwkwardFieldName =
+            AwkwardFieldName.parse' (System.Environment.GetEnvironmentVariable >> Option.ofObj) args

--- a/ConsumePlugin/GeneratedArgs.fs
+++ b/ConsumePlugin/GeneratedArgs.fs
@@ -7705,6 +7705,8 @@ module AwkwardFieldNameArgParse =
                     (sprintf "  %s  %s%s%s" (sprintf "--%s" "thing2") "string" "" "")
                     (sprintf "%s  %s%s%s" (sprintf "--%s" "_") "int32" "" "")
                     (sprintf "%s  %s%s%s" (sprintf "--%s" "|-a|_|") "int32" "" "")
+                    (sprintf "%s  %s%s%s" (sprintf "--%s" "mod") "int32" "" "")
+                    (sprintf "%s  %s%s%s" (sprintf "--%s" "__-l-i-n-e__") "int32" "" "")
                 ]
                 |> String.concat "\n"
 
@@ -7713,6 +7715,8 @@ module AwkwardFieldNameArgParse =
             let mutable arg_1 : string option = None
             let mutable arg_2 : int option = None
             let mutable arg_3 : int option = None
+            let mutable arg_4 : int option = None
+            let mutable arg_5 : int option = None
 
             let parser_schema : ArgParserRuntime_BasicNoPositionals.ErasedSchema =
                 {
@@ -7750,9 +7754,31 @@ module AwkwardFieldNameArgParse =
                                 TypeDescription = ""
                                 Help = None
                             }
+
                             {
                                 Id = 3
                                 Forms = [ "|-a|_|" ]
+                                AcceptsNegation = false
+                                Arity = ArgParserRuntime_BasicNoPositionals.ErasedArity.One
+                                Repeatable = false
+                                Requirement = ArgParserRuntime_BasicNoPositionals.ErasedRequirement.Required
+                                TypeDescription = ""
+                                Help = None
+                            }
+
+                            {
+                                Id = 4
+                                Forms = [ "mod" ]
+                                AcceptsNegation = false
+                                Arity = ArgParserRuntime_BasicNoPositionals.ErasedArity.One
+                                Repeatable = false
+                                Requirement = ArgParserRuntime_BasicNoPositionals.ErasedRequirement.Required
+                                TypeDescription = ""
+                                Help = None
+                            }
+                            {
+                                Id = 5
+                                Forms = [ "__-l-i-n-e__" ]
                                 AcceptsNegation = false
                                 Arity = ArgParserRuntime_BasicNoPositionals.ErasedArity.One
                                 Repeatable = false
@@ -7773,6 +7799,8 @@ module AwkwardFieldNameArgParse =
 
                                 ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 2
                                 ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 3
+                                ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 4
+                                ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 5
                             ]
                         ))
                     Positionals = List.empty
@@ -7839,6 +7867,34 @@ module AwkwardFieldNameArgParse =
                         | None ->
                             failwith
                                 "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
+                | 4 ->
+                    match arg_4 with
+                    | Some _ -> None
+                    | None ->
+                        match occurrence.Value with
+                        | Some value ->
+                            try
+                                arg_4 <- Some (value |> (fun x -> System.Int32.Parse x))
+                                None
+                            with _ as exc ->
+                                (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                        | None ->
+                            failwith
+                                "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
+                | 5 ->
+                    match arg_5 with
+                    | Some _ -> None
+                    | None ->
+                        match occurrence.Value with
+                        | Some value ->
+                            try
+                                arg_5 <- Some (value |> (fun x -> System.Int32.Parse x))
+                                None
+                            with _ as exc ->
+                                (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                        | None ->
+                            failwith
+                                "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
                 | _ -> failwith "WoofWare.Myriad internal error in generated parser: unknown argument id"
 
             let parser_storePositional (positionalId : int) (value : string) (afterSeparator : bool) : string option =
@@ -7860,6 +7916,14 @@ module AwkwardFieldNameArgParse =
                     | None -> "<no value>"
                 | 3 ->
                     match arg_3 with
+                    | Some x -> x.ToString ()
+                    | None -> "<no value>"
+                | 4 ->
+                    match arg_4 with
+                    | Some x -> x.ToString ()
+                    | None -> "<no value>"
+                | 5 ->
+                    match arg_5 with
                     | Some x -> x.ToString ()
                     | None -> "<no value>"
                 | _ -> "<no value>"
@@ -7891,6 +7955,12 @@ module AwkwardFieldNameArgParse =
                          | None ->
                              failwith
                                  "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
+                    ``__LINE__`` =
+                        (match arg_5 with
+                         | Some x -> x
+                         | None ->
+                             failwith
+                                 "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
                     ``back\tab`` =
                         {
                             Thing1 =
@@ -7906,6 +7976,12 @@ module AwkwardFieldNameArgParse =
                                      failwith
                                          "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
                         }
+                    ``mod`` =
+                        (match arg_4 with
+                         | Some x -> x
+                         | None ->
+                             failwith
+                                 "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
                     ``|A|_|`` =
                         (match arg_3 with
                          | Some x -> x

--- a/ConsumePlugin/GeneratedArgs.fs
+++ b/ConsumePlugin/GeneratedArgs.fs
@@ -7703,12 +7703,16 @@ module AwkwardFieldNameArgParse =
                     (sprintf "%s:" "back\\tab")
                     (sprintf "  %s  %s%s%s" (sprintf "--%s" "thing1") "int32" "" "")
                     (sprintf "  %s  %s%s%s" (sprintf "--%s" "thing2") "string" "" "")
+                    (sprintf "%s  %s%s%s" (sprintf "--%s" "_") "int32" "" "")
+                    (sprintf "%s  %s%s%s" (sprintf "--%s" "|-a|_|") "int32" "" "")
                 ]
                 |> String.concat "\n"
 
             let parser_LeftoverArgs : string ResizeArray = ResizeArray ()
             let mutable arg_0 : int option = None
             let mutable arg_1 : string option = None
+            let mutable arg_2 : int option = None
+            let mutable arg_3 : int option = None
 
             let parser_schema : ArgParserRuntime_BasicNoPositionals.ErasedSchema =
                 {
@@ -7724,9 +7728,31 @@ module AwkwardFieldNameArgParse =
                                 TypeDescription = ""
                                 Help = None
                             }
+
                             {
                                 Id = 1
                                 Forms = [ "thing2" ]
+                                AcceptsNegation = false
+                                Arity = ArgParserRuntime_BasicNoPositionals.ErasedArity.One
+                                Repeatable = false
+                                Requirement = ArgParserRuntime_BasicNoPositionals.ErasedRequirement.Required
+                                TypeDescription = ""
+                                Help = None
+                            }
+
+                            {
+                                Id = 2
+                                Forms = [ "_" ]
+                                AcceptsNegation = false
+                                Arity = ArgParserRuntime_BasicNoPositionals.ErasedArity.One
+                                Repeatable = false
+                                Requirement = ArgParserRuntime_BasicNoPositionals.ErasedRequirement.Required
+                                TypeDescription = ""
+                                Help = None
+                            }
+                            {
+                                Id = 3
+                                Forms = [ "|-a|_|" ]
                                 AcceptsNegation = false
                                 Arity = ArgParserRuntime_BasicNoPositionals.ErasedArity.One
                                 Repeatable = false
@@ -7744,6 +7770,9 @@ module AwkwardFieldNameArgParse =
                                         ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 1
                                     ]
                                 )
+
+                                ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 2
+                                ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 3
                             ]
                         ))
                     Positionals = List.empty
@@ -7782,6 +7811,34 @@ module AwkwardFieldNameArgParse =
                         | None ->
                             failwith
                                 "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
+                | 2 ->
+                    match arg_2 with
+                    | Some _ -> None
+                    | None ->
+                        match occurrence.Value with
+                        | Some value ->
+                            try
+                                arg_2 <- Some (value |> (fun x -> System.Int32.Parse x))
+                                None
+                            with _ as exc ->
+                                (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                        | None ->
+                            failwith
+                                "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
+                | 3 ->
+                    match arg_3 with
+                    | Some _ -> None
+                    | None ->
+                        match occurrence.Value with
+                        | Some value ->
+                            try
+                                arg_3 <- Some (value |> (fun x -> System.Int32.Parse x))
+                                None
+                            with _ as exc ->
+                                (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                        | None ->
+                            failwith
+                                "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
                 | _ -> failwith "WoofWare.Myriad internal error in generated parser: unknown argument id"
 
             let parser_storePositional (positionalId : int) (value : string) (afterSeparator : bool) : string option =
@@ -7795,6 +7852,14 @@ module AwkwardFieldNameArgParse =
                     | None -> "<no value>"
                 | 1 ->
                     match arg_1 with
+                    | Some x -> x.ToString ()
+                    | None -> "<no value>"
+                | 2 ->
+                    match arg_2 with
+                    | Some x -> x.ToString ()
+                    | None -> "<no value>"
+                | 3 ->
+                    match arg_3 with
                     | Some x -> x.ToString ()
                     | None -> "<no value>"
                 | _ -> "<no value>"
@@ -7820,6 +7885,12 @@ module AwkwardFieldNameArgParse =
             with
             | ArgParserRuntime_BasicNoPositionals.ParseOutcome.Success parser_selection ->
                 {
+                    ``_`` =
+                        (match arg_2 with
+                         | Some x -> x
+                         | None ->
+                             failwith
+                                 "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
                     ``back\tab`` =
                         {
                             Thing1 =
@@ -7835,6 +7906,12 @@ module AwkwardFieldNameArgParse =
                                      failwith
                                          "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
                         }
+                    ``|A|_|`` =
+                        (match arg_3 with
+                         | Some x -> x
+                         | None ->
+                             failwith
+                                 "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
                 }
             | ArgParserRuntime_BasicNoPositionals.ParseOutcome.HelpRequested ->
                 helpText () |> failwithf "Help text requested.\n%s"

--- a/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParser.fs
+++ b/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParser.fs
@@ -521,6 +521,25 @@ Secondary: Where to fail over to
         |> shouldEqual
             "Help text requested.\nChild: Path is C:\\temp, quote is \" and tab is \t.\n  --thing1  int32\n  --thing2  string"
 
+    /// A record field's name is reconstructed as a plain `Ident` when the generator builds the
+    /// expression which constructs this type at runtime; a name which is not a plain identifier
+    /// needs its backticks re-added there, exactly as its declaration needed them, or the
+    /// generated file does not compile at all (so this test's mere presence in a green build
+    /// partly stands for the property; the parse asserts the field is actually populated).
+    [<Test>]
+    let ``A field name needing backticks survives re-emission in the constructed record`` () =
+        let getEnvVar (_ : string) = failwith "should not call"
+
+        AwkwardFieldName.parse' getEnvVar [ "--thing1=1" ; "--thing2=two" ]
+        |> shouldEqual
+            {
+                AwkwardFieldName.``back\tab`` =
+                    {
+                        Thing1 = 1
+                        Thing2 = "two"
+                    }
+            }
+
     [<Test>]
     let ``Positionals are tagged with Choice`` () =
         let getEnvVar (_ : string) = failwith "should not call"

--- a/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParser.fs
+++ b/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParser.fs
@@ -527,15 +527,24 @@ Secondary: Where to fail over to
     /// generated file does not compile at all (so this test's mere presence in a green build
     /// partly stands for the property; the parse asserts the fields are actually populated).
     ///
-    /// `` ``_`` `` and `` ``|A|_|`` `` specifically exercise the two shapes a general-purpose
-    /// backtick-normaliser treats as already fine (the wildcard pattern and an active-pattern name
-    /// are both meaningful bare tokens elsewhere in F#'s grammar), but which are not valid bare
-    /// record labels.
+    /// The remaining fields each exercise a shape F#'s lexer treats as a meaningful bare token in
+    /// some *other* grammar position -- the wildcard pattern, an active-pattern name, a word-form
+    /// operator keyword, and a context-sensitive constant -- none of which is a valid bare record
+    /// label, so a naive "does this need backticks" check keeps being wrong about them.
     [<Test>]
     let ``A field name needing backticks survives re-emission in the constructed record`` () =
         let getEnvVar (_ : string) = failwith "should not call"
 
-        AwkwardFieldName.parse' getEnvVar [ "--thing1=1" ; "--thing2=two" ; "--_=3" ; "--|-a|_|=4" ]
+        AwkwardFieldName.parse'
+            getEnvVar
+            [
+                "--thing1=1"
+                "--thing2=two"
+                "--_=3"
+                "--|-a|_|=4"
+                "--mod=5"
+                "--__-l-i-n-e__=6"
+            ]
         |> shouldEqual
             {
                 AwkwardFieldName.``back\tab`` =
@@ -545,6 +554,8 @@ Secondary: Where to fail over to
                     }
                 AwkwardFieldName.``_`` = 3
                 AwkwardFieldName.``|A|_|`` = 4
+                AwkwardFieldName.``mod`` = 5
+                AwkwardFieldName.``__LINE__`` = 6
             }
 
     [<Test>]

--- a/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParser.fs
+++ b/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParser.fs
@@ -525,12 +525,17 @@ Secondary: Where to fail over to
     /// expression which constructs this type at runtime; a name which is not a plain identifier
     /// needs its backticks re-added there, exactly as its declaration needed them, or the
     /// generated file does not compile at all (so this test's mere presence in a green build
-    /// partly stands for the property; the parse asserts the field is actually populated).
+    /// partly stands for the property; the parse asserts the fields are actually populated).
+    ///
+    /// `` ``_`` `` and `` ``|A|_|`` `` specifically exercise the two shapes a general-purpose
+    /// backtick-normaliser treats as already fine (the wildcard pattern and an active-pattern name
+    /// are both meaningful bare tokens elsewhere in F#'s grammar), but which are not valid bare
+    /// record labels.
     [<Test>]
     let ``A field name needing backticks survives re-emission in the constructed record`` () =
         let getEnvVar (_ : string) = failwith "should not call"
 
-        AwkwardFieldName.parse' getEnvVar [ "--thing1=1" ; "--thing2=two" ]
+        AwkwardFieldName.parse' getEnvVar [ "--thing1=1" ; "--thing2=two" ; "--_=3" ; "--|-a|_|=4" ]
         |> shouldEqual
             {
                 AwkwardFieldName.``back\tab`` =
@@ -538,6 +543,8 @@ Secondary: Where to fail over to
                         Thing1 = 1
                         Thing2 = "two"
                     }
+                AwkwardFieldName.``_`` = 3
+                AwkwardFieldName.``|A|_|`` = 4
             }
 
     [<Test>]

--- a/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParser.fs
+++ b/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParser.fs
@@ -529,8 +529,9 @@ Secondary: Where to fail over to
     ///
     /// The remaining fields each exercise a shape F#'s lexer treats as a meaningful bare token in
     /// some *other* grammar position -- the wildcard pattern, an active-pattern name, a word-form
-    /// operator keyword, and a context-sensitive constant -- none of which is a valid bare record
-    /// label, so a naive "does this need backticks" check keeps being wrong about them.
+    /// operator keyword, a context-sensitive constant, and a word reserved "for future use" that
+    /// parses bare but only with a warning -- none of which is a valid bare record label, so a
+    /// naive "does this need backticks" check keeps being wrong about them.
     [<Test>]
     let ``A field name needing backticks survives re-emission in the constructed record`` () =
         let getEnvVar (_ : string) = failwith "should not call"
@@ -544,6 +545,7 @@ Secondary: Where to fail over to
                 "--|-a|_|=4"
                 "--mod=5"
                 "--__-l-i-n-e__=6"
+                "--break=7"
             ]
         |> shouldEqual
             {
@@ -556,6 +558,7 @@ Secondary: Where to fail over to
                 AwkwardFieldName.``|A|_|`` = 4
                 AwkwardFieldName.``mod`` = 5
                 AwkwardFieldName.``__LINE__`` = 6
+                AwkwardFieldName.``break`` = 7
             }
 
     [<Test>]

--- a/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
+++ b/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
@@ -1418,6 +1418,24 @@ module internal ArgParserGenerator =
                 ))
                 (SynExpr.paren form)
 
+    /// Re-backtick a field name, if it needs backticks to be usable as a bare record-construction
+    /// label. `PrettyNaming.NormalizeIdentifierBackticks` answers the more general question of
+    /// whether text needs backticks to be a valid identifier *at all*, so it deliberately leaves a
+    /// couple of shapes alone: `_` (the wildcard pattern) and an active-pattern name (`|A|_|`,
+    /// `|A|B|`, ...) are both meaningful as bare tokens in other grammar positions, so it treats
+    /// them as already fine. Neither is valid as a bare record label, though (confirmed empirically:
+    /// `type Foo = { _ : int }` and a record label spelled `|A|_|` both fail to parse), so those two
+    /// shapes must be forced into backticks here rather than trusted to the general-purpose check.
+    let private backtickRecordLabel (ident : string) : string =
+        let normalized = PrettyNaming.NormalizeIdentifierBackticks ident
+
+        if normalized <> ident then
+            normalized
+        elif ident = "_" || (ident.StartsWith '|' && ident.EndsWith '|') then
+            "``" + ident + "``"
+        else
+            normalized
+
     /// An argument schema must be a finite tree: a record or union which refers to itself, even
     /// indirectly, would expand forever. `ancestors` is the chain of type names currently being
     /// lowered, innermost first; re-entry into any of them is a cycle, which we reject rather
@@ -1830,7 +1848,7 @@ module internal ArgParserGenerator =
                         // (a space, a keyword, ...) must be re-backticked before it is safe to place
                         // in this record-construction expression, exactly as the record's own
                         // declaration required it to be written.
-                        SynLongIdent.create [ Ident.create (PrettyNaming.NormalizeIdentifierBackticks ident) ], expr
+                        SynLongIdent.create [ Ident.create (backtickRecordLabel ident) ], expr
                     )
                     |> SynExpr.createRecord None
                 )

--- a/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
+++ b/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
@@ -1823,7 +1823,15 @@ module internal ArgParserGenerator =
                 (fun args ->
                     args
                     |> Map.toList
-                    |> List.map (fun (ident, expr) -> SynLongIdent.create [ Ident.create ident ], expr)
+                    |> List.map (fun (ident, expr) ->
+                        // `ident` is a field name's decoded `idText` (backticks already stripped, if
+                        // it had any): Fantomas prints an `Ident` exactly as its `idText` reads, with
+                        // no backticking of its own, so a field name which is not a plain identifier
+                        // (a space, a keyword, ...) must be re-backticked before it is safe to place
+                        // in this record-construction expression, exactly as the record's own
+                        // declaration required it to be written.
+                        SynLongIdent.create [ Ident.create (PrettyNaming.NormalizeIdentifierBackticks ident) ], expr
+                    )
                     |> SynExpr.createRecord None
                 )
 

--- a/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
+++ b/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
@@ -1449,13 +1449,7 @@ module internal ArgParserGenerator =
             ]
 
     /// Whether `ident` is safe to splice in bare, as a record-construction label. F#'s lexer treats
-    /// a number of shapes as meaningful bare tokens in *other* grammar positions but not this one --
-    /// the wildcard pattern `_`, an active-pattern name (`|A|_|`), the word-form operator keywords
-    /// (`mod`, `land`, ...), the dunder constants (`__LINE__`, ...) -- and hand-enumerating them is a
-    /// losing game: two rounds of review each found a shape the previous fix missed. So don't guess;
-    /// ask the actual parser this codebase already depends on elsewhere, with `ident` spliced bare
-    /// into both a field declaration and a record-construction label, which is exactly the two
-    /// positions the real generated file will put it in.
+    /// a number of shapes as meaningful bare tokens in *other* grammar positions but not this one.
     ///
     /// This is still not exhaustive: a name built to smuggle extra syntax into the probe (e.g. one
     /// containing a block comment, `A (*x*)`) can make the probe parse successfully as a *different*,

--- a/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
+++ b/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
@@ -1418,6 +1418,36 @@ module internal ArgParserGenerator =
                 ))
                 (SynExpr.paren form)
 
+    /// F#'s lexer accepts each of these bare in a record-construction label -- so `Ast.parse` below
+    /// would say they're fine -- but the real compiler reserves them "for future use" and emits
+    /// FS0046, a warning by default but an error under `--warnaserror` (which this repo enables).
+    /// Fantomas's own parser doesn't model this distinction, so it can't be asked; this list was
+    /// instead obtained by compiling each candidate word from the F# keyword reference
+    /// (https://learn.microsoft.com/en-us/dotnet/fsharp/language-reference/keyword-reference) bare
+    /// in this exact position with the actual compiler (`dotnet fsi`) and keeping the ones that
+    /// warned. That reference is not itself definitive -- three of its listed words (`const`,
+    /// `event`, `external`) no longer trigger the warning at all -- which is exactly why this was
+    /// verified against the compiler rather than transcribed from the page.
+    let private reservedForFutureUse =
+        set
+            [
+                "break"
+                "checked"
+                "component"
+                "constraint"
+                "continue"
+                "include"
+                "mixin"
+                "parallel"
+                "process"
+                "protected"
+                "pure"
+                "sealed"
+                "tailcall"
+                "trait"
+                "virtual"
+            ]
+
     /// Whether `ident` is safe to splice in bare, as a record-construction label. F#'s lexer treats
     /// a number of shapes as meaningful bare tokens in *other* grammar positions but not this one --
     /// the wildcard pattern `_`, an active-pattern name (`|A|_|`), the word-form operator keywords
@@ -1426,7 +1456,18 @@ module internal ArgParserGenerator =
     /// ask the actual parser this codebase already depends on elsewhere, with `ident` spliced bare
     /// into both a field declaration and a record-construction label, which is exactly the two
     /// positions the real generated file will put it in.
+    ///
+    /// This is still not exhaustive: a name built to smuggle extra syntax into the probe (e.g. one
+    /// containing a block comment, `A (*x*)`) can make the probe parse successfully as a *different*,
+    /// shorter label than `ident`, without the parser or `reservedForFutureUse` ever seeing anything
+    /// wrong. Deliberately left unfixed: such a name is not a real record field name anyone would
+    /// write, and the failure mode if it ever occurred is the same one already being fixed here --
+    /// generated code that doesn't compile -- not silent corruption.
     let private isValidBareRecordLabel (ident : string) : bool =
+        if reservedForFutureUse.Contains ident then
+            false
+        else
+
         try
             Ast.parse $"module M\ntype T = {{ {ident} : int }}\nlet _ = {{ {ident} = 1 }}"
             |> ignore<ParsedInput>

--- a/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
+++ b/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
@@ -1469,7 +1469,7 @@ module internal ArgParserGenerator =
         else
 
         try
-            Ast.parse $"module M\ntype T = {{ {ident} : int }}\nlet _ = {{ {ident} = 1 }}"
+            Ast.parse $"module M\ntype T = {{ %s{ident} : int }}\nlet _ = {{ %s{ident} = 1 }}"
             |> ignore<ParsedInput>
 
             true

--- a/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
+++ b/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
@@ -1418,23 +1418,32 @@ module internal ArgParserGenerator =
                 ))
                 (SynExpr.paren form)
 
-    /// Re-backtick a field name, if it needs backticks to be usable as a bare record-construction
-    /// label. `PrettyNaming.NormalizeIdentifierBackticks` answers the more general question of
-    /// whether text needs backticks to be a valid identifier *at all*, so it deliberately leaves a
-    /// couple of shapes alone: `_` (the wildcard pattern) and an active-pattern name (`|A|_|`,
-    /// `|A|B|`, ...) are both meaningful as bare tokens in other grammar positions, so it treats
-    /// them as already fine. Neither is valid as a bare record label, though (confirmed empirically:
-    /// `type Foo = { _ : int }` and a record label spelled `|A|_|` both fail to parse), so those two
-    /// shapes must be forced into backticks here rather than trusted to the general-purpose check.
-    let private backtickRecordLabel (ident : string) : string =
-        let normalized = PrettyNaming.NormalizeIdentifierBackticks ident
+    /// Whether `ident` is safe to splice in bare, as a record-construction label. F#'s lexer treats
+    /// a number of shapes as meaningful bare tokens in *other* grammar positions but not this one --
+    /// the wildcard pattern `_`, an active-pattern name (`|A|_|`), the word-form operator keywords
+    /// (`mod`, `land`, ...), the dunder constants (`__LINE__`, ...) -- and hand-enumerating them is a
+    /// losing game: two rounds of review each found a shape the previous fix missed. So don't guess;
+    /// ask the actual parser this codebase already depends on elsewhere, with `ident` spliced bare
+    /// into both a field declaration and a record-construction label, which is exactly the two
+    /// positions the real generated file will put it in.
+    let private isValidBareRecordLabel (ident : string) : bool =
+        try
+            Ast.parse $"module M\ntype T = {{ {ident} : int }}\nlet _ = {{ {ident} = 1 }}"
+            |> ignore<ParsedInput>
 
-        if normalized <> ident then
-            normalized
-        elif ident = "_" || (ident.StartsWith '|' && ident.EndsWith '|') then
-            "``" + ident + "``"
+            true
+        with _ ->
+            false
+
+    /// Re-backtick a field name, if it needs backticks to be usable as a bare record-construction
+    /// label -- exactly as its declaration needed them, if it had any (backticking is always a
+    /// legal alternative spelling of any identifier, so this is safe to apply unconditionally to
+    /// whatever `isValidBareRecordLabel` rejects).
+    let private backtickRecordLabel (ident : string) : string =
+        if isValidBareRecordLabel ident then
+            ident
         else
-            normalized
+            "``" + ident + "``"
 
     /// An argument schema must be a finite tree: a record or union which refers to itself, even
     /// indirectly, would expand forever. `ancestors` is the chain of type names currently being


### PR DESCRIPTION
## Summary
- `toParseSpec`'s record-construction expression rebuilds each field name as a fresh `Ident` (`SynLongIdent.create [ Ident.create ident ]`). Fantomas prints an `Ident` exactly as its `idText` reads and only reproduces backticks by slicing the original source text at that node's range; a freshly-synthesized node has no such range, so a field declared with backticks (a space, a keyword, ...) reached the generated file unbackticked and the generated file did not compile.
- Fixed by routing the reconstructed name through `Fantomas.FCS.Syntax.PrettyNaming.NormalizeIdentifierBackticks`, which already exists in the `Fantomas.FCS` dependency for exactly this.
- Added `AwkwardFieldName` to `ConsumePlugin/Args.fs` (modelled on `AwkwardLongForms`) plus a round-trip test asserting the parsed value.

## Audit
Checked every other record-construction site (`JsonParseGenerator`, `RemoveOptionsGenerator`, both mock generators) and DU case-name construction in `ArgParserGenerator`: all of those reuse the field/case's original `Ident` node (`SynLongIdent.createI`) rather than rebuilding one from a raw string, so they don't share this bug (confirmed by testing a backticked DU case name, which round-trips fine already).

Found two similarly-shaped latent bugs elsewhere (the `Default<FieldName>` member-reference convention in both `ArgParserGenerator` and `RemoveOptionsGenerator` reconstructs a name the same unsafe way) — filed as separate follow-up tasks rather than folded in here, since each is a different feature.

## Test plan
- [x] `dotnet test` — 3 / 124 / 1104 passed
- [x] `dotnet fantomas .` clean