### PR TITLE
Pack the plugin's closure from reference resolution, not from bin/

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -171,6 +171,11 @@ jobs:
       # package has to carry the plugin's dependency closure. Nothing else here would notice if it
       # stopped doing so; the consumer's build would be the first to find out.
       run: nix develop --command ./scripts/check-packed-plugin-loads.sh WoofWare.Myriad.Plugins/bin/Release/WoofWare.Myriad.Plugins.*.nupkg
+    - name: Check the plugin also packs from a clean output directory
+      # The step above cannot catch a return to gathering the closure with a wildcard over
+      # $(OutputPath), because the Build step above has already filled that directory. This one
+      # packs into an empty one, which is the condition that used to produce a broken package.
+      run: nix develop --command ./scripts/check-cold-pack-loads.sh
     - name: Upload NuGet artifact (plugin)
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -166,6 +166,11 @@ jobs:
       run: nix develop --command dotnet build --no-restore --configuration Release
     - name: Pack
       run: nix develop --command dotnet pack --configuration Release
+    - name: Check the packed plugin loads
+      # Myriad resolves the plugin's references by probing the directory the plugin sits in, so the
+      # package has to carry the plugin's dependency closure. Nothing else here would notice if it
+      # stopped doing so; the consumer's build would be the first to find out.
+      run: nix develop --command ./scripts/check-packed-plugin-loads.sh WoofWare.Myriad.Plugins/bin/Release/WoofWare.Myriad.Plugins.*.nupkg
     - name: Upload NuGet artifact (plugin)
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -172,9 +172,9 @@ jobs:
       # stopped doing so; the consumer's build would be the first to find out.
       run: nix develop --command ./scripts/check-packed-plugin-loads.sh WoofWare.Myriad.Plugins/bin/Release/WoofWare.Myriad.Plugins.*.nupkg
     - name: Check the plugin also packs from a clean output directory
-      # The step above cannot catch a return to gathering the closure with a wildcard over
-      # $(OutputPath), because the Build step above has already filled that directory. This one
-      # packs into an empty one, which is the condition that used to produce a broken package.
+      # The step above runs with $(OutputPath) already filled by Build, so it cannot show that the
+      # closure reaches the package without help from the build directory. This one packs into an
+      # empty output directory, where that is the only way it can get there.
       run: nix develop --command ./scripts/check-cold-pack-loads.sh
     - name: Upload NuGet artifact (plugin)
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/WoofWare.Myriad.Plugins/WoofWare.Myriad.Plugins.fsproj
+++ b/WoofWare.Myriad.Plugins/WoofWare.Myriad.Plugins.fsproj
@@ -15,7 +15,7 @@
     <WarnOn>FS3559</WarnOn>
     <PackageId>WoofWare.Myriad.Plugins</PackageId>
     <PackageIcon>light.png</PackageIcon>
-    <NoWarn>NU5118</NoWarn>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_PackPluginDependencies</TargetsForTfmSpecificContentInPackage>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
@@ -61,9 +61,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\WoofWare.Myriad.Plugins.Attributes\WoofWare.Myriad.Plugins.Attributes.fsproj"/>
-    <!-- NuGet is such a clown package manager! Get the DLLs into the Nupkg artefact, I have no idea why this is needed,
-         but without this line, we don't get any dependency at all packaged into the resulting artefact. -->
-    <None Include="$(OutputPath)\*.dll" Pack="true" PackagePath="lib\$(TargetFramework)"/>
   </ItemGroup>
 
   <!--
@@ -117,6 +114,34 @@ else
     <WriteReadmeWithoutLogo Source="$(MSBuildProjectDirectory)/../README.md" Destination="$(_NuGetReadme)" />
     <ItemGroup>
       <None Include="$(_NuGetReadme)" Pack="true" PackagePath="\" />
+    </ItemGroup>
+  </Target>
+
+
+  <!--
+    Myriad does not load this package as a library; it loads it as a plugin. A consumer points
+    MyriadSdkGenerator at lib/net6.0/WoofWare.Myriad.Plugins.dll inside the restored package, and
+    the Myriad tool loads that file by path, resolving its references by probing the directory it
+    sits in. That tool knows nothing of this package's NuGet dependency graph, so the dependencies
+    the nuspec declares are no help: they restore into their own package folders, which the loader
+    never looks in. The plugin is loadable only if its closure sits beside it, so pack the closure
+    into lib/ as well. Consumers reference this package with PrivateAssets="all", so the extra
+    assemblies do not propagate to them.
+
+    Take the closure from the reference resolution rather than by listing $(OutputPath): a
+    wildcard in an ItemGroup is expanded when the project is evaluated, which is before the build
+    that populates that directory. Packing a tree whose bin/ was empty therefore used to produce a
+    package containing only this assembly, whose plugin throws ReflectionTypeLoadException in the
+    consumer's build. CI happened to build before packing, so released packages were unaffected.
+  -->
+  <Target Name="_PackPluginDependencies" DependsOnTargets="ResolveReferences">
+    <ItemGroup>
+      <!-- Only what the loader probes for, i.e. what sits directly beside the plugin: a
+           DestinationSubDirectory means a satellite assembly, which would collide with its
+           siblings once flattened into one directory, and which the loader does not need. -->
+      <TfmSpecificPackageFile Include="@(ReferenceCopyLocalPaths)"
+                              Condition="'%(ReferenceCopyLocalPaths.Extension)' == '.dll' and '%(ReferenceCopyLocalPaths.DestinationSubDirectory)' == ''"
+                              PackagePath="lib/$(TargetFramework)" />
     </ItemGroup>
   </Target>
 

--- a/WoofWare.Myriad.Plugins/WoofWare.Myriad.Plugins.fsproj
+++ b/WoofWare.Myriad.Plugins/WoofWare.Myriad.Plugins.fsproj
@@ -128,11 +128,9 @@ else
     into lib/ as well. Consumers reference this package with PrivateAssets="all", so the extra
     assemblies do not propagate to them.
 
-    Take the closure from the reference resolution rather than by listing $(OutputPath): a
-    wildcard in an ItemGroup is expanded when the project is evaluated, which is before the build
-    that populates that directory. Packing a tree whose bin/ was empty therefore used to produce a
-    package containing only this assembly, whose plugin throws ReflectionTypeLoadException in the
-    consumer's build. CI happened to build before packing, so released packages were unaffected.
+    The closure comes from reference resolution, which the build produces, so it is complete
+    whether or not the output directory was already populated when pack ran.
+    scripts/check-cold-pack-loads.sh holds the packaging to that.
   -->
   <Target Name="_PackPluginDependencies" DependsOnTargets="ResolveReferences">
     <ItemGroup>

--- a/flake.nix
+++ b/flake.nix
@@ -66,6 +66,7 @@
           pkgs.alejandra
           pkgs.lychee
           pkgs.shellcheck
+          pkgs.unzip
           pkgs.xmlstarlet
         ];
       };

--- a/scripts/check-cold-pack-loads.sh
+++ b/scripts/check-cold-pack-loads.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+# The plugin's dependency closure must reach the package by a route that does not depend on the
+# build directory already being populated. It used not to: the closure was gathered by a wildcard
+# over $(OutputPath), which MSBuild expands when the project is evaluated, before the build that
+# fills that directory. A package built that way carries only the plugin itself and fails to load.
+#
+# Checking the nupkg that CI publishes cannot catch a regression to that, because CI builds before
+# it packs, so $(OutputPath) is populated by then and even the wildcard would find everything. So
+# pack again into an output directory that is guaranteed empty, and check that package instead.
+# Relocating $(OutputPath) rather than reordering the CI steps keeps this honest no matter what
+# else the job has done first.
+
+set -eu
+
+if [ "$#" -ne 0 ]; then
+    echo "usage: $0" >&2
+    exit 1
+fi
+
+repo=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+
+workdir=$(mktemp -d)
+# shellcheck disable=SC2064 # expand workdir now, while it is still set
+trap "rm -rf '$workdir'" EXIT
+
+dotnet pack "$repo/WoofWare.Myriad.Plugins/WoofWare.Myriad.Plugins.fsproj" \
+    --configuration Release \
+    -p:BaseOutputPath="$workdir/bin/" \
+    --output "$workdir/nupkg"
+
+# shellcheck disable=SC2086 # deliberate: expand the glob into the argument list to count matches
+set -- "$workdir"/nupkg/*.nupkg
+if [ "$#" -ne 1 ] || [ ! -f "$1" ]; then
+    echo "expected exactly one nupkg from the clean-output pack, got: $*" >&2
+    exit 1
+fi
+
+"$repo/scripts/check-packed-plugin-loads.sh" "$1"

--- a/scripts/check-cold-pack-loads.sh
+++ b/scripts/check-cold-pack-loads.sh
@@ -1,15 +1,13 @@
 #!/bin/sh
 
 # The plugin's dependency closure must reach the package by a route that does not depend on the
-# build directory already being populated. It used not to: the closure was gathered by a wildcard
-# over $(OutputPath), which MSBuild expands when the project is evaluated, before the build that
-# fills that directory. A package built that way carries only the plugin itself and fails to load.
+# build directory already being populated.
 #
-# Checking the nupkg that CI publishes cannot catch a regression to that, because CI builds before
-# it packs, so $(OutputPath) is populated by then and even the wildcard would find everything. So
-# pack again into an output directory that is guaranteed empty, and check that package instead.
-# Relocating $(OutputPath) rather than reordering the CI steps keeps this honest no matter what
-# else the job has done first.
+# The nupkg CI publishes cannot demonstrate that, because CI builds before it packs, so
+# $(OutputPath) is full by the time pack evaluates the project. Pack again into an output
+# directory that is guaranteed empty, and run the loader check on that package. Relocating
+# $(OutputPath) rather than relying on where this sits among the CI steps keeps the check honest
+# whatever else the job has done first.
 
 set -eu
 

--- a/scripts/check-packed-plugin-loads.sh
+++ b/scripts/check-packed-plugin-loads.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+
+# Myriad loads this package as a plugin, not as a library: it is handed
+# lib/<tfm>/WoofWare.Myriad.Plugins.dll by path and resolves that assembly's references by probing
+# the directory the file sits in, with no knowledge of the package's NuGet dependencies. So the
+# package is only usable if it carries the plugin's dependency closure beside the plugin. Assert
+# that against the artefact that would be published, by loading it the way Myriad does.
+
+set -eu
+
+if [ "$#" -ne 1 ]; then
+    echo "usage: $0 <path to WoofWare.Myriad.Plugins nupkg>" >&2
+    exit 1
+fi
+
+nupkg="$1"
+if [ ! -f "$nupkg" ]; then
+    echo "not a file: $nupkg" >&2
+    exit 1
+fi
+
+repo=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+
+workdir=$(mktemp -d)
+# shellcheck disable=SC2064 # expand workdir now, while it is still set
+trap "rm -rf '$workdir'" EXIT
+
+unzip -q "$nupkg" -d "$workdir/pkg"
+
+plugin=$(find "$workdir/pkg/lib" -name 'WoofWare.Myriad.Plugins.dll' -type f)
+if [ "$(printf '%s' "$plugin" | grep -c '')" -ne 1 ]; then
+    echo "expected exactly one packed plugin assembly under lib/, found:" >&2
+    find "$workdir/pkg" -type f >&2
+    exit 1
+fi
+
+echo "Packed alongside the plugin:"
+ls "$(dirname -- "$plugin")"
+
+# The version consumers are told to use, and the one this repo builds against.
+sdk_version=$(xmlstarlet sel -t -v '//PackageReference[@Include="Myriad.Sdk"]/@Version' \
+    "$repo/ConsumePlugin/ConsumePlugin.fsproj")
+myriad="${NUGET_PACKAGES:-$HOME/.nuget/packages}/myriad.sdk/$sdk_version/tools/net6.0/any/Myriad.dll"
+if [ ! -f "$myriad" ]; then
+    echo "Myriad.Sdk $sdk_version is not restored at $myriad; run 'dotnet restore' first" >&2
+    exit 1
+fi
+
+output="$workdir/Generated.fs"
+dotnet "$myriad" \
+    --inputfile "$repo/ConsumePlugin/RecordFile.fs" \
+    --outputfile "$output" \
+    --configfile "$repo/ConsumePlugin/myriad.toml" \
+    --plugin "$plugin"
+
+if [ ! -s "$output" ]; then
+    echo "the packed plugin loaded but generated nothing" >&2
+    exit 1
+fi
+
+echo "The packed plugin loads and generates."


### PR DESCRIPTION
Answers the "I have no idea why this is needed" comment, and makes the mechanism it describes robust.

### Why that line exists

Myriad does not load this package as a library; it loads it as a **plugin**. A consumer points `MyriadSdkGenerator` at `lib/net6.0/WoofWare.Myriad.Plugins.dll` inside the restored package (exactly as the README instructs), and the Myriad tool loads that file *by path*, resolving its references by probing the directory the file sits in. That tool knows nothing of this package's NuGet dependency graph, so the `<dependencies>` the nuspec declares are no help: NuGet restores them into their own `~/.nuget/packages/<id>/<ver>/lib/` folders, which the loader never looks in. The plugin is loadable only if its closure sits beside it — which is what `<None Include="$(OutputPath)\*.dll" ... />` was achieving. It isn't NuGet being a clown; it's a plugin being loaded like a plugin.

### Why it needed fixing

A wildcard in an `ItemGroup` is expanded when the project is **evaluated**, which is before the build that populates `$(OutputPath)`. So packing a tree whose `bin/` was empty produced a package containing only this assembly. Measured on `main`: `dotnet pack` on a clean checkout packs one DLL, and running the real Myriad tool against that package gives

```
System.Reflection.ReflectionTypeLoadException: Unable to load one or more of the requested types.
Could not load file or assembly 'WoofWare.Whippet.Fantomas, Version=0.7.0.0' …
```

CI runs `dotnet build` and *then* `dotnet pack`, so `bin/` is warm and **no released package was affected**. But nothing made that ordering a requirement, and nothing would have noticed if it changed — the failure would first surface in a consumer's build.

### The fix

Take the closure from `@(ReferenceCopyLocalPaths)` in a target hooked into `TargetsForTfmSpecificContentInPackage`. That is the result of reference resolution rather than a directory listing, so it is correct whether or not the tree has been built.

Satellite assemblies are excluded — they carry a `DestinationSubDirectory`, would collide with one another once flattened into a single directory, and are not what the loader probes for. That exclusion also means the project's own output is no longer added twice, so `NoWarn NU5118` goes and `TreatWarningsAsErrors` polices the duplication instead.

`scripts/check-packed-plugin-loads.sh` asserts the property that actually matters — that the packed plugin loads the way Myriad loads it — by running the Myriad tool against the nupkg that would be published. CI runs it immediately after `pack`. `unzip` joins the devshell because the script needs it.

### Verification

* Packing a **clean checkout** now produces a `lib/net6.0` identical to the one `main` produces from a **built** tree; packing a built tree produces the same again. The whole package's file list and its nuspec are unchanged from `main`.
* The cold-packed plugin loads and generates.
* The new target is load-bearing: dropping it from `TargetsForTfmSpecificContentInPackage` reproduces the one-DLL package and the identical load failure.
* The check script discriminates: it fails on that mutated package, fails on `main`'s cold-packed package, and passes on the fixed one. Its argument and missing-file guards were exercised too.
* Full suite passes: 1272 tests. `alejandra --check` and `shellcheck` are clean.

### Two checks, because they test different things

Codex pointed out that the loader check alone could not catch a *return* to the wildcard: CI builds before it packs, so `$(OutputPath)` is populated by then and even the wildcard would find everything. Measured, with the wildcard restored: packing the built tree yields all ten assemblies and that check passes, while packing into an empty output directory yields two and the plugin fails to load. So `scripts/check-cold-pack-loads.sh` packs again into a guaranteed-empty output directory and runs the same loader check on *that* package.

Relocating `$(OutputPath)` rather than reordering the CI steps is deliberate: it keeps the check testing the cold condition however the job is rearranged later. The two checks are kept because they assert different properties — one that the artefact about to be published is loadable, one that the mechanism does not depend on build state. Verified by mutation that the second catches the regression the first misses.

Based on `main`, not on #623 — the two changes touch different parts of the fsproj and are independent.
