### PR TITLE
Document ArgParser attribute placement, and the 11.0 breaking changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,13 @@
 Notable changes are recorded here.
 
-# WoofWare.Myriad.Plugins 11.0
+# WoofWare.Myriad.Plugins 11.0.1
 
-**Breaking.** `ArgParserGenerator` now rejects, at generation time, several attribute placements which it previously accepted and then silently ignored.
-Each was read by nothing at the placement in question, so a schema which used one got a parser that did not do what its author asked, with no indication why; in the `[<ParseExact>]` case the generated help text went further and advertised a format the parser did not apply.
-Sources which relied on any of these placements will now fail to build.
-Where the attribute has a placement which would read it, the rejection message names it; where it does not (a parse format on a type whose parser has no notion of one), the fix is to remove the attribute, or to change the field to a type which does read it.
+Breaking change: `ArgParserGenerator` now rejects, at generation time, several attribute placements which it previously accepted and then silently ignored.
 
-* `[<ArgumentFlag>]` on a record field. It belongs on the two cases of a flag discriminated union, where it says which case means `true` and which means `false`; a field is not where that question can be answered. (The attribute's own documentation invited the mistake by describing it as going on "a field"; that wording is fixed.)
+* `[<ArgumentFlag>]` on a record field. It belongs on the two cases of a flag discriminated union, where it says which case means `true` and which means `false`; a field is not where that question can be answered.
 * `[<PositionalArgs>]`, `[<ParseExact>]`, `[<InvariantCulture>]` or `[<ArgumentNegateWithPrefix>]` on a field whose type is another argument record, or a union of alternative argument sets. Such a field contributes a whole set of arguments rather than one, so there is no single argument for these to collect into, spell or negate. `[<ArgumentHelpText>]` is deliberately still accepted there: it heads the group of arguments the field contributes.
 * `[<ArgumentNegateWithPrefix>]` on a `[<PositionalArgs>]` field. A positional field is a sink which accumulates values; its keyed spellings take a value rather than setting anything, so there is no boolean there for a `--no-` form to invert.
-* `[<ParseExact>]` or `[<InvariantCulture>]` on anything but a `System.TimeSpan`. These are read only by the `TimeSpan` parser. They continue to reach through the shapes which wrap a value — `TimeSpan option`, `TimeSpan list`, `Choice<TimeSpan, TimeSpan>`, and a `Map` either of whose halves is a `TimeSpan` — and are rejected only where no `TimeSpan` is reached at all.
-
-Also in this release, not breaking: a record field whose name requires backticks (````` ``my field`` `````) is now backticked in the expression which constructs the parsed record, so such a schema generates a file which compiles.
+* `[<ParseExact>]` or `[<InvariantCulture>]` on anything but a `System.TimeSpan`. These are read only by the `TimeSpan` parser. They continue to reach through the shapes which wrap a value — `TimeSpan option`, `TimeSpan list`, `Choice<TimeSpan, TimeSpan>`, and a `Map` either of whose halves is a `TimeSpan` — and are rejected only where no `TimeSpan` is reached at all. Future work may expand the range of types these attributes affect.
 
 # WoofWare.Myriad.Plugins 10.7.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 Notable changes are recorded here.
 
+# WoofWare.Myriad.Plugins 11.0
+
+**Breaking.** `ArgParserGenerator` now rejects, at generation time, several attribute placements which it previously accepted and then silently ignored.
+Each was read by nothing at the placement in question, so a schema which used one got a parser that did not do what its author asked, with no indication why; in the `[<ParseExact>]` case the generated help text went further and advertised a format the parser did not apply.
+Sources which relied on any of these placements will now fail to build.
+Where the attribute has a placement which would read it, the rejection message names it; where it does not (a parse format on a type whose parser has no notion of one), the fix is to remove the attribute, or to change the field to a type which does read it.
+
+* `[<ArgumentFlag>]` on a record field. It belongs on the two cases of a flag discriminated union, where it says which case means `true` and which means `false`; a field is not where that question can be answered. (The attribute's own documentation invited the mistake by describing it as going on "a field"; that wording is fixed.)
+* `[<PositionalArgs>]`, `[<ParseExact>]`, `[<InvariantCulture>]` or `[<ArgumentNegateWithPrefix>]` on a field whose type is another argument record, or a union of alternative argument sets. Such a field contributes a whole set of arguments rather than one, so there is no single argument for these to collect into, spell or negate. `[<ArgumentHelpText>]` is deliberately still accepted there: it heads the group of arguments the field contributes.
+* `[<ArgumentNegateWithPrefix>]` on a `[<PositionalArgs>]` field. A positional field is a sink which accumulates values; its keyed spellings take a value rather than setting anything, so there is no boolean there for a `--no-` form to invert.
+* `[<ParseExact>]` or `[<InvariantCulture>]` on anything but a `System.TimeSpan`. These are read only by the `TimeSpan` parser. They continue to reach through the shapes which wrap a value — `TimeSpan option`, `TimeSpan list`, `Choice<TimeSpan, TimeSpan>`, and a `Map` either of whose halves is a `TimeSpan` — and are rejected only where no `TimeSpan` is reached at all.
+
+Also in this release, not breaking: a record field whose name requires backticks (````` ``my field`` `````) is now backticked in the expression which constructs the parsed record, so such a schema generates a file which compiles.
+
 # WoofWare.Myriad.Plugins 10.7.2
 
 `ArgParserGenerator` now reads `[<ArgumentHelpText>]` from a nested argument record or union of alternative argument sets, and not only from the `[<ArgParser>]`-tagged root, and from a discriminated union's case (and that case's payload record).

--- a/README.md
+++ b/README.md
@@ -383,13 +383,12 @@ We will fail at build time to generate a parser if you have several DU cases whi
 #### Attribute placement at a structural boundary
 
 A field whose type is another argument record, or a union of alternative argument sets, is *structural*: it contributes that type's whole set of arguments rather than being one argument itself.
-The attributes which describe how a single argument is named, collected, spelled or read therefore have nothing to act on there, and are rejected at build time rather than silently dropped: `[<ArgumentLongForm>]`, `[<PositionalArgs>]`, `[<ParseExact>]`, `[<InvariantCulture>]`, `[<ArgumentNegateWithPrefix>]`, `[<ArgumentKeyValueSeparator>]` and `[<ArgumentMapEntrySeparator>]`.
-Put each on the leaf field it actually describes.
+Most attributes describe single arguments, so are rejected at build time when applied to a structural field.
 
-Two attributes are the exceptions, because they are *about* the group:
+Two attributes do apply to structural fields, because they are specifically about the group:
 
 * `[<ArgumentHelpText>]` describes the whole group of arguments the field contributes, and appears on the header line introducing it.
-* `[<ArgumentPrefix>]` namespaces every argument in the subtree; conversely, *it* is rejected on a leaf, which has no subtree.
+* `[<ArgumentPrefix>]` namespaces every argument in the subtree; conversely, it is rejected on a leaf, which has no subtree.
 
 `[<ArgumentFlag>]` is not a field attribute at all: it goes on the two cases of a flag discriminated union, and is rejected on a record field.
 

--- a/README.md
+++ b/README.md
@@ -243,7 +243,8 @@ and you get back respectively these objects:
 }
 ```
 
-You can control `TimeSpan` and friends with the `[<InvariantCulture>]` and `[<ParseExact @"hh\:mm\:ss">]` attributes.
+You can control how a `System.TimeSpan` is read with the `[<InvariantCulture>]` and `[<ParseExact @"hh\:mm\:ss">]` attributes.
+These are honoured on `TimeSpan` only — reaching through the shapes which wrap it, so `TimeSpan option`, `TimeSpan list` and a `Map` with a `TimeSpan` half are all covered — and are rejected on any other type, where nothing would read them.
 
 You can generate extension methods for the type, instead of a module with the type's name, using `[<ArgParser (* isExtensionMethod = *) true>]`.
 
@@ -378,6 +379,19 @@ Records compose: if your record contains other records which are visible to the 
 Discriminated unions compose with each other and with records, hopefully as you would expect: the fields specified by the record contained within the exactly-one field of each DU case must all be mutually satisified, or the parse will fail to select that DU field.
 We will fail at build time to generate a parser if you have several DU cases which contain fields of the same name, though, because in general resolving the parse in that case is NP-hard.
 (An upcoming piece of work will hopefully relax this restriction.)
+
+#### Attribute placement at a structural boundary
+
+A field whose type is another argument record, or a union of alternative argument sets, is *structural*: it contributes that type's whole set of arguments rather than being one argument itself.
+The attributes which describe how a single argument is named, collected, spelled or read therefore have nothing to act on there, and are rejected at build time rather than silently dropped: `[<ArgumentLongForm>]`, `[<PositionalArgs>]`, `[<ParseExact>]`, `[<InvariantCulture>]`, `[<ArgumentNegateWithPrefix>]`, `[<ArgumentKeyValueSeparator>]` and `[<ArgumentMapEntrySeparator>]`.
+Put each on the leaf field it actually describes.
+
+Two attributes are the exceptions, because they are *about* the group:
+
+* `[<ArgumentHelpText>]` describes the whole group of arguments the field contributes, and appears on the header line introducing it.
+* `[<ArgumentPrefix>]` namespaces every argument in the subtree; conversely, *it* is rejected on a leaf, which has no subtree.
+
+`[<ArgumentFlag>]` is not a field attribute at all: it goes on the two cases of a flag discriminated union, and is rejected on a record field.
 
 ### What's the point?
 

--- a/WoofWare.Myriad.Plugins.Attributes/ArgParserAttributes.fs
+++ b/WoofWare.Myriad.Plugins.Attributes/ArgParserAttributes.fs
@@ -31,6 +31,18 @@ type ArgParserAttribute (isExtensionMethod : bool) =
 /// tell you whether each arg came before or after a standalone `--` separator.
 /// For example, `MyApp foo bar -- baz` with PositionalArgs of `Choice<string, string>`
 /// would yield `Choice1Of2 foo, Choice1Of2 bar, Choice2Of2 baz`.
+///
+/// This attribute applies to an argument *leaf*. It is rejected on a field whose type is another
+/// [<ArgParser>]-schema record or a discriminated union of alternative argument sets: such a field
+/// contributes a whole set of arguments rather than being a place values can be collected into, so
+/// put the attribute on the leaf field inside that type which should do the collecting.
+///
+/// A positional field is a sink which accumulates values. It is addressable: `--foo value` and
+/// `--foo=value` route to it, as does any explicit [<ArgumentLongForm>]. But those keyed forms
+/// take a value rather than setting anything, so the field is rejected in combination with
+/// [<ArgumentNegateWithPrefix>] (there is no boolean for a `--no-` form to invert) and with
+/// [<ArgumentPrefix>] (there is no subtree to namespace), and it may not carry a default
+/// (positional args are collected, not defaulted).
 type PositionalArgsAttribute (includeFlagLike : bool) =
     inherit Attribute ()
 
@@ -102,25 +114,42 @@ type ArgumentDefaultValueAttribute (defaultValue : obj) =
 type ArgumentHelpTextAttribute (helpText : string) =
     inherit Attribute ()
 
-/// Attribute indicating that this field should be parsed with a ParseExact method on its type.
-/// For example, on a TimeSpan field, with [<ArgumentParseExact @"hh\:mm\:ss">], we will call
-/// `TimeSpan.ParseExact (s, @"hh\:mm\:ss", CultureInfo.CurrentCulture).
+/// Attribute giving the format in which this field's value is written.
+/// For example, on a TimeSpan field, with [<ParseExact @"hh\:mm\:ss">], we will call
+/// `TimeSpan.ParseExact (s, @"hh\:mm\:ss", CultureInfo.CurrentCulture)`.
+///
+/// This attribute is honoured on `System.TimeSpan` only, and is rejected anywhere else: no other
+/// type's parser reads it, so it would otherwise be dropped in silence while the generated help
+/// text went on advertising a format the parser did not apply.
+///
+/// It reaches through the shapes which wrap a value, since those parse their components with it:
+/// `TimeSpan option`, `TimeSpan list` and `Choice<TimeSpan, TimeSpan>` are all honoured, as is a
+/// `Map` either of whose halves is a `TimeSpan` (in which case the format describes each `TimeSpan`
+/// half; a map with no `TimeSpan` at all is rejected).
 type ParseExactAttribute (format : string) =
     inherit Attribute ()
 
 /// Attribute indicating that this field should be parsed in the invariant culture, rather than the
 /// default current culture.
-/// For example, on a TimeSpan field, with [<InvariantCulture>] and [<ArgumentParseExact @"hh\:mm\:ss">], we will call
-/// `TimeSpan.ParseExact (s, @"hh\:mm\:ss", CultureInfo.InvariantCulture).
+/// For example, on a TimeSpan field, with [<InvariantCulture>] and [<ParseExact @"hh\:mm\:ss">], we will call
+/// `TimeSpan.ParseExact (s, @"hh\:mm\:ss", CultureInfo.InvariantCulture)`.
+///
+/// As with [<ParseExact>], this is honoured on `System.TimeSpan` only -- reaching through option,
+/// list, choice and map in the same way -- and is rejected anywhere else, where nothing would read
+/// it.
 type InvariantCultureAttribute () =
     inherit Attribute ()
 
-/// Attribute placed on a field of a two-case no-data discriminated union, indicating that this is "basically a bool".
+/// Attribute placed on each case of a two-case no-data discriminated union, indicating that the
+/// union is "basically a bool".
 /// For example: `type DryRun = | [<ArgumentFlag true>] Dry | [<ArgumentFlag false>] Wet`
 /// A record with `{ DryRun : DryRun }` will then be parsed like `{ DryRun : bool }` (so the user supplies `--dry-run`),
 /// but that you get this strongly-typed value directly in the code (so you `match args.DryRun with | DryRun.Dry ...`).
 ///
 /// You must put this attribute on both cases of the discriminated union, with opposite values in each case.
+///
+/// It belongs on the union's *cases*, and is rejected on a record field: a field is not where the
+/// question "which case means true?" can be answered, and nothing read the attribute there.
 type ArgumentFlagAttribute (flagValue : bool) =
     inherit Attribute ()
 
@@ -132,6 +161,12 @@ type ArgumentFlagAttribute (flagValue : bool) =
 /// You can place this argument multiple times.
 ///
 /// Omit the initial `--` that you expect the user to type.
+///
+/// This attribute applies to an argument *leaf*. It is rejected on a field whose type is another
+/// [<ArgParser>]-schema record or a discriminated union of alternative argument sets: such a field
+/// contributes a whole set of arguments, each named by its own field, so there is no single
+/// argument here to rename. Put the attribute on the field you mean to rename, or use
+/// [<ArgumentPrefix>] to rename the whole subtree at once.
 [<AttributeUsage(AttributeTargets.Field, AllowMultiple = true)>]
 type ArgumentLongForm (s : string) =
     inherit Attribute ()
@@ -215,6 +250,12 @@ type ArgumentMapEntrySeparatorAttribute (separator : char) =
 ///   --no-field-name=false sets to the [<ArgumentFlag true>] case
 ///
 /// This attribute can only be applied to bool fields or flag DU fields (two-case DUs with [<ArgumentFlag>]).
+///
+/// It applies to an argument *leaf*, and to a leaf which has a name. So it is also rejected on a
+/// field whose type is another [<ArgParser>]-schema record or a discriminated union of alternative
+/// argument sets (which contributes a whole set of arguments, none of them singled out for
+/// negation), and on a [<PositionalArgs>] field (which accumulates values, so although it is
+/// addressable, there is no boolean there for a `--no-` form to invert).
 [<AttributeUsage(AttributeTargets.Field, AllowMultiple = false)>]
 type ArgumentNegateWithPrefixAttribute () =
     inherit Attribute ()


### PR DESCRIPTION
Stage 5 (final) of the attribute-rejection stack; stacked on #608. Docs only.

**Attribute doc comments** now state where each attribute is read and where it is rejected. Two were actively misleading:

- `ArgumentFlagAttribute` said it went on "a field of a two-case no-data discriminated union". It goes on the union's **cases** — the loose wording invited precisely the mistake #605 now rejects.
- `ParseExactAttribute` and `InvariantCultureAttribute` both spelled the attribute `[<ArgumentParseExact>]`, which does not exist, and neither said it is honoured on `TimeSpan` alone.

`PositionalArgs`, `ArgumentLongForm` and `ArgumentNegateWithPrefix` gain explicit statements that they apply to argument *leaves* and are rejected at a structural boundary.

**README** gains an "Attribute placement at a structural boundary" subsection under Composition — which attributes are rejected there, and why `[<ArgumentHelpText>]` and `[<ArgumentPrefix>]` are the exceptions — and no longer claims `[<ParseExact>]` works on "`TimeSpan` and friends".

**CHANGELOG** records `11.0` as a single entry covering the whole stack, since the whole stack lands together. It also picks up the record-construction backtick fix, which landed after `10.7.2` and was never published, so it ships as part of `11.0`.

No behaviour change; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)