### PR TITLE
ArgParser: backtick the Default<FieldName> member reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,5 @@
 Notable changes are recorded here.
 
-# WoofWare.Myriad.Plugins 11.0.2
-
-`ArgParserGenerator` now backticks the `Default`-prefixed member name it emits for an `[<ArgumentDefaultFunction>]` field, so a field whose name needs backticks no longer generates a file which fails to parse.
-This is the same class of bug as the record-construction fix in 11.0.1, at a different site: the generator concatenates `Default` with the field's name and emits the result as an identifier, both to set the default and to render it into help text.
-
-Note that the concatenation can cut either way, and the fix accounts for both: a field named `` ``mod`` `` needs backticks itself, but the `Defaultmod` member does not and is still emitted bare.
-
 # WoofWare.Myriad.Plugins 11.0.1
 
 Breaking change: `ArgParserGenerator` now rejects, at generation time, several attribute placements which it previously accepted and then silently ignored.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 Notable changes are recorded here.
 
+# WoofWare.Myriad.Plugins 11.0.2
+
+`ArgParserGenerator` now backticks the `Default`-prefixed member name it emits for an `[<ArgumentDefaultFunction>]` field, so a field whose name needs backticks no longer generates a file which fails to parse.
+This is the same class of bug as the record-construction fix in 11.0.1, at a different site: the generator concatenates `Default` with the field's name and emits the result as an identifier, both to set the default and to render it into help text.
+
+Note that the concatenation can cut either way, and the fix accounts for both: a field named `` ``mod`` `` needs backticks itself, but the `Defaultmod` member does not and is still emitted bare.
+
 # WoofWare.Myriad.Plugins 11.0.1
 
 Breaking change: `ArgParserGenerator` now rejects, at generation time, several attribute placements which it previously accepted and then silently ignored.

--- a/ConsumePlugin/Args.fs
+++ b/ConsumePlugin/Args.fs
@@ -413,3 +413,23 @@ type AwkwardFieldName =
         ``__LINE__`` : int
         ``break`` : int
     }
+
+/// The same problem at a second site. `[<ArgumentDefaultFunction>]` makes the generator emit a call
+/// to the static member `Default` ++ the field's name, so a field whose name needs backticks forces
+/// the *member* to be declared with them too -- and the generator has to re-add them when it
+/// reconstructs that concatenated name, or the call it emits does not parse.
+///
+/// Kept apart from `AwkwardFieldName` above because the two sites fail independently: that one is
+/// the record-construction expression, this one is a member reference.
+[<ArgParser true>]
+type AwkwardDefaultFunctionName =
+    {
+        [<ArgumentDefaultFunction>]
+        ``space in name`` : Choice<int, int>
+        [<ArgumentDefaultFunction>]
+        ``mod`` : Choice<int, int>
+    }
+
+    static member ``Defaultspace in name`` () : int = 3
+
+    static member ``Defaultmod`` () : int = 4

--- a/ConsumePlugin/GeneratedArgs.fs
+++ b/ConsumePlugin/GeneratedArgs.fs
@@ -8035,3 +8035,178 @@ module AwkwardFieldNameArgParse =
 
         static member parse (args : string list) : AwkwardFieldName =
             AwkwardFieldName.parse' (System.Environment.GetEnvironmentVariable >> Option.ofObj) args
+namespace ConsumePlugin
+
+open System
+open System.IO
+open WoofWare.Myriad.Plugins
+
+/// Methods to parse arguments for the type AwkwardDefaultFunctionName
+[<AutoOpen>]
+module AwkwardDefaultFunctionNameArgParse =
+    /// Extension methods for argument parsing
+    type AwkwardDefaultFunctionName with
+
+        static member parse'
+            (getEnvironmentVariable : string -> string option)
+            (args : string list)
+            : AwkwardDefaultFunctionName
+            =
+            let helpText () =
+                [
+                    (sprintf
+                        "%s  %s%s%s"
+                        (sprintf "--%s" "space in name")
+                        "int32"
+                        (AwkwardDefaultFunctionName.``Defaultspace in name``().ToString ()
+                         |> sprintf " (default value: %s)")
+                        "")
+                    (sprintf
+                        "%s  %s%s%s"
+                        (sprintf "--%s" "mod")
+                        "int32"
+                        (AwkwardDefaultFunctionName.Defaultmod().ToString ()
+                         |> sprintf " (default value: %s)")
+                        "")
+                ]
+                |> String.concat "\n"
+
+            let parser_LeftoverArgs : string ResizeArray = ResizeArray ()
+            let mutable arg_0 : Choice<int, int> option = None
+            let mutable arg_1 : Choice<int, int> option = None
+
+            let parser_schema : ArgParserRuntime_BasicNoPositionals.ErasedSchema =
+                {
+                    Leaves =
+                        [
+                            {
+                                Id = 0
+                                Forms = [ "space in name" ]
+                                AcceptsNegation = false
+                                Arity = ArgParserRuntime_BasicNoPositionals.ErasedArity.One
+                                Repeatable = false
+                                Requirement = ArgParserRuntime_BasicNoPositionals.ErasedRequirement.HasDefault
+                                TypeDescription = ""
+                                Help = None
+                            }
+                            {
+                                Id = 1
+                                Forms = [ "mod" ]
+                                AcceptsNegation = false
+                                Arity = ArgParserRuntime_BasicNoPositionals.ErasedArity.One
+                                Repeatable = false
+                                Requirement = ArgParserRuntime_BasicNoPositionals.ErasedRequirement.HasDefault
+                                TypeDescription = ""
+                                Help = None
+                            }
+                        ]
+                    Tree =
+                        (ArgParserRuntime_BasicNoPositionals.ErasedTree.Product (
+                            [
+                                ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 0
+                                ArgParserRuntime_BasicNoPositionals.ErasedTree.Leaf 1
+                            ]
+                        ))
+                    Positionals = List.empty
+                }
+
+            let parser_storeOccurrence
+                (occurrence : ArgParserRuntime_BasicNoPositionals.ErasedOccurrence)
+                : string option
+                =
+                match occurrence.LeafId with
+                | 0 ->
+                    match arg_0 with
+                    | Some _ -> None
+                    | None ->
+                        match occurrence.Value with
+                        | Some value ->
+                            try
+                                arg_0 <- Some (Choice1Of2 (value |> (fun x -> System.Int32.Parse x)))
+                                None
+                            with _ as exc ->
+                                (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                        | None ->
+                            failwith
+                                "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
+                | 1 ->
+                    match arg_1 with
+                    | Some _ -> None
+                    | None ->
+                        match occurrence.Value with
+                        | Some value ->
+                            try
+                                arg_1 <- Some (Choice1Of2 (value |> (fun x -> System.Int32.Parse x)))
+                                None
+                            with _ as exc ->
+                                (sprintf "%s (at arg %s)" exc.Message occurrence.Source) |> Some
+                        | None ->
+                            failwith
+                                "WoofWare.Myriad internal error in generated parser: arity-one occurrence with no value"
+                | _ -> failwith "WoofWare.Myriad internal error in generated parser: unknown argument id"
+
+            let parser_storePositional (positionalId : int) (value : string) (afterSeparator : bool) : string option =
+                failwith "WoofWare.Myriad internal error in generated parser: no positional sink exists"
+
+            let parser_renderStored (leafId : int) : string =
+                match leafId with
+                | 0 ->
+                    match arg_0 with
+                    | Some (Choice1Of2 x) -> x.ToString ()
+                    | Some (Choice2Of2 x) -> x.ToString ()
+                    | None -> "<no value>"
+                | 1 ->
+                    match arg_1 with
+                    | Some (Choice1Of2 x) -> x.ToString ()
+                    | Some (Choice2Of2 x) -> x.ToString ()
+                    | None -> "<no value>"
+                | _ -> "<no value>"
+
+            let parser_applyDefault (leafId : int) : string option =
+                match leafId with
+                | 0 ->
+                    arg_0 <- Some (Choice2Of2 (AwkwardDefaultFunctionName.``Defaultspace in name`` ()))
+                    None
+                | 1 ->
+                    arg_1 <- Some (Choice2Of2 (AwkwardDefaultFunctionName.Defaultmod ()))
+                    None
+                | _ -> failwith "WoofWare.Myriad internal error in generated parser: unknown defaulted argument id"
+
+            let parser_callbacks : ArgParserRuntime_BasicNoPositionals.TypedCallbacks =
+                {
+                    StoreOccurrence = parser_storeOccurrence
+                    StorePositional = parser_storePositional
+                    HelpText = helpText
+                    RenderStored = parser_renderStored
+                    ApplyDefault = parser_applyDefault
+                }
+
+            match
+                ArgParserRuntime_BasicNoPositionals.runParse
+                    (ArgParserRuntime_BasicNoPositionals.WellFormedSchema.checkOrFail parser_schema)
+                    parser_callbacks
+                    args
+            with
+            | ArgParserRuntime_BasicNoPositionals.ParseOutcome.Success parser_selection ->
+                {
+                    ``mod`` =
+                        (match arg_1 with
+                         | Some x -> x
+                         | None ->
+                             failwith
+                                 "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
+                    ``space in name`` =
+                        (match arg_0 with
+                         | Some x -> x
+                         | None ->
+                             failwith
+                                 "WoofWare.Myriad internal error in generated parser: required argument missing after successful parse")
+                }
+            | ArgParserRuntime_BasicNoPositionals.ParseOutcome.HelpRequested ->
+                helpText () |> failwithf "Help text requested.\n%s"
+            | ArgParserRuntime_BasicNoPositionals.ParseOutcome.Fatal message -> failwith message
+            | ArgParserRuntime_BasicNoPositionals.ParseOutcome.Errors errors ->
+                errors |> String.concat "\n" |> failwithf "Errors during parse!\n%s"
+
+        static member parse (args : string list) : AwkwardDefaultFunctionName =
+            AwkwardDefaultFunctionName.parse' (System.Environment.GetEnvironmentVariable >> Option.ofObj) args

--- a/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParser.fs
+++ b/WoofWare.Myriad.Plugins.Test/TestArgParser/TestArgParser.fs
@@ -561,6 +561,32 @@ Secondary: Where to fail over to
                 AwkwardFieldName.``break`` = 7
             }
 
+    /// The same hazard at a second site: `[<ArgumentDefaultFunction>]` makes the generator emit a
+    /// call to `Default` ++ the field's name, so a field whose name needs backticks forces the
+    /// member to be declared with them, and the generator must re-add them to the concatenated name
+    /// it reconstructs. Both the defaulted and the supplied paths are exercised, because the name is
+    /// emitted twice -- once to set the default and once to render it into help text.
+    ///
+    /// `` ``mod`` `` is here as the converse control: it needs backticks on its own, but
+    /// `Defaultmod` does not, so the concatenation *rescues* it and it must be emitted bare.
+    [<Test>]
+    let ``A default-function member name needing backticks survives re-emission`` () =
+        let getEnvVar (_ : string) = failwith "should not call"
+
+        AwkwardDefaultFunctionName.parse' getEnvVar []
+        |> shouldEqual
+            {
+                AwkwardDefaultFunctionName.``space in name`` = Choice2Of2 3
+                AwkwardDefaultFunctionName.``mod`` = Choice2Of2 4
+            }
+
+        AwkwardDefaultFunctionName.parse' getEnvVar [ "--space in name=1" ; "--mod=2" ]
+        |> shouldEqual
+            {
+                AwkwardDefaultFunctionName.``space in name`` = Choice1Of2 1
+                AwkwardDefaultFunctionName.``mod`` = Choice1Of2 2
+            }
+
     [<Test>]
     let ``Positionals are tagged with Choice`` () =
         let getEnvVar (_ : string) = failwith "should not call"

--- a/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
+++ b/WoofWare.Myriad.Plugins/ArgParserGenerator.fs
@@ -1542,8 +1542,19 @@ module internal ArgParserGenerator =
                 "virtual"
             ]
 
-    /// Whether `ident` is safe to splice in bare, as a record-construction label. F#'s lexer treats
-    /// a number of shapes as meaningful bare tokens in *other* grammar positions but not this one.
+    /// Whether `ident` is safe to splice in bare wherever the generated file wants a single
+    /// identifier. F#'s lexer treats a number of shapes as meaningful bare tokens in *other* grammar
+    /// positions but not as a plain identifier.
+    ///
+    /// The probe deliberately uses the record-label position for every caller, including the ones
+    /// which emit a member name rather than a label. That position is the tightest available: it
+    /// admits exactly one identifier and nothing else, so the parser accepts the probe only if
+    /// `ident` really is one token. A probe in the position a caller actually emits into can be far
+    /// weaker -- `Owner.%s{ident} ()` would happily parse `Owner.Defaultspace name ()` as an
+    /// application of `Owner.Defaultspace` to `name`, and report success for a name which is
+    /// nothing of the sort. Being tighter than a caller needs only means backticking something
+    /// which did not require it, and backticks are a legal alternative spelling of any identifier,
+    /// so that is always safe.
     ///
     /// This is still not exhaustive: a name built to smuggle extra syntax into the probe (e.g. one
     /// containing a block comment, `A (*x*)`) can make the probe parse successfully as a *different*,
@@ -1551,7 +1562,7 @@ module internal ArgParserGenerator =
     /// wrong. Deliberately left unfixed: such a name is not a real record field name anyone would
     /// write, and the failure mode if it ever occurred is the same one already being fixed here --
     /// generated code that doesn't compile -- not silent corruption.
-    let private isValidBareRecordLabel (ident : string) : bool =
+    let private isValidBareIdent (ident : string) : bool =
         if reservedForFutureUse.Contains ident then
             false
         else
@@ -1564,12 +1575,12 @@ module internal ArgParserGenerator =
         with _ ->
             false
 
-    /// Re-backtick a field name, if it needs backticks to be usable as a bare record-construction
-    /// label -- exactly as its declaration needed them, if it had any (backticking is always a
+    /// Re-backtick an identifier we are about to emit, if it needs backticks to be read back as
+    /// itself -- exactly as its declaration needed them, if it had any (backticking is always a
     /// legal alternative spelling of any identifier, so this is safe to apply unconditionally to
-    /// whatever `isValidBareRecordLabel` rejects).
-    let private backtickRecordLabel (ident : string) : string =
-        if isValidBareRecordLabel ident then
+    /// whatever `isValidBareIdent` rejects).
+    let private backtickIdent (ident : string) : string =
+        if isValidBareIdent ident then
             ident
         else
             "``" + ident + "``"
@@ -2019,7 +2030,7 @@ module internal ArgParserGenerator =
                         // (a space, a keyword, ...) must be re-backticked before it is safe to place
                         // in this record-construction expression, exactly as the record's own
                         // declaration required it to be written.
-                        SynLongIdent.create [ Ident.create (backtickRecordLabel ident) ], expr
+                        SynLongIdent.create [ Ident.create (backtickIdent ident) ], expr
                     )
                     |> SynExpr.createRecord None
                 )
@@ -2127,7 +2138,7 @@ module internal ArgParserGenerator =
                 |> SynExpr.paren
             | Accumulation.Choice (ArgumentDefaultSpec.FunctionCall (owner, var)) ->
                 // Display the spelling the user would have to type to supply this value.
-                SynExpr.callMethod var.idText (SynExpr.createIdent' owner)
+                SynExpr.callMethod (backtickIdent var.idText) (SynExpr.createIdent' owner)
                 |> renderLeafValue flagCases arg.EnumCases
                 |> SynExpr.pipeThroughFunction (
                     SynExpr.applyFunction (SynExpr.createIdent "sprintf") (SynExpr.CreateConst " (default value: %s)")
@@ -3042,7 +3053,9 @@ module internal ArgParserGenerator =
                         | ArgumentDefaultSpec.FunctionCall (owner, name) ->
                             SynExpr.sequential
                                 [
-                                    storeDefault (SynExpr.callMethod name.idText (SynExpr.createIdent' owner))
+                                    storeDefault (
+                                        SynExpr.callMethod (backtickIdent name.idText) (SynExpr.createIdent' owner)
+                                    )
                                     SynExpr.createIdent "None"
                                 ]
                         | ArgumentDefaultSpec.Literal value ->


### PR DESCRIPTION
Same class of bug as the record-construction fix in #604, at a different site.

`[<ArgumentDefaultFunction>]` makes the generator concatenate `Default` with the field's name and emit the result as an identifier — twice, once to set the default and once to render it into help text. A field whose name needs backticks forces the *member* to be declared with them too, and the reconstruction dropped them, so the generated file did not parse:

```
AwkwardDefaultFunctionName.Defaultspace in name()
```

The concatenation cuts both ways, and the fix accounts for both directions: a field named `` ``mod`` `` needs backticks itself, but the member `Defaultmod` does not, and is still emitted bare. Both are covered by tests.

`isValidBareRecordLabel`/`backtickRecordLabel` are renamed to `isValidBareIdent`/`backtickIdent`, since they now serve a member name as well as a record label. The probe deliberately stays in the **record-label** position for every caller, which is worth knowing about: that is the tightest position available, admitting exactly one identifier and nothing else. A probe in the position this new caller emits into would be far weaker — `Owner.Defaultspace name ()` parses perfectly happily as an application of `Owner.Defaultspace` to `name`, and would report success for a name which is nothing of the sort. Being tighter than a caller needs only over-backticks, which is always safe.

Test first, observed failing: `ConsumePlugin` gained `AwkwardDefaultFunctionName`, and the build broke exactly as above before the fix. Runtime test covers both the defaulted and the user-supplied path.

Suite green (1105 / 164 / 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)