### PR TITLE
ArgParser: reject [<ArgumentNegateWithPrefix>] on positional fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 Notable changes are recorded here.
 
+# WoofWare.Myriad.Plugins 11.0.1
+
+Breaking change: `ArgParserGenerator` now rejects, at generation time, several attribute placements which it previously accepted and then silently ignored.
+
+* `[<ArgumentFlag>]` on a record field. It belongs on the two cases of a flag discriminated union, where it says which case means `true` and which means `false`; a field is not where that question can be answered.
+* `[<PositionalArgs>]`, `[<ParseExact>]`, `[<InvariantCulture>]` or `[<ArgumentNegateWithPrefix>]` on a field whose type is another argument record, or a union of alternative argument sets. Such a field contributes a whole set of arguments rather than one, so there is no single argument for these to collect into, spell or negate. `[<ArgumentHelpText>]` is deliberately still accepted there: it heads the group of arguments the field contributes.
+* `[<ArgumentNegateWithPrefix>]` on a `[<PositionalArgs>]` field. A positional field is a sink which accumulates values; its keyed spellings take a value rather than setting anything, so there is no boolean there for a `--no-` form to invert.
+* `[<ParseExact>]` or `[<InvariantCulture>]` on anything but a `System.TimeSpan`. These are read only by the `TimeSpan` parser. They continue to reach through the shapes which wrap a value — `TimeSpan option`, `TimeSpan list`, `Choice<TimeSpan, TimeSpan>`, and a `Map` either of whose halves is a `TimeSpan` — and are rejected only where no `TimeSpan` is reached at all. Future work may expand the range of types these attributes affect.
+
 # WoofWare.Myriad.Plugins 10.7.2
 
 `ArgParserGenerator` now reads `[<ArgumentHelpText>]` from a nested argument record or union of alternative argument sets, and not only from the `[<ArgParser>]`-tagged root, and from a discriminated union's case (and that case's payload record).

--- a/README.md
+++ b/README.md
@@ -243,7 +243,8 @@ and you get back respectively these objects:
 }
 ```
 
-You can control `TimeSpan` and friends with the `[<InvariantCulture>]` and `[<ParseExact @"hh\:mm\:ss">]` attributes.
+You can control how a `System.TimeSpan` is read with the `[<InvariantCulture>]` and `[<ParseExact @"hh\:mm\:ss">]` attributes.
+These are honoured on `TimeSpan` only — reaching through the shapes which wrap it, so `TimeSpan option`, `TimeSpan list` and a `Map` with a `TimeSpan` half are all covered — and are rejected on any other type, where nothing would read them.
 
 You can generate extension methods for the type, instead of a module with the type's name, using `[<ArgParser (* isExtensionMethod = *) true>]`.
 
@@ -378,6 +379,18 @@ Records compose: if your record contains other records which are visible to the 
 Discriminated unions compose with each other and with records, hopefully as you would expect: the fields specified by the record contained within the exactly-one field of each DU case must all be mutually satisified, or the parse will fail to select that DU field.
 We will fail at build time to generate a parser if you have several DU cases which contain fields of the same name, though, because in general resolving the parse in that case is NP-hard.
 (An upcoming piece of work will hopefully relax this restriction.)
+
+#### Attribute placement at a structural boundary
+
+A field whose type is another argument record, or a union of alternative argument sets, is *structural*: it contributes that type's whole set of arguments rather than being one argument itself.
+Most attributes describe single arguments, so are rejected at build time when applied to a structural field.
+
+Two attributes do apply to structural fields, because they are specifically about the group:
+
+* `[<ArgumentHelpText>]` describes the whole group of arguments the field contributes, and appears on the header line introducing it.
+* `[<ArgumentPrefix>]` namespaces every argument in the subtree; conversely, it is rejected on a leaf, which has no subtree.
+
+`[<ArgumentFlag>]` is not a field attribute at all: it goes on the two cases of a flag discriminated union, and is rejected on a record field.
 
 ### What's the point?
 

--- a/WoofWare.Myriad.Plugins.Attributes/ArgParserAttributes.fs
+++ b/WoofWare.Myriad.Plugins.Attributes/ArgParserAttributes.fs
@@ -31,6 +31,18 @@ type ArgParserAttribute (isExtensionMethod : bool) =
 /// tell you whether each arg came before or after a standalone `--` separator.
 /// For example, `MyApp foo bar -- baz` with PositionalArgs of `Choice<string, string>`
 /// would yield `Choice1Of2 foo, Choice1Of2 bar, Choice2Of2 baz`.
+///
+/// This attribute applies to an argument *leaf*. It is rejected on a field whose type is another
+/// [<ArgParser>]-schema record or a discriminated union of alternative argument sets: such a field
+/// contributes a whole set of arguments rather than being a place values can be collected into, so
+/// put the attribute on the leaf field inside that type which should do the collecting.
+///
+/// A positional field is a sink which accumulates values. It is addressable: `--foo value` and
+/// `--foo=value` route to it, as does any explicit [<ArgumentLongForm>]. But those keyed forms
+/// take a value rather than setting anything, so the field is rejected in combination with
+/// [<ArgumentNegateWithPrefix>] (there is no boolean for a `--no-` form to invert) and with
+/// [<ArgumentPrefix>] (there is no subtree to namespace), and it may not carry a default
+/// (positional args are collected, not defaulted).
 type PositionalArgsAttribute (includeFlagLike : bool) =
     inherit Attribute ()
 
@@ -102,25 +114,42 @@ type ArgumentDefaultValueAttribute (defaultValue : obj) =
 type ArgumentHelpTextAttribute (helpText : string) =
     inherit Attribute ()
 
-/// Attribute indicating that this field should be parsed with a ParseExact method on its type.
-/// For example, on a TimeSpan field, with [<ArgumentParseExact @"hh\:mm\:ss">], we will call
-/// `TimeSpan.ParseExact (s, @"hh\:mm\:ss", CultureInfo.CurrentCulture).
+/// Attribute giving the format in which this field's value is written.
+/// For example, on a TimeSpan field, with [<ParseExact @"hh\:mm\:ss">], we will call
+/// `TimeSpan.ParseExact (s, @"hh\:mm\:ss", CultureInfo.CurrentCulture)`.
+///
+/// This attribute is honoured on `System.TimeSpan` only, and is rejected anywhere else: no other
+/// type's parser reads it, so it would otherwise be dropped in silence while the generated help
+/// text went on advertising a format the parser did not apply.
+///
+/// It reaches through the shapes which wrap a value, since those parse their components with it:
+/// `TimeSpan option`, `TimeSpan list` and `Choice<TimeSpan, TimeSpan>` are all honoured, as is a
+/// `Map` either of whose halves is a `TimeSpan` (in which case the format describes each `TimeSpan`
+/// half; a map with no `TimeSpan` at all is rejected).
 type ParseExactAttribute (format : string) =
     inherit Attribute ()
 
 /// Attribute indicating that this field should be parsed in the invariant culture, rather than the
 /// default current culture.
-/// For example, on a TimeSpan field, with [<InvariantCulture>] and [<ArgumentParseExact @"hh\:mm\:ss">], we will call
-/// `TimeSpan.ParseExact (s, @"hh\:mm\:ss", CultureInfo.InvariantCulture).
+/// For example, on a TimeSpan field, with [<InvariantCulture>] and [<ParseExact @"hh\:mm\:ss">], we will call
+/// `TimeSpan.ParseExact (s, @"hh\:mm\:ss", CultureInfo.InvariantCulture)`.
+///
+/// As with [<ParseExact>], this is honoured on `System.TimeSpan` only -- reaching through option,
+/// list, choice and map in the same way -- and is rejected anywhere else, where nothing would read
+/// it.
 type InvariantCultureAttribute () =
     inherit Attribute ()
 
-/// Attribute placed on a field of a two-case no-data discriminated union, indicating that this is "basically a bool".
+/// Attribute placed on each case of a two-case no-data discriminated union, indicating that the
+/// union is "basically a bool".
 /// For example: `type DryRun = | [<ArgumentFlag true>] Dry | [<ArgumentFlag false>] Wet`
 /// A record with `{ DryRun : DryRun }` will then be parsed like `{ DryRun : bool }` (so the user supplies `--dry-run`),
 /// but that you get this strongly-typed value directly in the code (so you `match args.DryRun with | DryRun.Dry ...`).
 ///
 /// You must put this attribute on both cases of the discriminated union, with opposite values in each case.
+///
+/// It belongs on the union's *cases*, and is rejected on a record field: a field is not where the
+/// question "which case means true?" can be answered, and nothing read the attribute there.
 type ArgumentFlagAttribute (flagValue : bool) =
     inherit Attribute ()
 
@@ -132,6 +161,12 @@ type ArgumentFlagAttribute (flagValue : bool) =
 /// You can place this argument multiple times.
 ///
 /// Omit the initial `--` that you expect the user to type.
+///
+/// This attribute applies to an argument *leaf*. It is rejected on a field whose type is another
+/// [<ArgParser>]-schema record or a discriminated union of alternative argument sets: such a field
+/// contributes a whole set of arguments, each named by its own field, so there is no single
+/// argument here to rename. Put the attribute on the field you mean to rename, or use
+/// [<ArgumentPrefix>] to rename the whole subtree at once.
 [<AttributeUsage(AttributeTargets.Field, AllowMultiple = true)>]
 type ArgumentLongForm (s : string) =
     inherit Attribute ()
@@ -215,6 +250,12 @@ type ArgumentMapEntrySeparatorAttribute (separator : char) =
 ///   --no-field-name=false sets to the [<ArgumentFlag true>] case
 ///
 /// This attribute can only be applied to bool fields or flag DU fields (two-case DUs with [<ArgumentFlag>]).
+///
+/// It applies to an argument *leaf*, and to a leaf which has a name. So it is also rejected on a
+/// field whose type is another [<ArgParser>]-schema record or a discriminated union of alternative
+/// argument sets (which contributes a whole set of arguments, none of them singled out for
+/// negation), and on a [<PositionalArgs>] field (which accumulates values, so although it is
+/// addressable, there is no boolean there for a `--no-` form to invert).
 [<AttributeUsage(AttributeTargets.Field, AllowMultiple = false)>]
 type ArgumentNegateWithPrefixAttribute () =
     inherit Attribute ()

--- a/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
+++ b/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
@@ -911,6 +911,60 @@ module internal ArgParserGenerator =
         | Accumulation.Choice _
         | Accumulation.List _ -> rejectSeparatorAttributes fieldName fieldType attrs
 
+    /// [<ParseExact>] and [<InvariantCulture>] are read in exactly one place: the TimeSpan arm of
+    /// `createParseFunction`. On any other type they are dropped -- and for [<ParseExact>] that is
+    /// worse than silence, because `helpText` advertises the format unconditionally, so the
+    /// generated --help promises a format the generated parser does not honour.
+    ///
+    /// Checked after the parse function has been built, against the type actually handed to the
+    /// parser rather than the declared field type -- exactly as `checkSeparatorAttributesPlacement`
+    /// is, and for the same reason: `TimeSpan option` and `TimeSpan list` reach the TimeSpan arm
+    /// through the recursion, so their element type is what the attribute really describes.
+    ///
+    /// A map is the one shape where that type is not the whole story: it hands the field's
+    /// attributes to its key parser as well as its value parser, so the attribute is genuinely
+    /// consumed if *either* component is a TimeSpan, while `parseTy` is only the value's.
+    let private checkCultureAttributesPlacement
+        (fieldName : Ident)
+        (fieldType : SynType)
+        (attrs : SynAttribute list)
+        (accumulation : Accumulation<'choice>)
+        (parseTy : SynType)
+        : unit
+        =
+        let isTimeSpan (ty : SynType) : bool =
+            match ty with
+            | TimeSpan -> true
+            | _ -> false
+
+        let consumed =
+            match accumulation with
+            | Accumulation.Map spec -> isTimeSpan spec.KeyType || isTimeSpan parseTy
+            | Accumulation.Required
+            | Accumulation.Optional
+            | Accumulation.Choice _
+            | Accumulation.List _ -> isTimeSpan parseTy
+
+        if not consumed then
+            let reject (names : string list) (display : string) (consequence : string) : unit =
+                let present =
+                    attrs
+                    |> List.exists (fun attr -> names |> List.contains (List.last attr.TypeName.LongIdent).idText)
+
+                if present then
+                    failwith
+                        $"[<%s{display}>] is only honoured on System.TimeSpan fields, but was applied to field '%s{fieldName.idText}' of type %s{describeType fieldType}. %s{consequence} Remove it, or use a System.TimeSpan: the attribute reaches through option, list and map, so `System.TimeSpan option` and `Map<string, System.TimeSpan>` are honoured too."
+
+            reject
+                [ "ParseExact" ; "ParseExactAttribute" ]
+                "ParseExact"
+                "Nothing reads it there, so the value is parsed in the default way -- while the generated help text still advertises the format, promising something the parser does not do."
+
+            reject
+                [ "InvariantCulture" ; "InvariantCultureAttribute" ]
+                "InvariantCulture"
+                "Nothing reads it there, so the value is parsed in whatever culture the default parse uses."
+
     /// What we found in the argument of an `[<ArgumentDefaultValue>]`.
     type private DefaultValueExpr =
         /// A constant written out in full. It denotes the same value wherever it appears, so we can
@@ -1802,6 +1856,7 @@ module internal ArgParserGenerator =
                         createParseFunction<unit> getChoice ambient finalRecord.Name ident attrs fieldType
 
                     checkSeparatorAttributesPlacement ident fieldType attrs accumulation
+                    checkCultureAttributesPlacement ident fieldType attrs accumulation parseTy
 
                     let isBoolLike =
                         match parseTy with
@@ -1866,6 +1921,7 @@ module internal ArgParserGenerator =
                         createParseFunction getChoice ambient finalRecord.Name ident attrs fieldType
 
                     checkSeparatorAttributesPlacement ident fieldType attrs accumulation
+                    checkCultureAttributesPlacement ident fieldType attrs accumulation parseTy
 
                     // A map's `parseTy` describes its *values*, not the field, so the boolean and
                     // enumerated metadata derived from it would misdescribe the argument. In

--- a/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
+++ b/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
@@ -1784,13 +1784,15 @@ module internal ArgParserGenerator =
 
                 match positionalArgAttr with
                 | Some includeFlagLike ->
-                    // A positional field is not spelled: it collects whatever carries no name. So
-                    // there is no name here for a --no- variant to be formed from, whatever the
-                    // field's type -- this is not the same complaint as the boolean-shape check on
-                    // the non-positional side below.
+                    // A positional field does have keyed spellings -- `--blah value` and
+                    // `--blah=value` route to the sink, and [<ArgumentLongForm>] can add more --
+                    // but they are value-taking routing keys, not a boolean to invert. So the
+                    // complaint is about what negation *means* here, not about the absence of a
+                    // name, and it holds whatever the field's element type: this is not the same
+                    // check as the boolean-shape one on the non-positional side below.
                     if hasNegateAttr then
                         failwith
-                            $"[<ArgumentNegateWithPrefix>] was applied to field '%s{ident.idText}', which carries [<PositionalArgs>]. Negation gives a boolean argument a --no- spelling, and a positional field has no spelling to negate: it collects the arguments which carry no name at all. Remove the [<ArgumentNegateWithPrefix>], or move it to the named boolean field you mean to negate."
+                            $"[<ArgumentNegateWithPrefix>] was applied to field '%s{ident.idText}', which carries [<PositionalArgs>]. Negation inverts a boolean argument: `--no-foo` means the same as `--foo=false`. A positional field is a sink which accumulates values -- its keyed spellings take a value and add it to the collection, rather than setting anything -- so there is no boolean here for a `--no-` form to invert. Remove the [<ArgumentNegateWithPrefix>], or move it to the named boolean field you mean to negate."
 
                     // Positional fields carrying a default attribute are rejected above, so the
                     // Choice-parsing path only ever reaches this callback with `None`.

--- a/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
+++ b/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
@@ -1770,8 +1770,28 @@ module internal ArgParserGenerator =
                         $"[<ArgumentPrefix>] can only be applied to a field whose type is another [<ArgParser>]-schema record or a discriminated union of alternative argument sets, but was applied to field '%s{ident.idText}' of type %s{describeType fieldType}. It renames every argument contributed by that field's subtree by prepending a namespace (e.g. [<ArgumentPrefix \"foo\">] on a field whose type is a record containing `Blah : string` turns --blah into --foo-blah); a leaf field has no subtree to rename. To change this one argument's name, use [<ArgumentLongForm>] instead."
                 | None -> ()
 
+                // Read before the positional split, because both sides have something to say about
+                // it: the positional branch cannot honour it at all, and previously did not even
+                // look, hardcoding `AcceptsNegation = false` and dropping the attribute in silence.
+                let hasNegateAttr =
+                    attrs
+                    |> List.exists (fun attr ->
+                        match (List.last attr.TypeName.LongIdent).idText with
+                        | "ArgumentNegateWithPrefixAttribute"
+                        | "ArgumentNegateWithPrefix" -> true
+                        | _ -> false
+                    )
+
                 match positionalArgAttr with
                 | Some includeFlagLike ->
+                    // A positional field is not spelled: it collects whatever carries no name. So
+                    // there is no name here for a --no- variant to be formed from, whatever the
+                    // field's type -- this is not the same complaint as the boolean-shape check on
+                    // the non-positional side below.
+                    if hasNegateAttr then
+                        failwith
+                            $"[<ArgumentNegateWithPrefix>] was applied to field '%s{ident.idText}', which carries [<PositionalArgs>]. Negation gives a boolean argument a --no- spelling, and a positional field has no spelling to negate: it collects the arguments which carry no name at all. Remove the [<ArgumentNegateWithPrefix>], or move it to the named boolean field you mean to negate."
+
                     // Positional fields carrying a default attribute are rejected above, so the
                     // Choice-parsing path only ever reaches this callback with `None`.
                     let getChoice (_ : ArgumentDefaultSpec option) : unit = ()
@@ -1898,17 +1918,6 @@ module internal ArgParserGenerator =
                         | Accumulation.Optional
                         | Accumulation.Choice _
                         | Accumulation.List _ -> None
-
-                    let hasNegateAttr =
-                        attrs
-                        |> List.exists (fun attr ->
-                            match attr.TypeName with
-                            | SynLongIdent.SynLongIdent (ident, _, _) ->
-                                match (List.last ident).idText with
-                                | "ArgumentNegateWithPrefixAttribute"
-                                | "ArgumentNegateWithPrefix" -> true
-                                | _ -> false
-                        )
 
                     let acceptsNegation =
                         if hasNegateAttr then

--- a/WoofWare.Myriad.Plugins/Test/TestArgParserRejection.fs
+++ b/WoofWare.Myriad.Plugins/Test/TestArgParserRejection.fs
@@ -2926,6 +2926,86 @@ type Args =
 
         List.length modules |> shouldEqual 2
 
+    /// `hasNegateAttr` was computed inside the non-positional leaf branch only; the positional
+    /// branch never looked at it and hardcoded `AcceptsNegation = false`, so the attribute was
+    /// silently ignored. The existing negation rejections all concern leaf fields of the wrong
+    /// scalar shape; none covered a positional field, whose problem is different in kind -- there
+    /// is no argument *name* to attach a --no- spelling to.
+    let private negateOnPositional (field : string) : string =
+        $"[<ArgumentNegateWithPrefix>] was applied to field '%s{field}', which carries [<PositionalArgs>]. Negation gives a boolean argument a --no- spelling, and a positional field has no spelling to negate: it collects the arguments which carry no name at all. Remove the [<ArgumentNegateWithPrefix>], or move it to the named boolean field you mean to negate."
+
+    [<Test>]
+    let ``ArgumentNegateWithPrefix on a positional field is rejected`` () =
+        """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+[<ArgParser>]
+type Args =
+    {
+        [<PositionalArgs>]
+        [<ArgumentNegateWithPrefix>]
+        Blah : string list
+    }
+"""
+        |> shouldRejectWith (negateOnPositional "Blah")
+
+    /// The shape which most invites the mistake: the field really is boolean-like, so every other
+    /// negation check passes it, and only its being positional makes negation meaningless.
+    [<Test>]
+    let ``ArgumentNegateWithPrefix on a boolean positional field is rejected`` () =
+        """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+[<ArgParser>]
+type Args =
+    {
+        [<PositionalArgs>]
+        [<ArgumentNegateWithPrefix>]
+        Blah : bool list
+    }
+"""
+        |> shouldRejectWith (negateOnPositional "Blah")
+
+    [<Test>]
+    let ``ArgumentNegateWithPrefix on a positional field is rejected under its long spelling`` () =
+        """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+[<ArgParser>]
+type Args =
+    {
+        [<PositionalArgs true>]
+        [<ArgumentNegateWithPrefixAttribute>]
+        Blah : string list
+    }
+"""
+        |> shouldRejectWith (negateOnPositional "Blah")
+
+    /// Neither attribute is at fault on its own: it is only their combination which cannot mean
+    /// anything.
+    [<Test>]
+    let ``A positional field and a negated boolean field coexist`` () =
+        let modules =
+            generateFromSource
+                """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+[<ArgParser>]
+type Args =
+    {
+        [<PositionalArgs>]
+        Rest : string list
+        [<ArgumentNegateWithPrefix>]
+        Verbose : bool
+    }
+"""
+
+        List.length modules |> shouldEqual 2
+
     /// [<ArgumentHelpText>] is deliberately NOT in the list: on a structural field it introduces
     /// the group of arguments the field contributes, which is a real and documented use.
     [<Test>]

--- a/WoofWare.Myriad.Plugins/Test/TestArgParserRejection.fs
+++ b/WoofWare.Myriad.Plugins/Test/TestArgParserRejection.fs
@@ -2929,10 +2929,12 @@ type Args =
     /// `hasNegateAttr` was computed inside the non-positional leaf branch only; the positional
     /// branch never looked at it and hardcoded `AcceptsNegation = false`, so the attribute was
     /// silently ignored. The existing negation rejections all concern leaf fields of the wrong
-    /// scalar shape; none covered a positional field, whose problem is different in kind -- there
-    /// is no argument *name* to attach a --no- spelling to.
+    /// scalar shape; none covered a positional field, whose problem is different in kind. Note that
+    /// a positional sink *is* addressable -- `--rest value` and `--rest=value` route to it, as can
+    /// an explicit [<ArgumentLongForm>] -- so the complaint is not that it has no name, but that a
+    /// value-accumulating sink has no boolean for a `--no-` form to invert.
     let private negateOnPositional (field : string) : string =
-        $"[<ArgumentNegateWithPrefix>] was applied to field '%s{field}', which carries [<PositionalArgs>]. Negation gives a boolean argument a --no- spelling, and a positional field has no spelling to negate: it collects the arguments which carry no name at all. Remove the [<ArgumentNegateWithPrefix>], or move it to the named boolean field you mean to negate."
+        $"[<ArgumentNegateWithPrefix>] was applied to field '%s{field}', which carries [<PositionalArgs>]. Negation inverts a boolean argument: `--no-foo` means the same as `--foo=false`. A positional field is a sink which accumulates values -- its keyed spellings take a value and add it to the collection, rather than setting anything -- so there is no boolean here for a `--no-` form to invert. Remove the [<ArgumentNegateWithPrefix>], or move it to the named boolean field you mean to negate."
 
     [<Test>]
     let ``ArgumentNegateWithPrefix on a positional field is rejected`` () =

--- a/WoofWare.Myriad.Plugins/Test/TestArgParserRejection.fs
+++ b/WoofWare.Myriad.Plugins/Test/TestArgParserRejection.fs
@@ -3008,6 +3008,135 @@ type Args =
 
         List.length modules |> shouldEqual 2
 
+    /// [<ParseExact>] and [<InvariantCulture>] are read in exactly one place: the TimeSpan arm of
+    /// `createParseFunction`. On any other type nothing reads them, and for [<ParseExact>] that is
+    /// worse than silence -- the help text advertises the format unconditionally, so the generated
+    /// --help promises a format the generated parser does not honour.
+    let private parseExactOnNonTimeSpan (field : string) (ty : string) : string =
+        $"[<ParseExact>] is only honoured on System.TimeSpan fields, but was applied to field '%s{field}' of type %s{ty}. Nothing reads it there, so the value is parsed in the default way -- while the generated help text still advertises the format, promising something the parser does not do. Remove it, or use a System.TimeSpan: the attribute reaches through option, list and map, so `System.TimeSpan option` and `Map<string, System.TimeSpan>` are honoured too."
+
+    let private invariantCultureOnNonTimeSpan (field : string) (ty : string) : string =
+        $"[<InvariantCulture>] is only honoured on System.TimeSpan fields, but was applied to field '%s{field}' of type %s{ty}. Nothing reads it there, so the value is parsed in whatever culture the default parse uses. Remove it, or use a System.TimeSpan: the attribute reaches through option, list and map, so `System.TimeSpan option` and `Map<string, System.TimeSpan>` are honoured too."
+
+    let private leafSource (attr : string) (ty : string) : string =
+        $"""namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+[<ArgParser>]
+type Args =
+    {{
+        [<%s{attr}>]
+        Blah : %s{ty}
+    }}
+"""
+
+    /// The motivating case: `string` has no notion of a parse format, so the format is dropped --
+    /// but the help text still shows it, and the author is told nothing.
+    ///
+    /// Note that `System.DateTime`, the type an author most likely reaches for a format with, is
+    /// not supported by the generator at all and fails earlier with its own message; there is
+    /// therefore no lying help to fix there, only here.
+    [<TestCase("string", "string")>]
+    [<TestCase("int", "int32")>]
+    [<TestCase("bool", "bool")>]
+    let ``ParseExact on a non-TimeSpan field is rejected`` (ty : string, described : string) =
+        leafSource "ParseExact \"hh\\:mm\"" ty
+        |> shouldRejectWith (parseExactOnNonTimeSpan "Blah" described)
+
+    [<TestCase("string", "string")>]
+    [<TestCase("int", "int32")>]
+    [<TestCase("bool", "bool")>]
+    let ``InvariantCulture on a non-TimeSpan field is rejected`` (ty : string, described : string) =
+        leafSource "InvariantCulture" ty
+        |> shouldRejectWith (invariantCultureOnNonTimeSpan "Blah" described)
+
+    /// The check runs against the type actually handed to the parser, so a list or option of the
+    /// wrong element type is reported rather than being waved through.
+    [<TestCase("int list", "int32 list")>]
+    [<TestCase("int option", "int32 option")>]
+    let ``ParseExact on a collection of a non-TimeSpan is rejected`` (ty : string, described : string) =
+        leafSource "ParseExact \"hh\\:mm\"" ty
+        |> shouldRejectWith (parseExactOnNonTimeSpan "Blah" described)
+
+    [<Test>]
+    let ``ParseExact on a positional field of the wrong element type is rejected`` () =
+        """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+[<ArgParser>]
+type Args =
+    {
+        [<PositionalArgs>]
+        [<ParseExact "hh\:mm">]
+        Blah : int list
+    }
+"""
+        |> shouldRejectWith (parseExactOnNonTimeSpan "Blah" "int32 list")
+
+    /// A map whose key and value are both innocent of TimeSpan consumes neither attribute.
+    [<Test>]
+    let ``ParseExact on a map of no TimeSpans is rejected`` () =
+        """namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+[<ArgParser>]
+type Args =
+    {
+        [<ArgumentKeyValueSeparator '='>]
+        [<ParseExact "hh\:mm">]
+        Blah : Map<string, string>
+    }
+"""
+        |> shouldRejectWith (parseExactOnNonTimeSpan "Blah" "map<string, string>")
+
+    [<Test>]
+    let ``ParseExact and InvariantCulture are rejected under their long spellings`` () =
+        leafSource "ParseExactAttribute \"hh\\:mm\"" "int"
+        |> shouldRejectWith (parseExactOnNonTimeSpan "Blah" "int32")
+
+        leafSource "InvariantCultureAttribute" "int"
+        |> shouldRejectWith (invariantCultureOnNonTimeSpan "Blah" "int32")
+
+    /// The placements where the attributes *are* read must keep working: the parse function
+    /// recurses through option, list and choice, so each of those reaches the TimeSpan arm.
+    [<TestCase("System.TimeSpan")>]
+    [<TestCase("System.TimeSpan option")>]
+    [<TestCase("System.TimeSpan list")>]
+    let ``ParseExact and InvariantCulture on TimeSpan-shaped fields are accepted`` (ty : string) =
+        generateFromSource (leafSource "ParseExact \"hh\\:mm\"" ty)
+        |> List.length
+        |> shouldEqual 2
+
+        generateFromSource (leafSource "InvariantCulture" ty)
+        |> List.length
+        |> shouldEqual 2
+
+    /// A map hands the field's attributes to *both* its key parser and its value parser, so the
+    /// attribute is genuinely consumed whenever either component is a TimeSpan. Rejecting maps
+    /// wholesale would have broken working schemas.
+    [<TestCase("Map<string, System.TimeSpan>")>]
+    [<TestCase("Map<System.TimeSpan, string>")>]
+    [<TestCase("Map<System.TimeSpan, System.TimeSpan>")>]
+    let ``ParseExact on a map containing a TimeSpan is accepted`` (ty : string) =
+        $"""namespace TestMe
+
+open WoofWare.Myriad.Plugins
+
+[<ArgParser>]
+type Args =
+    {{
+        [<ArgumentKeyValueSeparator '='>]
+        [<ParseExact "hh\:mm">]
+        Blah : %s{ty}
+    }}
+"""
+        |> generateFromSource
+        |> List.length
+        |> shouldEqual 2
+
     /// [<ArgumentHelpText>] is deliberately NOT in the list: on a structural field it introduces
     /// the group of arguments the field contributes, which is a real and documented use.
     [<Test>]


### PR DESCRIPTION
Stage 3 of the attribute-rejection stack; stacked on #606.

`hasNegateAttr` was computed inside the non-positional leaf branch only. The positional branch never looked at it and hardcoded `AcceptsNegation = false`, so `[<PositionalArgs>] [<ArgumentNegateWithPrefix>] Foo : bool list` silently ignored the negation.

A positional field is not spelled at all — it collects whatever carries no name — so there is no name from which a `--no-` variant could be formed, *whatever the field's type*. That is a different complaint from the existing boolean-shape check (`Negation is only available on boolean-like fields`), which is why it gets its own message rather than being folded into it.

The extraction of `hasNegateAttr` moves above the positional split so both sides read one definition.

Tests written first and observed failing: negation on a positional `string list`, on a positional `bool list` (the shape which most invites the mistake, since every other negation check passes it), and under the long `ArgumentNegateWithPrefixAttribute` spelling — plus a regression that a positional field and a negated boolean field coexist happily, since neither attribute is at fault alone.

Breaking; lands under the `11.0` bump carried by #605.

🤖 Generated with [Claude Code](https://claude.com/claude-code)