### PR TITLE
ArgParser: reject [<ArgumentFlag>] on record fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 Notable changes are recorded here.
 
+# WoofWare.Myriad.Plugins 11.0.1
+
+Breaking change: `ArgParserGenerator` now rejects, at generation time, several attribute placements which it previously accepted and then silently ignored.
+
+* `[<ArgumentFlag>]` on a record field. It belongs on the two cases of a flag discriminated union, where it says which case means `true` and which means `false`; a field is not where that question can be answered.
+* `[<PositionalArgs>]`, `[<ParseExact>]`, `[<InvariantCulture>]` or `[<ArgumentNegateWithPrefix>]` on a field whose type is another argument record, or a union of alternative argument sets. Such a field contributes a whole set of arguments rather than one, so there is no single argument for these to collect into, spell or negate. `[<ArgumentHelpText>]` is deliberately still accepted there: it heads the group of arguments the field contributes.
+* `[<ArgumentNegateWithPrefix>]` on a `[<PositionalArgs>]` field. A positional field is a sink which accumulates values; its keyed spellings take a value rather than setting anything, so there is no boolean there for a `--no-` form to invert.
+* `[<ParseExact>]` or `[<InvariantCulture>]` on anything but a `System.TimeSpan`. These are read only by the `TimeSpan` parser. They continue to reach through the shapes which wrap a value — `TimeSpan option`, `TimeSpan list`, `Choice<TimeSpan, TimeSpan>`, and a `Map` either of whose halves is a `TimeSpan` — and are rejected only where no `TimeSpan` is reached at all. Future work may expand the range of types these attributes affect.
+
 # WoofWare.Myriad.Plugins 10.7.2
 
 `ArgParserGenerator` now reads `[<ArgumentHelpText>]` from a nested argument record or union of alternative argument sets, and not only from the `[<ArgParser>]`-tagged root, and from a discriminated union's case (and that case's payload record).

--- a/README.md
+++ b/README.md
@@ -243,7 +243,8 @@ and you get back respectively these objects:
 }
 ```
 
-You can control `TimeSpan` and friends with the `[<InvariantCulture>]` and `[<ParseExact @"hh\:mm\:ss">]` attributes.
+You can control how a `System.TimeSpan` is read with the `[<InvariantCulture>]` and `[<ParseExact @"hh\:mm\:ss">]` attributes.
+These are honoured on `TimeSpan` only — reaching through the shapes which wrap it, so `TimeSpan option`, `TimeSpan list` and a `Map` with a `TimeSpan` half are all covered — and are rejected on any other type, where nothing would read them.
 
 You can generate extension methods for the type, instead of a module with the type's name, using `[<ArgParser (* isExtensionMethod = *) true>]`.
 
@@ -378,6 +379,18 @@ Records compose: if your record contains other records which are visible to the 
 Discriminated unions compose with each other and with records, hopefully as you would expect: the fields specified by the record contained within the exactly-one field of each DU case must all be mutually satisified, or the parse will fail to select that DU field.
 We will fail at build time to generate a parser if you have several DU cases which contain fields of the same name, though, because in general resolving the parse in that case is NP-hard.
 (An upcoming piece of work will hopefully relax this restriction.)
+
+#### Attribute placement at a structural boundary
+
+A field whose type is another argument record, or a union of alternative argument sets, is *structural*: it contributes that type's whole set of arguments rather than being one argument itself.
+Most attributes describe single arguments, so are rejected at build time when applied to a structural field.
+
+Two attributes do apply to structural fields, because they are specifically about the group:
+
+* `[<ArgumentHelpText>]` describes the whole group of arguments the field contributes, and appears on the header line introducing it.
+* `[<ArgumentPrefix>]` namespaces every argument in the subtree; conversely, it is rejected on a leaf, which has no subtree.
+
+`[<ArgumentFlag>]` is not a field attribute at all: it goes on the two cases of a flag discriminated union, and is rejected on a record field.
 
 ### What's the point?
 

--- a/WoofWare.Myriad.Plugins.Attributes/ArgParserAttributes.fs
+++ b/WoofWare.Myriad.Plugins.Attributes/ArgParserAttributes.fs
@@ -31,6 +31,18 @@ type ArgParserAttribute (isExtensionMethod : bool) =
 /// tell you whether each arg came before or after a standalone `--` separator.
 /// For example, `MyApp foo bar -- baz` with PositionalArgs of `Choice<string, string>`
 /// would yield `Choice1Of2 foo, Choice1Of2 bar, Choice2Of2 baz`.
+///
+/// This attribute applies to an argument *leaf*. It is rejected on a field whose type is another
+/// [<ArgParser>]-schema record or a discriminated union of alternative argument sets: such a field
+/// contributes a whole set of arguments rather than being a place values can be collected into, so
+/// put the attribute on the leaf field inside that type which should do the collecting.
+///
+/// A positional field is a sink which accumulates values. It is addressable: `--foo value` and
+/// `--foo=value` route to it, as does any explicit [<ArgumentLongForm>]. But those keyed forms
+/// take a value rather than setting anything, so the field is rejected in combination with
+/// [<ArgumentNegateWithPrefix>] (there is no boolean for a `--no-` form to invert) and with
+/// [<ArgumentPrefix>] (there is no subtree to namespace), and it may not carry a default
+/// (positional args are collected, not defaulted).
 type PositionalArgsAttribute (includeFlagLike : bool) =
     inherit Attribute ()
 
@@ -102,25 +114,42 @@ type ArgumentDefaultValueAttribute (defaultValue : obj) =
 type ArgumentHelpTextAttribute (helpText : string) =
     inherit Attribute ()
 
-/// Attribute indicating that this field should be parsed with a ParseExact method on its type.
-/// For example, on a TimeSpan field, with [<ArgumentParseExact @"hh\:mm\:ss">], we will call
-/// `TimeSpan.ParseExact (s, @"hh\:mm\:ss", CultureInfo.CurrentCulture).
+/// Attribute giving the format in which this field's value is written.
+/// For example, on a TimeSpan field, with [<ParseExact @"hh\:mm\:ss">], we will call
+/// `TimeSpan.ParseExact (s, @"hh\:mm\:ss", CultureInfo.CurrentCulture)`.
+///
+/// This attribute is honoured on `System.TimeSpan` only, and is rejected anywhere else: no other
+/// type's parser reads it, so it would otherwise be dropped in silence while the generated help
+/// text went on advertising a format the parser did not apply.
+///
+/// It reaches through the shapes which wrap a value, since those parse their components with it:
+/// `TimeSpan option`, `TimeSpan list` and `Choice<TimeSpan, TimeSpan>` are all honoured, as is a
+/// `Map` either of whose halves is a `TimeSpan` (in which case the format describes each `TimeSpan`
+/// half; a map with no `TimeSpan` at all is rejected).
 type ParseExactAttribute (format : string) =
     inherit Attribute ()
 
 /// Attribute indicating that this field should be parsed in the invariant culture, rather than the
 /// default current culture.
-/// For example, on a TimeSpan field, with [<InvariantCulture>] and [<ArgumentParseExact @"hh\:mm\:ss">], we will call
-/// `TimeSpan.ParseExact (s, @"hh\:mm\:ss", CultureInfo.InvariantCulture).
+/// For example, on a TimeSpan field, with [<InvariantCulture>] and [<ParseExact @"hh\:mm\:ss">], we will call
+/// `TimeSpan.ParseExact (s, @"hh\:mm\:ss", CultureInfo.InvariantCulture)`.
+///
+/// As with [<ParseExact>], this is honoured on `System.TimeSpan` only -- reaching through option,
+/// list, choice and map in the same way -- and is rejected anywhere else, where nothing would read
+/// it.
 type InvariantCultureAttribute () =
     inherit Attribute ()
 
-/// Attribute placed on a field of a two-case no-data discriminated union, indicating that this is "basically a bool".
+/// Attribute placed on each case of a two-case no-data discriminated union, indicating that the
+/// union is "basically a bool".
 /// For example: `type DryRun = | [<ArgumentFlag true>] Dry | [<ArgumentFlag false>] Wet`
 /// A record with `{ DryRun : DryRun }` will then be parsed like `{ DryRun : bool }` (so the user supplies `--dry-run`),
 /// but that you get this strongly-typed value directly in the code (so you `match args.DryRun with | DryRun.Dry ...`).
 ///
 /// You must put this attribute on both cases of the discriminated union, with opposite values in each case.
+///
+/// It belongs on the union's *cases*, and is rejected on a record field: a field is not where the
+/// question "which case means true?" can be answered, and nothing read the attribute there.
 type ArgumentFlagAttribute (flagValue : bool) =
     inherit Attribute ()
 
@@ -132,6 +161,12 @@ type ArgumentFlagAttribute (flagValue : bool) =
 /// You can place this argument multiple times.
 ///
 /// Omit the initial `--` that you expect the user to type.
+///
+/// This attribute applies to an argument *leaf*. It is rejected on a field whose type is another
+/// [<ArgParser>]-schema record or a discriminated union of alternative argument sets: such a field
+/// contributes a whole set of arguments, each named by its own field, so there is no single
+/// argument here to rename. Put the attribute on the field you mean to rename, or use
+/// [<ArgumentPrefix>] to rename the whole subtree at once.
 [<AttributeUsage(AttributeTargets.Field, AllowMultiple = true)>]
 type ArgumentLongForm (s : string) =
     inherit Attribute ()
@@ -215,6 +250,12 @@ type ArgumentMapEntrySeparatorAttribute (separator : char) =
 ///   --no-field-name=false sets to the [<ArgumentFlag true>] case
 ///
 /// This attribute can only be applied to bool fields or flag DU fields (two-case DUs with [<ArgumentFlag>]).
+///
+/// It applies to an argument *leaf*, and to a leaf which has a name. So it is also rejected on a
+/// field whose type is another [<ArgParser>]-schema record or a discriminated union of alternative
+/// argument sets (which contributes a whole set of arguments, none of them singled out for
+/// negation), and on a [<PositionalArgs>] field (which accumulates values, so although it is
+/// addressable, there is no boolean there for a `--no-` form to invert).
 [<AttributeUsage(AttributeTargets.Field, AllowMultiple = false)>]
 type ArgumentNegateWithPrefixAttribute () =
     inherit Attribute ()

--- a/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
+++ b/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
@@ -1612,6 +1612,24 @@ module internal ArgParserGenerator =
                         failwith
                             $"Field '%s{ident.idText}' has a default-value attribute ([<ArgumentDefaultFunction>], [<ArgumentDefaultValue>], or [<ArgumentDefaultEnvironmentVariable>]), but its type is not Choice<'a, 'a>. Defaults are surfaced through Choice<'a, 'a> so a successful parse can report whether a value was user-supplied (Choice1Of2) or defaulted (Choice2Of2); a bare field cannot express this. Change the field's type to Choice<'a, 'a>, or remove the attribute."
 
+                // [<ArgumentFlag>] is read only from a union's cases, where it says which case
+                // means 'true' and which means 'false'. On a record field nothing reads it at all,
+                // so it was silently doing nothing -- and the attribute's own documentation invited
+                // the mistake by describing it as going on "a field". Checked here, above the
+                // leaf/structural dispatch, so it fires wherever the field would have been handled.
+                let hasFlagAttr =
+                    attrs
+                    |> List.exists (fun attr ->
+                        match (List.last attr.TypeName.LongIdent).idText with
+                        | "ArgumentFlag"
+                        | "ArgumentFlagAttribute" -> true
+                        | _ -> false
+                    )
+
+                if hasFlagAttr then
+                    failwith
+                        $"[<ArgumentFlag>] was applied to field '%s{ident.idText}', but it belongs on the cases of a discriminated union, not on a record field: it says which of a two-case union's cases means 'true' and which means 'false'. Nothing reads it from a field, so it would have had no effect. Remove it, or declare a two-case union whose cases carry [<ArgumentFlag true>] and [<ArgumentFlag false>], and give this field that type."
+
                 let prefixAttr = prefixAttribute attrs
 
                 // The structural branches below run before any leaf machinery, so this pairing has

--- a/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
+++ b/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
@@ -857,6 +857,46 @@ module internal ArgParserGenerator =
             failwith
                 $"Field '%s{fieldName.idText}' has an [<ArgumentLongForm>], but its type %s{ty} is an argument record or a discriminated union of alternative argument sets, so it contributes a whole set of arguments rather than one. [<ArgumentLongForm>] renames a single argument, and there is none here to rename: the names come from the fields of %s{ty} itself. Put the attribute on the field you mean to rename."
 
+    /// The same argument as `rejectLongFormAttribute`, for the attributes which describe how a
+    /// single argument is collected, spelled or read: a structural field contributes a whole set of
+    /// arguments, so there is no one argument for any of these to act on. The structural branches
+    /// take over before the leaf machinery which reads them ever runs, so without this each was
+    /// computed and then dropped on the floor.
+    ///
+    /// [<ArgumentHelpText>] is deliberately absent: on a structural field it introduces the group
+    /// of arguments the field contributes, which is a real use rather than a misplacement.
+    let private rejectLeafOnlyAttributes (fieldName : Ident) (fieldType : SynType) (attrs : SynAttribute list) : unit =
+        let reject (names : string list) (display : string) (purpose : string) : unit =
+            let present =
+                attrs
+                |> List.exists (fun attr -> names |> List.contains (List.last attr.TypeName.LongIdent).idText)
+
+            if present then
+                let ty = describeType fieldType
+
+                failwith
+                    $"Field '%s{fieldName.idText}' has a [<%s{display}>], but its type %s{ty} is an argument record or a discriminated union of alternative argument sets, so it contributes a whole set of arguments rather than one. %s{purpose}"
+
+        reject
+            [ "PositionalArgs" ; "PositionalArgsAttribute" ]
+            "PositionalArgs"
+            "[<PositionalArgs>] makes one field collect the arguments which carry no name, and a set of arguments cannot collect them. Put it on the leaf field which should do the collecting."
+
+        reject
+            [ "ParseExact" ; "ParseExactAttribute" ]
+            "ParseExact"
+            "[<ParseExact>] gives the format in which one argument's value is written, and a set of arguments has no single value. Put it on the leaf field whose value is written that way."
+
+        reject
+            [ "InvariantCulture" ; "InvariantCultureAttribute" ]
+            "InvariantCulture"
+            "[<InvariantCulture>] chooses the culture in which one argument's value is read, and a set of arguments has no single value. Put it on the leaf field whose value should be read that way."
+
+        reject
+            [ "ArgumentNegateWithPrefix" ; "ArgumentNegateWithPrefixAttribute" ]
+            "ArgumentNegateWithPrefix"
+            "[<ArgumentNegateWithPrefix>] gives one boolean argument a --no- spelling, and there is no single argument here to negate. Put it on the leaf field you mean to negate."
+
     let private checkSeparatorAttributesPlacement
         (fieldName : Ident)
         (fieldType : SynType)
@@ -870,6 +910,60 @@ module internal ArgParserGenerator =
         | Accumulation.Optional
         | Accumulation.Choice _
         | Accumulation.List _ -> rejectSeparatorAttributes fieldName fieldType attrs
+
+    /// [<ParseExact>] and [<InvariantCulture>] are read in exactly one place: the TimeSpan arm of
+    /// `createParseFunction`. On any other type they are dropped -- and for [<ParseExact>] that is
+    /// worse than silence, because `helpText` advertises the format unconditionally, so the
+    /// generated --help promises a format the generated parser does not honour.
+    ///
+    /// Checked after the parse function has been built, against the type actually handed to the
+    /// parser rather than the declared field type -- exactly as `checkSeparatorAttributesPlacement`
+    /// is, and for the same reason: `TimeSpan option` and `TimeSpan list` reach the TimeSpan arm
+    /// through the recursion, so their element type is what the attribute really describes.
+    ///
+    /// A map is the one shape where that type is not the whole story: it hands the field's
+    /// attributes to its key parser as well as its value parser, so the attribute is genuinely
+    /// consumed if *either* component is a TimeSpan, while `parseTy` is only the value's.
+    let private checkCultureAttributesPlacement
+        (fieldName : Ident)
+        (fieldType : SynType)
+        (attrs : SynAttribute list)
+        (accumulation : Accumulation<'choice>)
+        (parseTy : SynType)
+        : unit
+        =
+        let isTimeSpan (ty : SynType) : bool =
+            match ty with
+            | TimeSpan -> true
+            | _ -> false
+
+        let consumed =
+            match accumulation with
+            | Accumulation.Map spec -> isTimeSpan spec.KeyType || isTimeSpan parseTy
+            | Accumulation.Required
+            | Accumulation.Optional
+            | Accumulation.Choice _
+            | Accumulation.List _ -> isTimeSpan parseTy
+
+        if not consumed then
+            let reject (names : string list) (display : string) (consequence : string) : unit =
+                let present =
+                    attrs
+                    |> List.exists (fun attr -> names |> List.contains (List.last attr.TypeName.LongIdent).idText)
+
+                if present then
+                    failwith
+                        $"[<%s{display}>] is only honoured on System.TimeSpan fields, but was applied to field '%s{fieldName.idText}' of type %s{describeType fieldType}. %s{consequence} Remove it, or use a System.TimeSpan: the attribute reaches through option, list and map, so `System.TimeSpan option` and `Map<string, System.TimeSpan>` are honoured too."
+
+            reject
+                [ "ParseExact" ; "ParseExactAttribute" ]
+                "ParseExact"
+                "Nothing reads it there, so the value is parsed in the default way -- while the generated help text still advertises the format, promising something the parser does not do."
+
+            reject
+                [ "InvariantCulture" ; "InvariantCultureAttribute" ]
+                "InvariantCulture"
+                "Nothing reads it there, so the value is parsed in whatever culture the default parse uses."
 
     /// What we found in the argument of an `[<ArgumentDefaultValue>]`.
     type private DefaultValueExpr =
@@ -1674,6 +1768,7 @@ module internal ArgParserGenerator =
                     // misplaced one would be told nothing at all.
                     rejectSeparatorAttributes ident fieldType attrs
                     rejectLongFormAttribute ident fieldType attrs
+                    rejectLeafOnlyAttributes ident fieldType attrs
 
                     // This field has a type we need to obtain from parsing another record.
                     let childPrefix =
@@ -1697,6 +1792,7 @@ module internal ArgParserGenerator =
                 | Some union ->
                     rejectSeparatorAttributes ident fieldType attrs
                     rejectLongFormAttribute ident fieldType attrs
+                    rejectLeafOnlyAttributes ident fieldType attrs
 
                     // A discriminated union of alternative argument sets: exactly one case's
                     // arguments must be supplied. (Flag-like and data-free unions are argument
@@ -1728,8 +1824,30 @@ module internal ArgParserGenerator =
                         $"[<ArgumentPrefix>] can only be applied to a field whose type is another [<ArgParser>]-schema record or a discriminated union of alternative argument sets, but was applied to field '%s{ident.idText}' of type %s{describeType fieldType}. It renames every argument contributed by that field's subtree by prepending a namespace (e.g. [<ArgumentPrefix \"foo\">] on a field whose type is a record containing `Blah : string` turns --blah into --foo-blah); a leaf field has no subtree to rename. To change this one argument's name, use [<ArgumentLongForm>] instead."
                 | None -> ()
 
+                // Read before the positional split, because both sides have something to say about
+                // it: the positional branch cannot honour it at all, and previously did not even
+                // look, hardcoding `AcceptsNegation = false` and dropping the attribute in silence.
+                let hasNegateAttr =
+                    attrs
+                    |> List.exists (fun attr ->
+                        match (List.last attr.TypeName.LongIdent).idText with
+                        | "ArgumentNegateWithPrefixAttribute"
+                        | "ArgumentNegateWithPrefix" -> true
+                        | _ -> false
+                    )
+
                 match positionalArgAttr with
                 | Some includeFlagLike ->
+                    // A positional field does have keyed spellings -- `--blah value` and
+                    // `--blah=value` route to the sink, and [<ArgumentLongForm>] can add more --
+                    // but they are value-taking routing keys, not a boolean to invert. So the
+                    // complaint is about what negation *means* here, not about the absence of a
+                    // name, and it holds whatever the field's element type: this is not the same
+                    // check as the boolean-shape one on the non-positional side below.
+                    if hasNegateAttr then
+                        failwith
+                            $"[<ArgumentNegateWithPrefix>] was applied to field '%s{ident.idText}', which carries [<PositionalArgs>]. Negation inverts a boolean argument: `--no-foo` means the same as `--foo=false`. A positional field is a sink which accumulates values -- its keyed spellings take a value and add it to the collection, rather than setting anything -- so there is no boolean here for a `--no-` form to invert. Remove the [<ArgumentNegateWithPrefix>], or move it to the named boolean field you mean to negate."
+
                     // Positional fields carrying a default attribute are rejected above, so the
                     // Choice-parsing path only ever reaches this callback with `None`.
                     let getChoice (_ : ArgumentDefaultSpec option) : unit = ()
@@ -1738,6 +1856,7 @@ module internal ArgParserGenerator =
                         createParseFunction<unit> getChoice ambient finalRecord.Name ident attrs fieldType
 
                     checkSeparatorAttributesPlacement ident fieldType attrs accumulation
+                    checkCultureAttributesPlacement ident fieldType attrs accumulation parseTy
 
                     let isBoolLike =
                         match parseTy with
@@ -1802,6 +1921,7 @@ module internal ArgParserGenerator =
                         createParseFunction getChoice ambient finalRecord.Name ident attrs fieldType
 
                     checkSeparatorAttributesPlacement ident fieldType attrs accumulation
+                    checkCultureAttributesPlacement ident fieldType attrs accumulation parseTy
 
                     // A map's `parseTy` describes its *values*, not the field, so the boolean and
                     // enumerated metadata derived from it would misdescribe the argument. In
@@ -1856,17 +1976,6 @@ module internal ArgParserGenerator =
                         | Accumulation.Optional
                         | Accumulation.Choice _
                         | Accumulation.List _ -> None
-
-                    let hasNegateAttr =
-                        attrs
-                        |> List.exists (fun attr ->
-                            match attr.TypeName with
-                            | SynLongIdent.SynLongIdent (ident, _, _) ->
-                                match (List.last ident).idText with
-                                | "ArgumentNegateWithPrefixAttribute"
-                                | "ArgumentNegateWithPrefix" -> true
-                                | _ -> false
-                        )
 
                     let acceptsNegation =
                         if hasNegateAttr then

--- a/WoofWare.Myriad.Plugins/Test/TestArgParserRejection.fs
+++ b/WoofWare.Myriad.Plugins/Test/TestArgParserRejection.fs
@@ -2603,3 +2603,154 @@ type Args =
 """
         |> shouldRejectWith
             "The [<ArgParser>] schema is recursive: Args -> Args. Argument records and unions may not contain themselves, even indirectly."
+
+    /// [<ArgumentFlag>] is read only from a union's *cases*, so on a record field it did nothing
+    /// whatsoever -- and the attribute's own documentation invited exactly that mistake by
+    /// describing it as going on "a field". The check is hoisted above the leaf/structural
+    /// dispatch, so the message is the same wherever the field would otherwise have been handled.
+    let private flagOnField (field : string) : string =
+        $"[<ArgumentFlag>] was applied to field '%s{field}', but it belongs on the cases of a discriminated union, not on a record field: it says which of a two-case union's cases means 'true' and which means 'false'. Nothing reads it from a field, so it would have had no effect. Remove it, or declare a two-case union whose cases carry [<ArgumentFlag true>] and [<ArgumentFlag false>], and give this field that type."
+
+    [<Test>]
+    let ``ArgumentFlag on a bool field is rejected`` () =
+        """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+[<ArgParser>]
+type Args =
+    {
+        [<ArgumentFlag true>]
+        Blah : bool
+    }
+"""
+        |> shouldRejectWith (flagOnField "Blah")
+
+    /// The likeliest way to write it wrong: the union is a perfectly good flag union, and its
+    /// cases are correctly marked, but the attribute has been repeated on the field which uses it.
+    [<Test>]
+    let ``ArgumentFlag on a flag-union field is rejected`` () =
+        """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+type DryRun =
+    | [<ArgumentFlag true>] Dry
+    | [<ArgumentFlag false>] Wet
+
+[<ArgParser>]
+type Args =
+    {
+        [<ArgumentFlag true>]
+        Blah : DryRun
+    }
+"""
+        |> shouldRejectWith (flagOnField "Blah")
+
+    /// The check runs before the structural dispatch, which would otherwise take over and drop the
+    /// attribute without a word.
+    [<Test>]
+    let ``ArgumentFlag on a sub-record field is rejected`` () =
+        """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+type Child =
+    {
+        Blah : int
+    }
+
+[<ArgParser>]
+type Args =
+    {
+        [<ArgumentFlag true>]
+        A : Child
+    }
+"""
+        |> shouldRejectWith (flagOnField "A")
+
+    [<Test>]
+    let ``ArgumentFlag on a union-typed field is rejected`` () =
+        """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+type FooArgs =
+    {
+        Foo : int
+    }
+
+type BarArgs =
+    {
+        Bar : int
+    }
+
+type Mode =
+    | FooCase of FooArgs
+    | BarCase of BarArgs
+
+[<ArgParser>]
+type Args =
+    {
+        [<ArgumentFlag false>]
+        A : Mode
+    }
+"""
+        |> shouldRejectWith (flagOnField "A")
+
+    [<Test>]
+    let ``ArgumentFlag on a positional field is rejected`` () =
+        """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+[<ArgParser>]
+type Args =
+    {
+        [<ArgumentFlag true>]
+        [<PositionalArgs>]
+        Blah : string list
+    }
+"""
+        |> shouldRejectWith (flagOnField "Blah")
+
+    /// F# lets an attribute be named with or without its `Attribute` suffix, and the union-case
+    /// reader has always accepted both; the rejection has to see both too, or the longer spelling
+    /// slips through to the silent-no-op behaviour this replaces.
+    [<Test>]
+    let ``ArgumentFlagAttribute on a field is rejected under its long spelling`` () =
+        """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+[<ArgParser>]
+type Args =
+    {
+        [<ArgumentFlagAttribute true>]
+        Blah : bool
+    }
+"""
+        |> shouldRejectWith (flagOnField "Blah")
+
+    /// The rejection is about the *field's* attribute: the placement it points at is still
+    /// entirely ordinary.
+    [<Test>]
+    let ``ArgumentFlag on a union's cases is still accepted`` () =
+        let modules =
+            generateFromSource
+                """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+type DryRun =
+    | [<ArgumentFlag true>] Dry
+    | [<ArgumentFlag false>] Wet
+
+[<ArgParser>]
+type Args =
+    {
+        Blah : DryRun
+    }
+"""
+
+        List.length modules |> shouldEqual 2

--- a/WoofWare.Myriad.Plugins/Test/TestArgParserRejection.fs
+++ b/WoofWare.Myriad.Plugins/Test/TestArgParserRejection.fs
@@ -2754,3 +2754,410 @@ type Args =
 """
 
         List.length modules |> shouldEqual 2
+
+    /// The structural branches are taken before any leaf machinery runs, so each of the
+    /// leaf-oriented attributes below was computed and then dropped on the floor: the author got a
+    /// parser which did not do what they asked, and no indication why. The two structural shapes --
+    /// a nested argument record, and a union of alternative argument sets -- share one message,
+    /// exactly as the [<ArgumentLongForm>] rejection above does, because the reason is the same for
+    /// both: the field contributes a whole set of arguments rather than one.
+    let private leafOnlyOnStructural (attr : string) (purpose : string) (field : string) (ty : string) : string =
+        $"Field '%s{field}' has a [<%s{attr}>], but its type %s{ty} is an argument record or a discriminated union of alternative argument sets, so it contributes a whole set of arguments rather than one. %s{purpose}"
+
+    let private positionalOnStructural =
+        leafOnlyOnStructural
+            "PositionalArgs"
+            "[<PositionalArgs>] makes one field collect the arguments which carry no name, and a set of arguments cannot collect them. Put it on the leaf field which should do the collecting."
+
+    let private parseExactOnStructural =
+        leafOnlyOnStructural
+            "ParseExact"
+            "[<ParseExact>] gives the format in which one argument's value is written, and a set of arguments has no single value. Put it on the leaf field whose value is written that way."
+
+    let private invariantCultureOnStructural =
+        leafOnlyOnStructural
+            "InvariantCulture"
+            "[<InvariantCulture>] chooses the culture in which one argument's value is read, and a set of arguments has no single value. Put it on the leaf field whose value should be read that way."
+
+    let private negateOnStructural =
+        leafOnlyOnStructural
+            "ArgumentNegateWithPrefix"
+            "[<ArgumentNegateWithPrefix>] gives one boolean argument a --no- spelling, and there is no single argument here to negate. Put it on the leaf field you mean to negate."
+
+    /// Source for the two structural shapes, so each attribute is exercised against both without
+    /// restating the schema four times over.
+    let private structuralRecordSource (attr : string) : string =
+        $"""namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+type Child =
+    {{
+        Blah : int
+    }}
+
+[<ArgParser>]
+type Args =
+    {{
+        [<%s{attr}>]
+        A : Child
+    }}
+"""
+
+    let private structuralUnionSource (attr : string) : string =
+        $"""namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+type FooArgs =
+    {{
+        Foo : int
+    }}
+
+type BarArgs =
+    {{
+        Bar : int
+    }}
+
+type Mode =
+    | FooCase of FooArgs
+    | BarCase of BarArgs
+
+[<ArgParser>]
+type Args =
+    {{
+        [<%s{attr}>]
+        A : Mode
+    }}
+"""
+
+    [<Test>]
+    let ``PositionalArgs on a sub-record field is rejected`` () =
+        structuralRecordSource "PositionalArgs"
+        |> shouldRejectWith (positionalOnStructural "A" "Child")
+
+    [<Test>]
+    let ``PositionalArgs on a union-typed field is rejected`` () =
+        structuralUnionSource "PositionalArgs"
+        |> shouldRejectWith (positionalOnStructural "A" "Mode")
+
+    /// The attribute takes an optional argument, and the rejection must not depend on which
+    /// constructor was used to write it.
+    [<Test>]
+    let ``PositionalArgs with an explicit argument on a sub-record field is rejected`` () =
+        structuralRecordSource "PositionalArgs true"
+        |> shouldRejectWith (positionalOnStructural "A" "Child")
+
+    [<Test>]
+    let ``ParseExact on a sub-record field is rejected`` () =
+        structuralRecordSource "ParseExact \"hh\\:mm\""
+        |> shouldRejectWith (parseExactOnStructural "A" "Child")
+
+    [<Test>]
+    let ``ParseExact on a union-typed field is rejected`` () =
+        structuralUnionSource "ParseExact \"hh\\:mm\""
+        |> shouldRejectWith (parseExactOnStructural "A" "Mode")
+
+    [<Test>]
+    let ``InvariantCulture on a sub-record field is rejected`` () =
+        structuralRecordSource "InvariantCulture"
+        |> shouldRejectWith (invariantCultureOnStructural "A" "Child")
+
+    [<Test>]
+    let ``InvariantCulture on a union-typed field is rejected`` () =
+        structuralUnionSource "InvariantCulture"
+        |> shouldRejectWith (invariantCultureOnStructural "A" "Mode")
+
+    [<Test>]
+    let ``ArgumentNegateWithPrefix on a sub-record field is rejected`` () =
+        structuralRecordSource "ArgumentNegateWithPrefix"
+        |> shouldRejectWith (negateOnStructural "A" "Child")
+
+    [<Test>]
+    let ``ArgumentNegateWithPrefix on a union-typed field is rejected`` () =
+        structuralUnionSource "ArgumentNegateWithPrefix"
+        |> shouldRejectWith (negateOnStructural "A" "Mode")
+
+    /// Each attribute is rejected under its long spelling too: F# admits both, and the leaf
+    /// machinery has always accepted both, so a check which saw only the short one would let the
+    /// longer spelling through to the silent-no-op behaviour this replaces.
+    [<Test>]
+    let ``Leaf-only attributes on a structural field are rejected under their long spellings`` () =
+        structuralRecordSource "PositionalArgsAttribute"
+        |> shouldRejectWith (positionalOnStructural "A" "Child")
+
+        structuralRecordSource "ParseExactAttribute \"hh\\:mm\""
+        |> shouldRejectWith (parseExactOnStructural "A" "Child")
+
+        structuralRecordSource "InvariantCultureAttribute"
+        |> shouldRejectWith (invariantCultureOnStructural "A" "Child")
+
+        structuralRecordSource "ArgumentNegateWithPrefixAttribute"
+        |> shouldRejectWith (negateOnStructural "A" "Child")
+
+    /// The rejection is about the *field's* attribute, not about the child's: each of these on the
+    /// leaf field it actually describes is entirely ordinary, which is precisely the placement the
+    /// messages point at.
+    [<Test>]
+    let ``Leaf-only attributes inside a sub-record are still accepted`` () =
+        let modules =
+            generateFromSource
+                """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+type Child =
+    {
+        [<PositionalArgs>]
+        Rest : string list
+        [<ParseExact "hh\:mm">]
+        [<InvariantCulture>]
+        Duration : System.TimeSpan
+        [<ArgumentNegateWithPrefix>]
+        Verbose : bool
+    }
+
+[<ArgParser>]
+type Args =
+    {
+        A : Child
+    }
+"""
+
+        List.length modules |> shouldEqual 2
+
+    /// `hasNegateAttr` was computed inside the non-positional leaf branch only; the positional
+    /// branch never looked at it and hardcoded `AcceptsNegation = false`, so the attribute was
+    /// silently ignored. The existing negation rejections all concern leaf fields of the wrong
+    /// scalar shape; none covered a positional field, whose problem is different in kind. Note that
+    /// a positional sink *is* addressable -- `--rest value` and `--rest=value` route to it, as can
+    /// an explicit [<ArgumentLongForm>] -- so the complaint is not that it has no name, but that a
+    /// value-accumulating sink has no boolean for a `--no-` form to invert.
+    let private negateOnPositional (field : string) : string =
+        $"[<ArgumentNegateWithPrefix>] was applied to field '%s{field}', which carries [<PositionalArgs>]. Negation inverts a boolean argument: `--no-foo` means the same as `--foo=false`. A positional field is a sink which accumulates values -- its keyed spellings take a value and add it to the collection, rather than setting anything -- so there is no boolean here for a `--no-` form to invert. Remove the [<ArgumentNegateWithPrefix>], or move it to the named boolean field you mean to negate."
+
+    [<Test>]
+    let ``ArgumentNegateWithPrefix on a positional field is rejected`` () =
+        """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+[<ArgParser>]
+type Args =
+    {
+        [<PositionalArgs>]
+        [<ArgumentNegateWithPrefix>]
+        Blah : string list
+    }
+"""
+        |> shouldRejectWith (negateOnPositional "Blah")
+
+    /// The shape which most invites the mistake: the field really is boolean-like, so every other
+    /// negation check passes it, and only its being positional makes negation meaningless.
+    [<Test>]
+    let ``ArgumentNegateWithPrefix on a boolean positional field is rejected`` () =
+        """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+[<ArgParser>]
+type Args =
+    {
+        [<PositionalArgs>]
+        [<ArgumentNegateWithPrefix>]
+        Blah : bool list
+    }
+"""
+        |> shouldRejectWith (negateOnPositional "Blah")
+
+    [<Test>]
+    let ``ArgumentNegateWithPrefix on a positional field is rejected under its long spelling`` () =
+        """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+[<ArgParser>]
+type Args =
+    {
+        [<PositionalArgs true>]
+        [<ArgumentNegateWithPrefixAttribute>]
+        Blah : string list
+    }
+"""
+        |> shouldRejectWith (negateOnPositional "Blah")
+
+    /// Neither attribute is at fault on its own: it is only their combination which cannot mean
+    /// anything.
+    [<Test>]
+    let ``A positional field and a negated boolean field coexist`` () =
+        let modules =
+            generateFromSource
+                """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+[<ArgParser>]
+type Args =
+    {
+        [<PositionalArgs>]
+        Rest : string list
+        [<ArgumentNegateWithPrefix>]
+        Verbose : bool
+    }
+"""
+
+        List.length modules |> shouldEqual 2
+
+    /// [<ParseExact>] and [<InvariantCulture>] are read in exactly one place: the TimeSpan arm of
+    /// `createParseFunction`. On any other type nothing reads them, and for [<ParseExact>] that is
+    /// worse than silence -- the help text advertises the format unconditionally, so the generated
+    /// --help promises a format the generated parser does not honour.
+    let private parseExactOnNonTimeSpan (field : string) (ty : string) : string =
+        $"[<ParseExact>] is only honoured on System.TimeSpan fields, but was applied to field '%s{field}' of type %s{ty}. Nothing reads it there, so the value is parsed in the default way -- while the generated help text still advertises the format, promising something the parser does not do. Remove it, or use a System.TimeSpan: the attribute reaches through option, list and map, so `System.TimeSpan option` and `Map<string, System.TimeSpan>` are honoured too."
+
+    let private invariantCultureOnNonTimeSpan (field : string) (ty : string) : string =
+        $"[<InvariantCulture>] is only honoured on System.TimeSpan fields, but was applied to field '%s{field}' of type %s{ty}. Nothing reads it there, so the value is parsed in whatever culture the default parse uses. Remove it, or use a System.TimeSpan: the attribute reaches through option, list and map, so `System.TimeSpan option` and `Map<string, System.TimeSpan>` are honoured too."
+
+    let private leafSource (attr : string) (ty : string) : string =
+        $"""namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+[<ArgParser>]
+type Args =
+    {{
+        [<%s{attr}>]
+        Blah : %s{ty}
+    }}
+"""
+
+    /// The motivating case: `string` has no notion of a parse format, so the format is dropped --
+    /// but the help text still shows it, and the author is told nothing.
+    ///
+    /// Note that `System.DateTime`, the type an author most likely reaches for a format with, is
+    /// not supported by the generator at all and fails earlier with its own message; there is
+    /// therefore no lying help to fix there, only here.
+    [<TestCase("string", "string")>]
+    [<TestCase("int", "int32")>]
+    [<TestCase("bool", "bool")>]
+    let ``ParseExact on a non-TimeSpan field is rejected`` (ty : string, described : string) =
+        leafSource "ParseExact \"hh\\:mm\"" ty
+        |> shouldRejectWith (parseExactOnNonTimeSpan "Blah" described)
+
+    [<TestCase("string", "string")>]
+    [<TestCase("int", "int32")>]
+    [<TestCase("bool", "bool")>]
+    let ``InvariantCulture on a non-TimeSpan field is rejected`` (ty : string, described : string) =
+        leafSource "InvariantCulture" ty
+        |> shouldRejectWith (invariantCultureOnNonTimeSpan "Blah" described)
+
+    /// The check runs against the type actually handed to the parser, so a list or option of the
+    /// wrong element type is reported rather than being waved through.
+    [<TestCase("int list", "int32 list")>]
+    [<TestCase("int option", "int32 option")>]
+    let ``ParseExact on a collection of a non-TimeSpan is rejected`` (ty : string, described : string) =
+        leafSource "ParseExact \"hh\\:mm\"" ty
+        |> shouldRejectWith (parseExactOnNonTimeSpan "Blah" described)
+
+    [<Test>]
+    let ``ParseExact on a positional field of the wrong element type is rejected`` () =
+        """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+[<ArgParser>]
+type Args =
+    {
+        [<PositionalArgs>]
+        [<ParseExact "hh\:mm">]
+        Blah : int list
+    }
+"""
+        |> shouldRejectWith (parseExactOnNonTimeSpan "Blah" "int32 list")
+
+    /// A map whose key and value are both innocent of TimeSpan consumes neither attribute.
+    [<Test>]
+    let ``ParseExact on a map of no TimeSpans is rejected`` () =
+        """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+[<ArgParser>]
+type Args =
+    {
+        [<ArgumentKeyValueSeparator '='>]
+        [<ParseExact "hh\:mm">]
+        Blah : Map<string, string>
+    }
+"""
+        |> shouldRejectWith (parseExactOnNonTimeSpan "Blah" "map<string, string>")
+
+    [<Test>]
+    let ``ParseExact and InvariantCulture are rejected under their long spellings`` () =
+        leafSource "ParseExactAttribute \"hh\\:mm\"" "int"
+        |> shouldRejectWith (parseExactOnNonTimeSpan "Blah" "int32")
+
+        leafSource "InvariantCultureAttribute" "int"
+        |> shouldRejectWith (invariantCultureOnNonTimeSpan "Blah" "int32")
+
+    /// The placements where the attributes *are* read must keep working: the parse function
+    /// recurses through option, list and choice, so each of those reaches the TimeSpan arm.
+    [<TestCase("System.TimeSpan")>]
+    [<TestCase("System.TimeSpan option")>]
+    [<TestCase("System.TimeSpan list")>]
+    let ``ParseExact and InvariantCulture on TimeSpan-shaped fields are accepted`` (ty : string) =
+        generateFromSource (leafSource "ParseExact \"hh\\:mm\"" ty)
+        |> List.length
+        |> shouldEqual 2
+
+        generateFromSource (leafSource "InvariantCulture" ty)
+        |> List.length
+        |> shouldEqual 2
+
+    /// A map hands the field's attributes to *both* its key parser and its value parser, so the
+    /// attribute is genuinely consumed whenever either component is a TimeSpan. Rejecting maps
+    /// wholesale would have broken working schemas.
+    [<TestCase("Map<string, System.TimeSpan>")>]
+    [<TestCase("Map<System.TimeSpan, string>")>]
+    [<TestCase("Map<System.TimeSpan, System.TimeSpan>")>]
+    let ``ParseExact on a map containing a TimeSpan is accepted`` (ty : string) =
+        $"""namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+[<ArgParser>]
+type Args =
+    {{
+        [<ArgumentKeyValueSeparator '='>]
+        [<ParseExact "hh\:mm">]
+        Blah : %s{ty}
+    }}
+"""
+        |> generateFromSource
+        |> List.length
+        |> shouldEqual 2
+
+    /// [<ArgumentHelpText>] is deliberately NOT in the list: on a structural field it introduces
+    /// the group of arguments the field contributes, which is a real and documented use.
+    [<Test>]
+    let ``ArgumentHelpText on a structural field is still accepted`` () =
+        let modules =
+            generateFromSource
+                """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+type Child =
+    {
+        Blah : int
+    }
+
+[<ArgParser>]
+type Args =
+    {
+        [<ArgumentHelpText "Database settings">]
+        A : Child
+    }
+"""
+
+        List.length modules |> shouldEqual 2

--- a/WoofWare.Myriad.Plugins/version.json
+++ b/WoofWare.Myriad.Plugins/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "10.7",
+  "version": "11.0",
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],


### PR DESCRIPTION
Stage 1 of the attribute-rejection stack. Each stage is its own PR for review, but the stack lands in `main` as one collection of breaking changes.

`[<ArgumentFlag>]` is read only from a union's *cases*, where it says which case means `true` and which means `false`. Placed on a record field, nothing read it at all — it silently did nothing. The attribute's own doc comment invited exactly that mistake by describing it as going on "a field".

The check sits above the leaf/structural dispatch, alongside the existing default-attribute check, so it fires for structural, positional and ordinary leaf fields alike rather than only where the leaf machinery happens to run.

**Breaking:** sources which previously built now fail to generate. This carries the `11.0` bump for the whole stack; the later rejection PRs land under it.

Tests written first and observed failing, in `TestArgParserRejection.fs`: the attribute on a bool leaf, on a flag-union-typed field (the likeliest mistake), on a nested-record field, on a structural-union field, on a positional field, and under its long `ArgumentFlagAttribute` spelling — plus a regression that the correct placement, on the union's cases, is still accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)